### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Build source distribution
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Get build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           uv pip install $WHEEL_FILE[${{matrix.config.extras}}] --resolution=${{matrix.config.resolution}}
 
       - name: Install DGL and MatGL specially on ubuntu.
-        if: matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'ubuntu-latest' && matrix.config.python < '3.13'
         run: |
           micromamba activate pmg
           pip install --upgrade dgl -f https://data.dgl.ai/wheels/torch-2.4/repo.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,22 +28,22 @@ jobs:
         # Maximize CI coverage of different platforms and python versions while minimizing the
         # total number of jobs. We run all pytest splits with the oldest supported python
         # version (currently 3.10) on windows (seems most likely to surface errors) and with
-        # newest version (currently 3.12) on ubuntu (to get complete coverage on unix).
+        # newest version (currently 3.13) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
-            python: "3.10"
+            python: "3.13"
             resolution: highest
             extras: ci,optional,prototypes
           - os: windows-latest
-            python: "3.10"
+            python: "3.13"
             resolution: highest
             extras: ci,prototypes,optional,numpy-v1 # Test NP1 on Windows (quite buggy ATM)
           - os: ubuntu-latest
-            python: "3.12"
+            python: "3.13"
             resolution: lowest-direct
             extras: ci,prototypes,optional
           - os: macos-latest
-            python: "3.11"
+            python: "3.13"
             resolution: lowest-direct
             extras: ci,prototypes # test with only required dependencies installed
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,11 @@ jobs:
         # newest version (currently 3.13) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
-            python: "3.13"
+            python: "3.11"
             resolution: highest
             extras: ci,optional,prototypes
           - os: windows-latest
-            python: "3.13"
+            python: "3.11"
             resolution: highest
             extras: ci,prototypes,optional,numpy-v1 # Test NP1 on Windows (quite buggy ATM)
           - os: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
             resolution: lowest-direct
             extras: ci,prototypes,optional
           - os: macos-latest
-            python: "3.13"
+            python: "3.12"
             resolution: lowest-direct
             extras: ci,prototypes # test with only required dependencies installed
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,8 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           micromamba install -n pmg -c conda-forge bader enumlib \
-            openff-toolkit packmol pygraphviz tblite --yes
+            packmol pygraphviz tblite --yes
+            # openff-toolkit # TODO: doesn't support Python 3.13 yet
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Physics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ Pypi = "https://pypi.org/project/pymatgen"
 abinit = ["netcdf4>=1.7.2"]
 ase = ["ase>=3.23.0"]
 electronic_structure = ["fdint>=2.0.2"]
-mlp = ["matgl>=1.2.5"]
+mlp = ["matgl>=1.2.5 ; python_version<'3.13'"]
 numba = ["numba>=0.55"]
 numpy-v1 = ["numpy>=1.25.0,<2"] # Test NP1 on Windows (quite buggy ATM)
 zeopp = ["pyzeo"]  # Note: requires voro++ and zeo++ to be installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Python Materials Genomics is a robust materials analysis code that defines core 
 and molecules with support for many electronic structure codes. It is currently the core analysis code powering the
 Materials Project (https://materialsproject.org)."""
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 keywords = [
     "ABINIT",
     "VASP",


### PR DESCRIPTION
### Summary

- Python 3.13 support (previously #4100), to close #4284
- [x] Revert Python 3.13 for all platforms
- [ ] fix vampire install:  https://github.com/richard-evans/vampire/issues/122
```
wget https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
--2025-04-18 10:45:13--  https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
Resolving vampire.york.ac.uk (vampire.york.ac.uk)... 144.32.124.80, 2001:630:61:17c::1:50
Connecting to vampire.york.ac.uk (vampire.york.ac.uk)|144.32.124.80|:443... connected.
ERROR: cannot verify vampire.york.ac.uk's certificate, issued by ‘CN=Sectigo ECC Organization Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB’:
  Unable to locally verify the issuer's authority.
To connect to vampire.york.ac.uk insecurely, use `--no-check-certificate'
```