### PR TITLE
JDFTXStructure - partial fix for special case lattice tags

### DIFF
--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -789,6 +789,11 @@ class JDFTXStructure(MSONable):
             JDFTXStructure: The created JDFTXStructure object.
         """
         jl = jdftxinfile["lattice"]
+        if "R00" not in jl:
+            raise NotImplementedError(
+                "JDFTXStructure construction from JDFTXInfile currently only implemented for "
+                "lattices defined as a 3x3 matrix. "
+            )
         lattice = np.zeros([3, 3])
         for i in range(3):
             for j in range(3):

--- a/tests/io/jdftx/test_jdftxinfile.py
+++ b/tests/io/jdftx/test_jdftxinfile.py
@@ -487,6 +487,40 @@ def test_lattice_writing(value_str: str):
     )
 
 
+@pytest.mark.parametrize(
+    ("value_str"),
+    [
+        ("Rhombohedral 1.0 1.0"),
+        ("Triclinic 1.0 1.0 1.0 1.0 1.0 1.0"),
+        ("Hexagonal 1.0 1.0"),
+        ("Body-Centered Cubic 1.0"),
+        ("Cubic 1.0"),
+        ("Orthorhombic 1.0 1.0 1.0"),
+        ("Base-Centered Orthorhombic 1.0 1.0 1.0"),
+        ("Monoclinic 1.0 1.0 1.0 1.0"),
+        ("Base-Centered Monoclinic 1.0 1.0 1.0 1.0"),
+        ("Tetragonal 1.0 1.0"),
+        ("Body-Centered Tetragonal 1.0 1.0"),
+    ],
+)
+def test_jdftxstructure_lattice_conversion(value_str: str):
+    test_vars = ["a", "b", "c", "alpha", "beta", "gamma"]
+    mft_lattice_tag = get_tag_object("lattice")
+    assert mft_lattice_tag is not None
+    i = mft_lattice_tag.get_format_index_for_str_value("lattice", value_str)
+    tag_object = mft_lattice_tag.format_options[i]
+    parsed_tag = tag_object.read("lattice", value_str)
+    infile = JDFTXInfile.from_str("lattice " + value_str + "\n ion H 0.0 0.0 0.0 0", dont_require_structure=True)
+    if "modification" in parsed_tag:
+        with pytest.raises(NotImplementedError):
+            _ = infile.to_pmg_structure(infile)
+    else:
+        structure = infile.to_pmg_structure(infile)
+        for var in test_vars:
+            if var in parsed_tag:
+                assert_same_value(float(getattr(structure.lattice, var)), float(parsed_tag[var]))
+
+
 # This fails, but I don't think we need to support this
 # @pytest.mark.parametrize(
 #     ("unordered_dict", "expected_out"),


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: `pymatgen.io.jdftx.inputs.JDFTXStructure`
-- `JDFTXStructure.from_jdftxinfile` no longer assumes 'lattice' tag is provided in 3x3 matrix format
-- Testing in `tests/io/jdftx/test_jdftxinfile.py` for `Structure <-> JDFTXStructure <-> JDFTXInfile` conversion for `JDFTXInfile` with newly implemented special case values for 'lattice' tag

TODO:
-  Implement `JDFTXStructure.from_jdftxinfile` for JDFTXInfile with special case tag 'lattice' value and non-identity value for 'latt-scale' tag


