### PR TITLE
fix perturb bug that displaced all atoms equally

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -4738,10 +4738,10 @@ class Structure(IStructure, collections.abc.MutableSequence):
         Returns:
             Structure: self with perturbed sites.
         """
+        rng = np.random.default_rng(seed=seed)
 
         def get_rand_vec():
             # Deal with zero vectors
-            rng = np.random.default_rng(seed=seed)
             vector = rng.standard_normal(3)
             vnorm = np.linalg.norm(vector)
             dist = distance


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: If I'm not mistaken, #4270 added a random seed parameter to Structure.perturb() but ended up setting the same random vector for all atoms. This should probably be fixed by pulling the seed-setting line out of the get_rand_vec() function.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))


