### PR TITLE
[WIP]`Trajectory` -> Gaussview readable ".log" file

### DIFF
--- a/src/pymatgen/core/trajectory.py
+++ b/src/pymatgen/core/trajectory.py
@@ -477,6 +477,21 @@ class Trajectory(MSONable):
         with zopen(filename, mode="wt", encoding="utf-8") as file:
             file.write(xdatcar_str)  # type:ignore[arg-type]
 
+    def write_Gaussian_log(
+        self,
+        filename: PathLike = "calc.log",
+    ) -> None:
+        """Write Trajectory object to a Gaussian-formatted log file.
+
+        The produced file will be readable by Gaussview.
+
+        Args:
+            filename: File to write. File does not need to end with '.log' to be readable by Gaussview.
+                The suffix ".logx" is recommended to distinguish from real Gaussian log files.
+        """
+        # TODO: Write me! :)
+        print(f"Writing {filename} ...")
+
     def as_dict(self) -> dict:
         """Return the trajectory as a MSONable dict."""
         lat = self.lattice.tolist() if self.lattice is not None else None


### PR DESCRIPTION
From #4420

## Summary

Major changes:

- feature 1: Adds the class function `core.trajectory.Trajectory.write_Gaussian_log`, which writes a Gaussview readable ".log" file from the contents of a `Trajectory` object

## Todos

- feature 1: Fill out the function stub
-- Write each `Structure` in the `Trajectory`
-- Fetch the energies series from `Trajectory.frame_properties["energy"]`
-- Default write from `Trajectory.site_properties[i]`
--- "charges" to "Mulliken charges" and "magmom" to "Mulliken spin"
-- Implement an optional mapping of a site property name to a supported (producible by Gaussian) site property
--- Allows flexible representation of up to (9?) compatible site properties
--- Assumes the requested site property maps each site to a single float

