### PR TITLE
JDFTXInfile addition (`__add__`) method tweak

### DIFF
--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -46,6 +46,10 @@ __author__ = "Jacob Clary, Ben Rich"
 
 # TODO: Add check for whether all ions have or lack velocities.
 # TODO: Add default value filling like JDFTx does.
+# TODO: Add more robust checking for if two repeatable tag values represent the
+# same information. This is likely fixed by implementing filling of default values.
+# TODO: Incorporate something to collapse repeated dump tags of the same frequency
+# into a single value.
 
 
 class JDFTXInfile(dict, MSONable):

--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -80,6 +80,7 @@ class JDFTXInfile(dict, MSONable):
         """Add existing JDFTXInfile object to method caller JDFTXInfile object.
 
         Add all the values of another JDFTXInfile object to this object. Facilitate the use of "standard" JDFTXInfiles.
+        Repeatable tags are appended together. Non-repeatable tags are replaced with their value from the other object.
 
         Args:
             other (JDFTXInfile): JDFTXInfile object to add to the method caller object.
@@ -87,11 +88,26 @@ class JDFTXInfile(dict, MSONable):
         Returns:
             JDFTXInfile: The combined JDFTXInfile object.
         """
-        params: dict[str, Any] = dict(self.items())
+        # Deepcopy needed here, or else in `jif1 = jif2 + jif3`, `jif1` will become a reference to `jif2`
+        params: dict[str, Any] = deepcopy(dict(self.items()))
         for key, val in other.items():
-            if key in self and val != self[key]:
-                raise ValueError(f"JDFTXInfiles have conflicting values for {key}: {self[key]} != {val}")
-            params[key] = val
+            if key in self:
+                if val is params[key]:
+                    # Unlinking the two objects fully cannot be done by deepcopy for some reason
+                    continue
+                tag_object = get_tag_object(key)
+                if tag_object.can_repeat:
+                    if isinstance(val, list):
+                        for subval in list(val):
+                            # Minimum effort to avoid duplicates
+                            if subval not in params[key]:
+                                params[key].append(subval)
+                    else:
+                        params[key].append(val)
+                else:
+                    params[key] = val
+            else:
+                params[key] = val
         return type(self)(params)
 
     def as_dict(self, sort_tags: bool = True, skip_module_keys: bool = False) -> dict:


### PR DESCRIPTION
Changing addition method - now infiles with shared keys will either concatenate their inputs if the key is for a repeatable tag, or change to whatever value is in the second infile if it is not a repeatable tag. A bare minimum `if subval in params[key]` check is done to avoid adding duplicate values. This seems like something the `set` built-in could help with, but since the sub-values are dictionaries, using `set` is a little more difficult

## Summary

Major changes:

- fix 1: Addition of two JDFTXInfiles (`jif1 = jif2 + jif3`) no longer requires each `jif2` and `jif3` to have a unique set of tags
-- For a non-repeatable tag 'key', `jif1['key'] == jif3['key']`
-- For a repeatable-tag 'key', `jif1['key'] = jif2['key'] + [val for val in jif3['key'] if not val in jif2['key']`
-- implemented in `src/pymatgen/io/jdftx/inputs.py`
-- tested in `tests/io/jdftx/test_jdftxinfile.py`
--- error raising test for conflicting tag values removed 

## Todos

- fix 1: Add more robust checking for if two repeatable tag values represent the same information.
-- This is likely fixed by implementing the pre-existing TODO - "Add default value filling like JDFTx does"
- fix 2: Incorporate something to collapse repeated dump tags of the same frequency into a single value.
-- The 'dump' tag currently can get bloated very quickly, as the newly implemented change for concatenating two repeatable tags will not detect that something like `{"End": {"State": True}}` is technically already in a list that contains something like `{"End": {"State": True, "Berry": True}}`
-- A cleanup function that can convert `{'dump': [{"End": {"State": True, "BGW": True}}, {"End": {"State": True, "Berry": True}}]` into `{'dump': [{"End": {"State": True, "BGW": True, "Berry": True}}]` would fix this bloat risk
