### PR TITLE
`to_jdftxinfile` method for JDFTXOutfile

### DIFF
--- a/src/pymatgen/io/jdftx/generic_tags.py
+++ b/src/pymatgen/io/jdftx/generic_tags.py
@@ -430,6 +430,7 @@ class FloatTag(AbstractTag):
     """
 
     prec: int | None = None
+    minval: float | None = None
 
     def validate_value_type(self, tag: str, value: Any, try_auto_type_fix: bool = False) -> tuple[str, bool, Any]:
         """Validate the type of the value for this tag.
@@ -472,6 +473,11 @@ class FloatTag(AbstractTag):
         Returns:
             str: The tag and its value as a string.
         """
+        # Returning an empty string instead of raising an error as value == self.minval
+        # will cause JDFTx to throw an error, but the internal infile dumps the value as
+        # as the minval if not set by the user.
+        if (self.minval is not None) and (not value > self.minval):
+            return ""
         # pre-convert to string: self.prec+3 is minimum room for:
         # - sign, 1 integer left of decimal, decimal, and precision.
         # larger numbers auto add places to left of decimal

--- a/src/pymatgen/io/jdftx/inputs.py
+++ b/src/pymatgen/io/jdftx/inputs.py
@@ -573,6 +573,17 @@ class JDFTXInfile(dict, MSONable):
                     warnmsg += "(Check earlier warnings for more details)\n"
                 warnings.warn(warnmsg, stacklevel=2)
 
+    def strip_structure_tags(self) -> None:
+        """Strip all structural tags from the JDFTXInfile.
+
+        Strip all structural tags from the JDFTXInfile. This is useful for preparing a JDFTXInfile object
+        from a pre-existing calculation for a new structure.
+        """
+        strucural_tags = ["lattice", "ion", "lattice-scale", "coords-type"]
+        for tag in strucural_tags:
+            if tag in self:
+                del self[tag]
+
     def __setitem__(self, key: str, value: Any) -> None:
         """Set an item in the JDFTXInfile.
 

--- a/src/pymatgen/io/jdftx/jdftxinfile_ref_options.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_ref_options.py
@@ -800,7 +800,7 @@ jdftxminimize_subtagdict = {
     "wolfeGradient": FloatTag(),
 }
 jdftxfluid_subtagdict = {
-    "epsBulk": FloatTag(),
+    "epsBulk": FloatTag(minval=1.0),
     "epsInf": FloatTag(),
     "epsLJ": FloatTag(),
     "Nnorm": FloatTag(),
@@ -814,12 +814,12 @@ jdftxfluid_subtagdict = {
             "A0": FloatTag(write_tagname=False, optional=False),
         },
     ),
-    "Pvap": FloatTag(),
+    "Pvap": FloatTag(minval=0.0),
     "quad_nAlpha": FloatTag(),
     "quad_nBeta": FloatTag(),
     "quad_nGamma": FloatTag(),
     "representation": TagContainer(subtags={"MuEps": FloatTag(), "Pomega": FloatTag(), "PsiAlpha": FloatTag()}),
-    "Res": FloatTag(),
+    "Res": FloatTag(minval=0.0),
     "Rvdw": FloatTag(),
     "s2quadType": StrTag(
         options=[
@@ -844,7 +844,7 @@ jdftxfluid_subtagdict = {
             "Tetrahedron",
         ]
     ),
-    "sigmaBulk": FloatTag(),
+    "sigmaBulk": FloatTag(minval=0.0),
     "tauNuc": FloatTag(),
     "translation": StrTag(options=["ConstantSpline", "Fourier", "LinearSpline"]),
 }

