### PR TITLE
Fixing "(null)" in JDFTx example out files

### DIFF
--- a/tests/files/io/jdftx/test_jdftx_out_file_sections/ex_out_slice_latmin
+++ b/tests/files/io/jdftx/test_jdftx_out_file_sections/ex_out_slice_latmin
@@ -57,7 +57,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \

--- a/tests/files/io/jdftx/test_jdftx_out_files/example_latmin.out
+++ b/tests/files/io/jdftx/test_jdftx_out_files/example_latmin.out
@@ -58,7 +58,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -1239,7 +1239,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -1981,7 +1981,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -2754,7 +2754,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -3936,7 +3936,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -4678,7 +4678,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -5452,7 +5452,7 @@ electronic-minimize  \
 	fdTest               no
 exchange-regularization WignerSeitzTruncated
 fluid None
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \

--- a/tests/files/io/jdftx/test_jdftx_out_files/latticeminimize_different.out
+++ b/tests/files/io/jdftx/test_jdftx_out_files/latticeminimize_different.out
@@ -72,7 +72,7 @@ fluid-cation Na+ 0.5 MeanFieldLJ \
 	Rvdw 2.19208 \
 	Res 0 \
 	tauNuc 343133
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \

--- a/tests/files/io/jdftx/test_jdftx_out_files/partial_lattice_init.out
+++ b/tests/files/io/jdftx/test_jdftx_out_files/partial_lattice_init.out
@@ -81,7 +81,7 @@ fluid-cation Na+ 0.5 MeanFieldLJ \
 	Rvdw 2.19208 \
 	Res 0 \
 	tauNuc 343133
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \
@@ -3587,7 +3587,7 @@ fluid-cation Na+ 0.5 MeanFieldLJ \
 	Rvdw 2.19208 \
 	Res 0 \
 	tauNuc 343133
-fluid-ex-corr (null) lda-PZ
+fluid-ex-corr lda-TF lda-PZ
 fluid-gummel-loop 10 1.000000e-05
 fluid-minimize  \
 	dirUpdateScheme      PolakRibiere \


### PR DESCRIPTION
Many of the example out files were obtained during a brief period of time where a bug in JDFTx caused the printed value of the "fluid-ex-corr" tag to contain an un-string-able value, that was replaced by the string "(null)" to allow parsing. In an upcoming change to the outfile parser, JDFTXInfile objects are created from this portion of the out file, and will fail parsing these files as "fluid-ex-corr (null) lda-PZ" is an invalid JDFTx input tag.