### PR TITLE
Brute force order matcher speedup

### DIFF
--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -752,7 +752,9 @@ class KabschMatcher(MSONable):
             RMSD : Root mean squared deviation between P and Q
         """
         if self.target.atomic_numbers != p.atomic_numbers:
-            raise ValueError("The order of the species aren't matching! Please try using PermInvMatcher.")
+            raise ValueError(
+                "The order of the species aren't matching! Please try using BruteForceOrderMatcher instead."
+            )
 
         p_coord, q_coord = p.cart_coords, self.target.cart_coords
 

--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -834,16 +834,22 @@ class BruteForceOrderMatcher(KabschMatcher):
         of atoms from the same species.
     """
 
-    def match(self, mol: Molecule, ignore_warning: bool = False) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    def match(
+        self, mol: Molecule, ignore_warning: bool = False, break_on_tol: float | None = None
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
         """Similar as `KabschMatcher.match` but this method also finds the order of
         atoms which belongs to the best match.
 
         A `ValueError` will be raised when the total number of possible combinations
         become unfeasible (more than a million combination).
 
+        The `break_on_tol` option can be used for efficiency, to stop searching over
+        permutations if the RMSD becomes smaller than `break_on_tol`.
+
         Args:
             mol: a `Molecule` object what will be matched with the target one.
-            ignore_warning: ignoring error when the number of combination is too large
+            ignore_warning: ignoring error when the number of combination is too large.
+            break_on_tol: return the first match with an RMSD value less than this tolerance.
 
         Returns:
             inds: The indices of atoms
@@ -894,6 +900,9 @@ class BruteForceOrderMatcher(KabschMatcher):
             if rmsd_test < rmsd:
                 p_inds, U, rmsd = p_inds_test, U_test, rmsd_test
 
+            if break_on_tol and rmsd < break_on_tol:
+                break
+
         # Rotate and translate matrix P unto matrix Q using Kabsch algorithm.
         # P' = P * U + V
         V = q_trans - np.dot(p_trans, U)
@@ -903,21 +912,25 @@ class BruteForceOrderMatcher(KabschMatcher):
 
         return indices, U, V, rmsd
 
-    def fit(self, p: Molecule, ignore_warning=False):
+    def fit(self, p: Molecule, ignore_warning=False, break_on_tol: float | None = None):
         """Order, rotate and transform `p` molecule according to the best match.
 
         A `ValueError` will be raised when the total number of possible combinations
         become unfeasible (more than a million combinations).
 
+        The `break_on_tol` option can be used for efficiency, to stop searching over
+        permutations if the RMSD becomes smaller than `break_on_tol`.
+
         Args:
             p: a `Molecule` object what will be matched with the target one.
-            ignore_warning: ignoring error when the number of combination is too large
+            ignore_warning: ignoring error when the number of combination is too large.
+            break_on_tol: return the first match with an RMSD value less than this tolerance.
 
         Returns:
             p_prime: Rotated and translated of the `p` `Molecule` object
             rmsd: Root-mean-square-deviation between `p_prime` and the `target`
         """
-        inds, U, V, rmsd = self.match(p, ignore_warning=ignore_warning)
+        inds, U, V, rmsd = self.match(p, ignore_warning=ignore_warning, break_on_tol=break_on_tol)
 
         p_prime = Molecule.from_sites([p[idx] for idx in inds])
         for site in p_prime:

--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -752,9 +752,7 @@ class KabschMatcher(MSONable):
             RMSD : Root mean squared deviation between P and Q
         """
         if self.target.atomic_numbers != p.atomic_numbers:
-            raise ValueError(
-                "The order of the species aren't matching! Please try using BruteForceOrderMatcher instead."
-            )
+            raise ValueError("The order of the species aren't matching! Please try using BruteForceOrderMatcher")
 
         p_coord, q_coord = p.cart_coords, self.target.cart_coords
 

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -760,7 +760,7 @@ class TestBruteForceOrderMatcherSi2O:
         _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e-5)
         assert rmsd == approx(0.2434045087608993, abs=1e-6)
 
