### PR TITLE
Update JDFTx IO output utils private module

### DIFF
--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -144,7 +144,7 @@ def get_colon_val(linetext: str, lkey: str) -> float | None:
 
 
 # Temporary alias until the outside modules are merged with the renaming
-get_colon_val_t1 = get_colon_val
+get_colon_var_t1 = get_colon_val
 
 
 # This function matches the format of the generic "is_<x>_start_line" functions specific to

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from numpy.typing import NDArray
 
 
 def check_file_exists(func: Callable) -> Any:
@@ -120,7 +122,7 @@ def _brkt_list_of_3x3_to_nparray(lines: list[str], i_start: int = 0) -> np.ndarr
 
 # Named "t1" in unmet anticipation of multiple ways that a float would be needed
 # to be read following the variable string with a colon.
-def get_colon_var_t1(linetext: str, lkey: str) -> float | None:
+def get_colon_val(linetext: str, lkey: str) -> float | None:
     """Return float val from '...lkey: val...' in linetext.
 
     Read a float from an elec minimization line assuming value appears as
@@ -136,8 +138,13 @@ def get_colon_var_t1(linetext: str, lkey: str) -> float | None:
     """
     colon_var = None
     if lkey in linetext:
-        colon_var = float(linetext.split(lkey)[1].strip().split(" ")[0])
+        val = linetext.split(lkey)[1].strip().split(" ")[0]
+        colon_var = np.nan if val == "nan" else float(linetext.split(lkey)[1].strip().split(" ")[0])
     return colon_var
+
+
+# Temporary alias until the outside modules are merged with the renaming
+get_colon_val_t1 = get_colon_val
 
 
 # This function matches the format of the generic "is_<x>_start_line" functions specific to
@@ -164,6 +171,8 @@ def is_lowdin_start_line(line_text: str) -> bool:
     return "#--- Lowdin population analysis ---" in line_text
 
 
+# TODO: Figure out if this ever actually gets called, (I think I added it to make JOutStructure user friendly
+# but JOutStructure is not intended to be a user-initialized class)
 def correct_geom_opt_type(opt_type: str | None) -> str | None:
     """Return recognizable opt_type string.
 
@@ -183,7 +192,7 @@ def correct_geom_opt_type(opt_type: str | None) -> str | None:
         if "lattice" in opt_type.lower():
             opt_type = "LatticeMinimize"
         elif "ionic" in opt_type.lower():
-            opt_type = "IonicMinimize"
+            opt_type = "IonicDynamics" if "dyn" in opt_type.lower() else "IonicMinimize"
         else:
             opt_type = None
     return opt_type
@@ -325,16 +334,16 @@ def find_all_key(key_input: str, tempfile: list[str], startline: int = 0) -> lis
     return [i for i in range(startline, len(tempfile)) if key_input in tempfile[i]]
 
 
-def _parse_bandfile_complex(bandfile_filepath: str | Path) -> np.ndarray[np.complex64]:
-    dtype = np.complex64
+def _parse_bandfile_complex(bandfile_filepath: str | Path) -> NDArray[np.complex64]:
+    Dtype: TypeAlias = np.complex64
     token_parser = _complex_token_parser
-    return _parse_bandfile_reader(bandfile_filepath, dtype, token_parser)
+    return _parse_bandfile_reader(bandfile_filepath, Dtype, token_parser)
 
 
-def _parse_bandfile_normalized(bandfile_filepath: str | Path) -> np.ndarray[np.float32]:
-    dtype = np.float32
+def _parse_bandfile_normalized(bandfile_filepath: str | Path) -> NDArray[np.float32]:
+    Dtype: TypeAlias = np.float32
     token_parser = _normalized_token_parser
-    return _parse_bandfile_reader(bandfile_filepath, dtype, token_parser)
+    return _parse_bandfile_reader(bandfile_filepath, Dtype, token_parser)
 
 
 def _get__from_bandfile_filepath(bandfile_filepath: Path | str, tok_idx: int) -> int:
@@ -417,9 +426,7 @@ def _get_nspecies_from_bandfile_filepath(bandfile_filepath: Path | str) -> int:
     return _get__from_bandfile_filepath(bandfile_filepath, 6)
 
 
-def _parse_bandfile_reader(
-    bandfile_filepath: str | Path, dtype: type, token_parser: Callable
-) -> np.ndarray[np.complex64] | np.ndarray[np.float32]:
+def _parse_bandfile_reader(bandfile_filepath: str | Path, arr_dtype: TypeAlias, token_parser: Callable) -> NDArray:
     nstates = _get_nstates_from_bandfile_filepath(bandfile_filepath)
     nbands = _get_nbands_from_bandfile_filepath(bandfile_filepath)
     nproj = _get_nproj_from_bandfile_filepath(bandfile_filepath)
@@ -429,7 +436,7 @@ def _parse_bandfile_reader(
     expected_length = 2 + nspecies + (nstates * (1 + nbands))
     if not expected_length == len(bandfile):
         raise RuntimeError("Bandprojections file does not match expected length - ensure no edits have been made.")
-    proj_tju = np.zeros((nstates, nbands, nproj), dtype=dtype)
+    proj_tju: NDArray[arr_dtype] = np.zeros((nstates, nbands, nproj), dtype=arr_dtype)
     for line, text in enumerate(bandfile):
         tokens = text.split()
         if line >= nspecies + 2:
@@ -440,7 +447,7 @@ def _parse_bandfile_reader(
     return proj_tju
 
 
-def _complex_token_parser(tokens: list[str]) -> np.ndarray[np.complex64]:
+def _complex_token_parser(tokens: list[str]) -> NDArray[np.complex64]:
     out = np.zeros(int(len(tokens) / 2), dtype=np.complex64)
     ftokens = np.array(tokens, dtype=np.float32)
     out += 1j * ftokens[1::2]
@@ -448,8 +455,9 @@ def _complex_token_parser(tokens: list[str]) -> np.ndarray[np.complex64]:
     return out
 
 
-def _normalized_token_parser(tokens: list[str]) -> np.ndarray[np.float32]:
-    return np.array(tokens, dtype=np.float32)
+def _normalized_token_parser(tokens: list[str]) -> NDArray[np.float32]:
+    normalized_tokens: NDArray[np.float32] = np.array(tokens, dtype=np.float32)
+    return normalized_tokens
 
 
 def get_proj_tju_from_file(bandfile_filepath: Path | str) -> np.ndarray:

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -503,9 +503,9 @@ def _is_complex_bandfile_filepath(bandfile_filepath: str | Path) -> bool:
 # TODO: This is very likely redundant to something in pymatgen - replace with that if possible.
 orb_ref_list = [
     ["s"],
-    ["px", "py", "pz"],
-    ["dxy", "dxz", "dyz", "dx2y2", "dz2"],
-    ["fx3-3xy2", "fyx2-yz2", "fxz2", "fz3", "fyz2", "fxyz", "f3yx2-y3"],
+    ["py", "pz", "px"],
+    ["dxy", "dyz", "dz2", "dxz", "dx2-y2"],
+    ["fy(3x2-y2)", "fxyz", "fyz2", "fz3", "fxz2", "fz(x2-y2)", "fx(x2-3y2)"],
 ]
 
 

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -122,7 +122,7 @@ def _brkt_list_of_3x3_to_nparray(lines: list[str], i_start: int = 0) -> np.ndarr
 
 # Named "t1" in unmet anticipation of multiple ways that a float would be needed
 # to be read following the variable string with a colon.
-def get_colon_val(linetext: str, lkey: str) -> float | None:
+def get_colon_val(linetext: str, lkey: str) -> float | np.float64 | None:
     """Return float val from '...lkey: val...' in linetext.
 
     Read a float from an elec minimization line assuming value appears as

