### PR TITLE
Fix Molecule.get_boxed_structure when reorder=False

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -3959,7 +3959,7 @@ class IMolecule(SiteCollection, MSONable):
         return cls(
             lattice,
             self.species * nimages,
-            coords,
+            all_coords,
             coords_are_cartesian=True,
             site_properties=site_props,
             labels=self.labels * nimages,

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -2237,6 +2237,7 @@ Site: H (-0.5134, 0.8892, -0.3630)"""
         no_reorder = self.mol.get_boxed_structure(10, 10, 10, reorder=False)
         assert str(s3[0].specie) == "H"
         assert str(no_reorder[0].specie) == "C"
+        assert_allclose(no_reorder[2].frac_coords, [0.60267191, 0.5, 0.4637])
 
     def test_get_distance(self):
         assert self.mol.get_distance(0, 1) == approx(1.089)


### PR DESCRIPTION
## Summary

In `Molecule.get_boxed_structure`, when `reorder=False`, in the current version of the code does not use the processed new coordinates, but the initial ones of the Molecule. This usually results for example in a Molecule not being centered in the box.
Unless I am missing something there should be no reason not to use the modified coordinates in the case of `reorder=False`. This PR switches to use the same coordinates independently of the final sorting.

I added a test based on the coordinates that would have failed in the previous implementation due to the molecule not being centered in the box.
