### PR TITLE
speed-up Structure instantiation

### DIFF
--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -236,7 +236,7 @@ class ElementBase(Enum):
 
     def __hash__(self) -> int:
         # multiply Z by 1000 to avoid hash collisions of element N with isotopes of elements N+/-1,2,3...
-        return self.Z * 1000 + self.A if self._is_named_isotope else self.Z
+        return self.Z * 1000 + self.A if self._is_named_isotope else self.Z * 137 * 100
 
     def __repr__(self) -> str:
         return f"Element {self.symbol}"
@@ -1605,7 +1605,7 @@ def get_el_sp(obj: SpeciesLike) -> Element | Species | DummySpecies:
     pass
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=1024)
 def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
     """Utility function to get an Element, Species or DummySpecies from any input.
 


### PR DESCRIPTION
## Summary
This PR speeds up the instantiation of `Structure` objects by preventing hash collisions in the `lru_cache` of `get_el_sp` and increasing its `maxsize`. The issue is that currently `Element` objects are hashed to the same value as the integer atomic numbers (e.g., `Element[H]` maps to the same hash as `int(1)`). This forces the `lru_hash` to perform an expensive `__eq__` comparison between the two, which reduces the performance of instantiating many `Structure` objects. Also here we increase the `maxsize` of `get_el_sp`'s `lru_cache` to 1024 for further performance improvements.

This reduces time taken to instantiate 100,000 `Structure` objects from 31 seconds to 8.7s (avoid hash collisions) to 6.1s (also increase `maxsize` to 1024). Test snippet:

```python
from pymatgen.core import Structure
import numpy as np
from time import time

t = time()
for _ in range(100_000):
    struc = Structure(
        coords = np.random.rand(10, 3),
        species = np.random.randint(1, 100, size=(10,)),
        lattice = np.random.rand(3, 3),
        coords_are_cartesian = False,
    )
print("Time taken to create 100,000 structures:", time() - t)
```

Unless I'm missing some deep reason for why the hash of `Element` objects should be the same as their atomic number hashes, this should not lead to any different behavior of the code.

Major changes:

* Update `ElementBase` `__hash__` function to map to a different value than the atomic number
* Increase the `maxsize` of `get_el_sp`'s `lru_cache` to 1024

## Checklist

- [ x ] Google format doc strings added. Check with `ruff`.
- [ x ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ x ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