--- a/src/pymatgen/io/jdftx/jdftxinfile_ref_options.py
+++ b/src/pymatgen/io/jdftx/jdftxinfile_ref_options.py
@@ -792,7 +792,7 @@ jdftxminimize_subtagdict = {
     "knormThreshold": FloatTag(),
     "linminMethod": StrTag(options=["CubicWolfe", "DirUpdateRecommended", "Quad", "Relax"]),
     "maxThreshold": BoolTag(),
-    "nAlphaAdjustMax": FloatTag(),
+    "nAlphaAdjustMax": IntTag(),
     "nEnergyDiff": IntTag(),
     "nIterations": IntTag(),
     "updateTestStepSize": BoolTag(),

--- a/src/pymatgen/io/jdftx/jdftxoutfileslice.py
+++ b/src/pymatgen/io/jdftx/jdftxoutfileslice.py
@@ -391,7 +391,10 @@ class JDFTXOutfileSlice:
         Args:
             text (list[str]): Output of read_file for out file.
         """
-        start_line_idx = find_key("Input parsed successfully", text) + 2
+        start_line_idx = find_key("Input parsed successfully", text)
+        if start_line_idx is None:
+            raise ValueError("JDFTx input parsing failed on most recent call.")
+        start_line_idx += 2
         end_line_idx = None
         for i in range(start_line_idx, len(text)):
             if not len(text[i].strip()):

--- a/src/pymatgen/io/jdftx/jdftxoutfileslice.py
+++ b/src/pymatgen/io/jdftx/jdftxoutfileslice.py
@@ -1157,6 +1157,24 @@ class JDFTXOutfileSlice:
             raise ValueError("Cannot determine if system is metal - self.nspin undefined")
         return None
 
+    def to_jdftxinfile(self) -> JDFTXInfile:
+        """
+        Convert the JDFTXOutfile object to a JDFTXInfile object with the most recent structure.
+        If the input structure is desired, simply fetch JDFTXOutfile.infile
+
+        Returns:
+            JDFTXInfile: A JDFTXInfile object representing the input parameters of the JDFTXOutfile.
+        """
+        # Use internal infile as a reference for calculation parameters
+        base_infile = self.infile.copy()
+        # Strip references to the input
+        base_infile.strip_structure_tags()
+        if self.structure is None:
+            return base_infile
+        infile = JDFTXInfile.from_structure(self.structure)
+        infile += base_infile
+        return infile
+
     def _check_solvation(self) -> bool:
         """Check for implicit solvation.
 

--- a/src/pymatgen/io/jdftx/outputs.py
+++ b/src/pymatgen/io/jdftx/outputs.py
@@ -596,6 +596,7 @@ class JDFTXOutfile:
         ]
         return cls(slices=slices)
 
