### PR TITLE
Add `orjson` as required depdency as default JSON handler when custom encoder/decoder is not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,17 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "bibtexparser>=1.4.0",
     "joblib>=1",
     "matplotlib>=3.8",
     "monty>=2025.1.9",
     "networkx>=2.7", # PR4116
+    # NumPy documentation suggests pinning the current major version as the C API is used
+    # https://numpy.org/devdocs/dev/depending_on_numpy.html#runtime-dependency-version-ranges
+    "numpy>=1.25.0,<3",
     "palettable>=3.3.3",
     "pandas>=2",
     "plotly>=5.0.0",
-    "bibtexparser>=1.4.0",
     "requests>=2.32",
     "ruamel.yaml>=0.17.0",
     "scipy>=1.13.0",
@@ -74,9 +77,6 @@ dependencies = [
     "tabulate>=0.9",
     "tqdm>=4.60",
     "uncertainties>=3.1.4",
-    # NumPy documentation suggests pinning the current major version as the C API is used
-    # https://numpy.org/devdocs/dev/depending_on_numpy.html#runtime-dependency-version-ranges
-    "numpy>=1.25.0,<3",
 ]
 version = "2025.5.2"
 
@@ -106,7 +106,6 @@ optional = [
     "h5py>=3.11.0",
     "hiphive>=1.3.1",
     "jarvis-tools>=2020.7.14",
-    "matplotlib>=3.8",
     "phonopy>=2.33.3",
     "seekpath>=2.0.1",
 ]
@@ -264,9 +263,7 @@ addopts = "--durations=30 --quiet -r xXs --color=yes --import-mode=importlib"
 filterwarnings = [
     # NOTE: the LAST matching option would be used
     "ignore::UserWarning", # Ignore UserWarning
-    "error:We strongly encourage explicit `encoding`:EncodingWarning", # Mark `zopen` EncodingWarning as error
-    "error:We strongly discourage using implicit binary/text:FutureWarning", # Mark `zopen` FutureWarning as error
-    # TODO: remove the following filter once `monty.io` dropped custom EncodingWarning
+    # TODO: remove the following filter once `monty.io` dropped custom EncodingWarning (python 3.10+ only)
     "error:We strongly encourage explicit `encoding`:monty.io.EncodingWarning",
     # TODO: pybtex (perhaps some others) emits the following warnings
     'ignore:pkg_resources is deprecated as an API:DeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,10 +265,6 @@ filterwarnings = [
     "ignore::UserWarning", # Ignore UserWarning
     # TODO: remove the following filter once `monty.io` dropped custom EncodingWarning (python 3.10+ only)
     "error:We strongly encourage explicit `encoding`:monty.io.EncodingWarning",
-    # TODO: pybtex (perhaps some others) emits the following warnings
-    'ignore:pkg_resources is deprecated as an API:DeprecationWarning',
-    'ignore:distutils Version classes are deprecated:DeprecationWarning',
-    'ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

- Add `orjson` as required depdency as default JSON handler when custom encoder/decoder is not needed, to close #4385
- Minor cleanup of `pyproject.toml`