-        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e5)
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=0.25)
         assert rmsd == approx(0.2434045087608993, abs=1e-6)
 
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_permuted.xyz")

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -570,7 +570,7 @@ class TestKabschMatcherSi:
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster.xyz")
         with pytest.raises(
             ValueError,
-            match="The order of the species aren't matching! Please try using PermInvMatcher",
+            match="The order of the species aren't matching! Please try using BruteForceOrderMatcher",
         ):
             self.mol_matcher.fit(mol2)
 
@@ -699,7 +699,7 @@ class TestKabschMatcherSi2O:
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si_cluster_rotated.xyz")
         with pytest.raises(
             ValueError,
-            match="The order of the species aren't matching! Please try using PermInvMatcher",
+            match="The order of the species aren't matching! Please try using BruteForceOrderMatcher",
         ):
             self.mol_matcher.fit(mol2)
 
@@ -719,7 +719,7 @@ class TestKabschMatcherSi2O:
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_permuted.xyz")
         with pytest.raises(
             ValueError,
-            match="The order of the species aren't matching! Please try using PermInvMatcher",
+            match="The order of the species aren't matching! Please try using BruteForceOrderMatcher",
         ):
             self.mol_matcher.fit(mol2)
 

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -755,6 +755,26 @@ class TestBruteForceOrderMatcherSi2O:
         _, rmsd = self.mol_matcher.fit(mol2)
         assert rmsd == approx(0.23051587697194997, abs=1e-6)
 
+    def test_break_on_tol_perturbed_atom_position(self):
+        mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_perturbed.xyz")
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e-5)
+        assert rmsd == approx(0.2434045087608993, abs=1e-6)
+
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e5)
+        assert rmsd == approx(0.2434045087608993, abs=1e-6)
+
+        mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_permuted.xyz")
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e5)
+        assert rmsd == approx(0, abs=6)
+
+        mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_2.xyz")
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=2)  # breaks early with higher RMSD, < tol
+        assert rmsd == approx(1.1655, abs=1e-3)
+
+        mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_2.xyz")
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=0.2)  # doesn't break early, returns orig best RMSD
+        assert rmsd == approx(0.23051587697194997, abs=1e-6)
+
 
 class TestHungarianOrderMatcherSi2O:
     @classmethod

--- a/tests/analysis/test_molecule_matcher.py
+++ b/tests/analysis/test_molecule_matcher.py
@@ -758,18 +758,21 @@ class TestBruteForceOrderMatcherSi2O:
     def test_break_on_tol_perturbed_atom_position(self):
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_perturbed.xyz")
         _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e-5)
+        # proceeds as normal and doesn't break early if tol is below possible RMSD
         assert rmsd == approx(0.2434045087608993, abs=1e-6)
 
         _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=0.25)
+        # can break early in this case, with tol above possible lowest RMSD
         assert rmsd == approx(0.2434045087608993, abs=1e-6)
 
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_permuted.xyz")
-        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1e5)
-        assert rmsd == approx(0, abs=6)
+        _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=1)
+        # perfect match possible here, breaks once found
+        assert rmsd == approx(0, abs=1e-4)
 
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_2.xyz")
         _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=2)  # breaks early with higher RMSD, < tol
-        assert rmsd == approx(1.1655, abs=1e-3)
+        assert rmsd < 2
 
         mol2 = Molecule.from_file(f"{TEST_DIR}/Si2O_cluster_2.xyz")
         _, rmsd = self.mol_matcher.fit(mol2, break_on_tol=0.2)  # doesn't break early, returns orig best RMSD


### PR DESCRIPTION
This is a small PR to add a `break_on_tol` option to `BruteForceOrderMatcher`, which allows one to massively speed up the molecule matching in cases where one just cares _if_ the molecules match within a given RMSD (rather than screening over _all_ possible permutations, to get the lowest possible RMSD). 

The speedup factor can be anywhere from 0% to several orders of magnitude, depending on the number of possible permutations and when a matching permutation is found.

Also includes a small typo fix that for an error message that reference the original class name (in https://github.com/materialsproject/pymatgen/pull/1938) which was later renamed. 

I've also added some tests for this.