--- a/src/pymatgen/io/jdftx/_output_utils.py
+++ b/src/pymatgen/io/jdftx/_output_utils.py
@@ -84,7 +84,7 @@ def read_outfile_slices(file_name: str) -> list[list[str]]:
     return texts
 
 
-def _brkt_list_of_3_to_nparray(line: str) -> np.ndarray:
+def _brkt_list_of_3_to_nparray(line: str) -> NDArray[np.float64]:
     """Return 3x1 numpy array.
 
     Convert a string of the form "[ x y z ]" to a 3x1 numpy array
@@ -97,7 +97,7 @@ def _brkt_list_of_3_to_nparray(line: str) -> np.ndarray:
     return np.array([float(x) for x in line.split()[1:-1]])
 
 
-def _brkt_list_of_3x3_to_nparray(lines: list[str], i_start: int = 0) -> np.ndarray:
+def _brkt_list_of_3x3_to_nparray(lines: list[str], i_start: int = 0) -> NDArray[np.float64]:
     """Return 3x3 numpy array.
 
     Convert a list of strings of the form "[ x y z ]" to a 3x3 numpy array
@@ -460,7 +460,7 @@ def _normalized_token_parser(tokens: list[str]) -> NDArray[np.float32]:
     return normalized_tokens
 
 
-def get_proj_tju_from_file(bandfile_filepath: Path | str) -> np.ndarray:
+def get_proj_tju_from_file(bandfile_filepath: Path | str) -> NDArray[np.float32 | np.complex64]:
     """Return projections from file in tju shape.
 
     Return projections from file in (state, band, proj) shape. Collected in this shape before sabcju shape due to ready


### PR DESCRIPTION
## Summary

Major changes:
- function `get_colon_var_t1`
-- Renaming to `get_colon_val`, but keeping an alias until renaming is updated outside this module
-- Returning `np.nan` instead of `None` when "nan" is the value
- updating `correct_geom_opt_type` for working with JDFTx AIMD out files
- updating typing on array-construction functions
- correcting ordering and syntax of orbital labels to exactly match JDFTx