+    # TODO: Write testing for this function
     def to_jdftxinfile(self) -> JDFTXInfile:
         """
         Convert the JDFTXOutfile object to a JDFTXInfile object with the most recent structure.

--- a/src/pymatgen/io/jdftx/outputs.py
+++ b/src/pymatgen/io/jdftx/outputs.py
@@ -27,6 +27,7 @@ from pymatgen.io.jdftx.jdftxoutfileslice import JDFTXOutfileSlice
 if TYPE_CHECKING:
     from pymatgen.core.structure import Structure
     from pymatgen.core.trajectory import Trajectory
+    from pymatgen.io.jdftx.inputs import JDFTXInfile
     from pymatgen.io.jdftx.jelstep import JElSteps
     from pymatgen.io.jdftx.jminsettings import (
         JMinSettingsElectronic,
@@ -287,7 +288,42 @@ _jof_atr_from_last_slice = (
     "electronic_output",
     "t_s",
     "ecomponents",
+    "infile",
 )
+
+# TODO: Remove references to the deprecated 'jsettings_*' attributes in `JDFTXOutfile` and `JDFTXOutfileSlice`
+# TODO: JDFTXOutfile and JDFTXOutfileSlice are VERY bloated. The following attributes are redundant
+# to fields of the `Structure` object and their removal likely won't cause any confusion.
+# - lattice
+# - lattice_final
+# - atom_coords
+# - atom_coords_final
+# - a/b/c
+# The following attributes are redundant to the internal `JDFTXInfile` object, but since the JDFTXInfile
+# object is not a standard pymatgen object, it may be better to decorate them with a deprecated decorator
+# until end of year. Additionally, it should be made certain which of these are dumped in the outfile's
+# input section regardless of what was set in the input file - for those that are not, they need to be kept.
+# - lattice_initial
+# - atom_coords_initial
+# - broadening
+# - broadening_type
+# - kgrid
+# - truncation_type
+# - truncation_radius
+# - fluid
+# - pwcut
+# - rhocut
+# The following are attributes that come from the electronic/fluid/ionic/lattice optimization step
+# logs. I am not sure if it is actually helpful to have access to these from the `JDFTXOutfile` object,
+# as they are only informative for analyzing optimization convergence. Additionally, the fields are
+# less universal than I thought, and can change depending on the optimization settings, so it might
+# be smarter to store them in a dictionary of arbitrary keys instead within the contained substructures.
+# - grad_k
+# - alpha
+# - linmin
+# - elec_grad_k
+# - elec_alpha
+# - elec_linmin
 
 
 @dataclass
@@ -420,6 +456,7 @@ class JDFTXOutfile:
         elec_alpha (float): The step size of the final electronic step in the most recent JDFTx call.
         elec_linmin (float): The final normalized projection of the electronic step direction onto the gradient for the
             most recent JDFTx call.
+        infile (JDFTXInfile): The JDFTXInfile object representing the input parameters of the JDFTXOutfile.
 
     Magic Methods:
         __getitem__(key: str | int) -> Any: Decides behavior of how JDFTXOutfile objects are indexed. If the key is a
@@ -506,6 +543,7 @@ class JDFTXOutfile:
     elec_alpha: float = field(init=False)
     elec_linmin: float = field(init=False)
     electronic_output: float = field(init=False)
+    infile: JDFTXInfile = field(init=False)
 
     @classmethod
     def from_calc_dir(
@@ -557,6 +595,16 @@ class JDFTXOutfile:
             for i, text in enumerate(texts)
         ]
         return cls(slices=slices)
+
+    def to_jdftxinfile(self) -> JDFTXInfile:
+        """
+        Convert the JDFTXOutfile object to a JDFTXInfile object with the most recent structure.
+        If the input structure is desired, simply fetch JDFTXOutfile.infile
+
+        Returns:
+            JDFTXInfile: A JDFTXInfile object representing the input parameters of the JDFTXOutfile.
+        """
+        return self.slices[-1].to_jdftxinfile()
 
     def __post_init__(self):
         last_slice = None

--- a/tests/io/jdftx/test_jdftxinfile.py
+++ b/tests/io/jdftx/test_jdftxinfile.py
@@ -186,6 +186,14 @@ def test_JDFTXInfile_expected_exceptions():
         jif[1.2] = 3.4
 
 
+def test_JDFTXInfile_strip_structure():
+    jif = JDFTXInfile.from_file(ex_infile1_fname)
+    structural_tags = ["lattice", "ion", "coords-type"]
+    assert all(tag in jif for tag in structural_tags)
+    jif.strip_structure_tags()
+    assert all(tag not in jif for tag in structural_tags)
+
+
 def test_JDFTXInfile_niche_cases():
     jif = JDFTXInfile.from_file(ex_infile1_fname)
     tag_object, tag, value = jif._preprocess_line("dump-only")


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: Method `to_jdftxinfile` for JDFTXOutfile(Slice)
-- Uses internal `JDFTXInfile` and `Structure` to create a new `JDFTXInfile` object that can be ran to restart a calculation
- feature 2: Method `strip_structure_tags` for `JDFTXInfile`
-- Strips all structural tags from a `JDFTXInfile` for creating equivalent `JDFTXInfile` objects with updated associated structures
- fix 1: Changing 'nAlphaAdjustMax' shared tag from a `FloatTag` to an `IntTag`
- fix 2: Adding an optional `minval` field for certain `FloatTag`s which prevent writing error-raising values
-- Certain tag options in JDFTx can internally be the minimum value, but trying to pass the minimum value will raise an error

## Todos

- feature 1: Testing for the `to_jdftxinfile`
-- I know the function works from having used it, but I haven't written in an explicit test for it yet. 
- fix 2: Look through JDFTx source code and identify all the numeric tag value boundaries and add them to the FloatTag. This will likely require generalizing how boundaries are tested as a quick glance (see [here](https://github.com/shankar1729/jdftx/blob/master/jdftx/commands/fluid.cpp#L378)) shows there are tags that actually do use the `>=` operator
- Unrelated: Reduce bloat in outputs module
-- Remove references to deprecated fields
-- Begin phasing out redundant fields
--- i.e. `JDFTXOutfile.lattice` redundant to `JDFTXOutfile.structure.lattice.matrix`
-- Generalize how optimization logs are stored in outputs module objects
--- Fields like `grad_K` are part of a broad group of values that can be logged for an optimization step, and the fields present in each log varies a lot more than I previously thought when I initially wrote the JDFTx outputs module. Generalizing how these are stored into a dictionary of arbitrary keys should make the outputs module more robust, as well as helping reduce the bloat in the outputs module.



