### PR TITLE
adding radd dunder method to Volumetric data + test_outputs

### DIFF
--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -130,12 +130,12 @@ class VolumetricData(MSONable):
         return self.linear_add(other, 1.0)
 
     def __radd__(self, other):
-        """Right-side addition for sum() and similar use cases."""
-        if other == 0 or other is None:
-            return self
-        if isinstance(other, Dos):
-            return self.__add__(other)
-        raise TypeError(f"Unsupported operand type(s) for +: '{type(other).__name__}' and '{type(self).__name__}'")
+    if other == 0 or other is None:
+        # sum() calls 0 + self first; we treat 0 as the identity element
+        return self
+    if isinstance(other, self.__class__):
+        return self.__add__(other)
+    raise TypeError(f"Unsupported operand type(s) for +: '{type(other).__name__}' and '{type(self).__name__}'")
 
     def __sub__(self, other):
         return self.linear_add(other, -1.0)

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -130,9 +130,12 @@ class VolumetricData(MSONable):
         return self.linear_add(other, 1.0)
 
     def __radd__(self, other):
-        if other == 0:
+        """Right-side addition for sum() and similar use cases."""
+        if other == 0 or other is None:
             return self
-        return self.__add__(other)
+        if isinstance(other, Dos):
+            return self.__add__(other)
+        raise TypeError(f"Unsupported operand type(s) for +: '{type(other).__name__}' and '{type(self).__name__}'")
 
     def __sub__(self, other):
         return self.linear_add(other, -1.0)

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -130,12 +130,13 @@ class VolumetricData(MSONable):
         return self.linear_add(other, 1.0)
 
     def __radd__(self, other):
-    if other == 0 or other is None:
-        # sum() calls 0 + self first; we treat 0 as the identity element
-        return self
-    if isinstance(other, self.__class__):
-        return self.__add__(other)
-    raise TypeError(f"Unsupported operand type(s) for +: '{type(other).__name__}' and '{type(self).__name__}'")
+        if other == 0 or other is None:
+            # sum() calls 0 + self first; we treat 0 as the identity element
+            return self
+        if isinstance(other, self.__class__):
+            return self.__add__(other)
+
+        raise TypeError(f"Unsupported operand type(s) for +: '{type(other).__name__}' and '{type(self).__name__}'")
 
     def __sub__(self, other):
         return self.linear_add(other, -1.0)

--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -129,6 +129,11 @@ class VolumetricData(MSONable):
     def __add__(self, other):
         return self.linear_add(other, 1.0)
 
+    def __radd__(self, other):
+        if other == 0:
+            return self
+        return self.__add__(other)
+
     def __sub__(self, other):
         return self.linear_add(other, -1.0)
 

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1585,6 +1585,9 @@ class TestChgcar(MatSciTest):
         chgcar = self.chgcar_spin + self.chgcar_spin
         assert chgcar.get_integrated_diff(0, 1)[0, 1] == approx(-0.0043896932237534022 * 2)
 
+        chgcar = sum([self.chgcar_spin, self.chgcar_spin])
+        assert chgcar.get_integrated_diff(0, 1)[0, 1] == approx(-0.0043896932237534022 * 2)
+
         chgcar = self.chgcar_spin - self.chgcar_spin
         assert chgcar.get_integrated_diff(0, 1)[0, 1] == approx(0)
 


### PR DESCRIPTION
## Summary

Minor changes:

- Added ```__radd__``` method to VolumetricData to avoid errors associated with operations like `sum([chgcar1, chgcar2, ... etc] )` 
- Added test in `test_outputs.py` to check if method works

All tests passing 
`125 passed, 9 warnings in 69.04s (0:01:09)` 

