### PR TITLE
`UFloat` update

### DIFF
--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -288,7 +288,9 @@ class AnionCorrection(Correction):
         if len(comp) == 1:  # Skip element entry
             return ufloat(0.0, np.nan)
 
-        correction = ufloat(0.0, 0.0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Using UFloat")
+            correction = ufloat(0.0, 0.0)
 
         # Check for sulfide corrections
         if Element("S") in comp:

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -364,7 +364,9 @@ class ComputedEntry(Entry):
             float: the total energy correction / adjustment applied to the entry in eV.
         """
         # either sum of adjustments or ufloat with nan std_dev, so that no corrections still result in ufloat object:
-        corr = sum(ufloat(ea.value, ea.uncertainty) for ea in self.energy_adjustments) or ufloat(0.0, np.nan)
+        corr = sum(ufloat(ea.value, ea.uncertainty) for ea in self.energy_adjustments if ea.value) or ufloat(
+            0.0, np.nan
+        )
         return corr.nominal_value
 
     @correction.setter
@@ -388,7 +390,7 @@ class ComputedEntry(Entry):
         """
         # either sum of adjustments or ufloat with nan std_dev, so that no corrections still result in ufloat object:
         unc = sum(
-            (ufloat(ea.value, ea.uncertainty) if not np.isnan(ea.uncertainty) else ufloat(ea.value, 0))
+            (ufloat(ea.value, ea.uncertainty) if not np.isnan(ea.uncertainty) and ea.value else ufloat(ea.value, 0))
             for ea in self.energy_adjustments
         ) or ufloat(0.0, np.nan)
 


### PR DESCRIPTION
This is a minor addition to https://github.com/materialsproject/pymatgen/pull/4400.

I found that there were some cases where an energy adjustment of `UFloat(0, 0)` were already present in `ComputedEntry.energy_adjustments`, avoiding the updated handling of setting `std_dev` to `np.nan` when it is 0 (and avoiding the `UFloat` warning about `std_dev` being 0).
When accessing the MP database and pulling ozonide structures (for which the MP Anion Correction is set to 0, with std_dev 0), it throws the `UFloat` warning again.

MWE:
```python
from pymatgen.ext.matproj import MPRester

with MPRester() as mpr:
    entries = mpr.get_entries_in_chemsys("Na-O")

for entry in entries:
    print(entry.name, entry.energy_adjustments)
```
where one of the outputs is:
```
NaO3 [CompositionEnergyAdjustment(name='MP2020 anion correction (ozonide)', value=0.0, uncertainty=0.0, description='Composition-based energy adjustment', generated_by='MaterialsProject2020Compatibility')]
```

The updated handling in this minor fix avoids the `UFloat` warning being unnecessarily triggered for these cases.