### PR TITLE
Fix uncertainty as int for `EnergyAdjustment`

### DIFF
--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -322,7 +322,7 @@ class ComputedEntry(Entry):
         super().__init__(composition, energy)
         self.energy_adjustments = energy_adjustments or []
 
-        if correction != 0.0:
+        if not math.isclose(correction, 0.0):
             if energy_adjustments:
                 raise ValueError(
                     f"Argument conflict! Setting correction = {correction:.3f} conflicts "
@@ -395,7 +395,7 @@ class ComputedEntry(Entry):
             for ea in self.energy_adjustments
         ) or ufloat(0.0, np.nan)
 
-        if unc.nominal_value != 0 and unc.std_dev == 0:
+        if not math.isclose(unc.nominal_value, 0) and math.isclose(unc.std_dev, 0):
             return np.nan
 
         return unc.std_dev
@@ -498,7 +498,7 @@ class ComputedEntry(Entry):
         # we don't pass correction explicitly because it will be calculated
         # on the fly from energy_adjustments
         correction = 0
-        if dct["correction"] != 0 and len(energy_adj) == 0:
+        if not math.isclose(dct["correction"], 0) and len(energy_adj) == 0:
             # this block is for legacy ComputedEntry that were
             # serialized before we had the energy_adjustments attribute.
             correction = dct["correction"]
@@ -629,7 +629,7 @@ class ComputedStructureEntry(ComputedEntry):
         """
         # the first block here is for legacy ComputedEntry that were
         # serialized before we had the energy_adjustments attribute.
-        if dct["correction"] != 0 and not dct.get("energy_adjustments"):
+        if not math.isclose(dct["correction"], 0) and not dct.get("energy_adjustments"):
             struct = MontyDecoder().process_decoded(dct["structure"])
             return cls(
                 struct,

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -191,7 +191,7 @@ class CompositionEnergyAdjustment(EnergyAdjustment):
             description: str, human-readable explanation of the energy adjustment.
         """
         self._adj_per_atom = adj_per_atom
-        self.uncertainty_per_atom = uncertainty_per_atom
+        self.uncertainty_per_atom = float(uncertainty_per_atom)
         self.n_atoms = n_atoms
         self.cls = cls or {}
         self.name = name
@@ -519,6 +519,7 @@ class ComputedEntry(Entry):
         return_dict |= {
             "entry_id": self.entry_id,
             "correction": self.correction,
+            # "energy_adjustments": json.loads(orjson.dumps(self.energy_adjustments, default=MontyEncoder().default)),
             "energy_adjustments": json.loads(json.dumps(self.energy_adjustments, cls=MontyEncoder)),
             "parameters": json.loads(json.dumps(self.parameters, cls=MontyEncoder)),
             "data": json.loads(json.dumps(self.data, cls=MontyEncoder)),

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -50,12 +50,12 @@ class EnergyAdjustment(MSONable):
 
     def __init__(
         self,
-        value,
-        uncertainty=np.nan,
-        name="Manual adjustment",
-        cls=None,
-        description="",
-    ):
+        value: float,
+        uncertainty: float = np.nan,
+        name: str = "Manual adjustment",
+        cls: dict | None = None,
+        description: str = "",
+    ) -> None:
         """
         Args:
             value (float): value of the energy adjustment in eV
@@ -69,7 +69,7 @@ class EnergyAdjustment(MSONable):
         self.cls = cls or {}
         self.description = description
         self._value = value
-        self._uncertainty = uncertainty
+        self._uncertainty = float(uncertainty)
 
     @property
     def value(self):
@@ -133,7 +133,7 @@ class ConstantEnergyAdjustment(EnergyAdjustment):
         """
         super().__init__(value, uncertainty, name=name, cls=cls, description=description)
         self._value = value
-        self._uncertainty = uncertainty
+        self._uncertainty = float(uncertainty)
 
     @property
     def explain(self):
@@ -251,7 +251,7 @@ class TemperatureEnergyAdjustment(EnergyAdjustment):
             description: str, human-readable explanation of the energy adjustment.
         """
         self._adj_per_deg = adj_per_deg
-        self.uncertainty_per_deg = uncertainty_per_deg
+        self.uncertainty_per_deg = float(uncertainty_per_deg)
         self.temp = temp
         self.n_atoms = n_atoms
         self.name = name
@@ -519,7 +519,6 @@ class ComputedEntry(Entry):
         return_dict |= {
             "entry_id": self.entry_id,
             "correction": self.correction,
-            # "energy_adjustments": json.loads(orjson.dumps(self.energy_adjustments, default=MontyEncoder().default)),
             "energy_adjustments": json.loads(json.dumps(self.energy_adjustments, cls=MontyEncoder)),
             "parameters": json.loads(json.dumps(self.parameters, cls=MontyEncoder)),
             "data": json.loads(json.dumps(self.data, cls=MontyEncoder)),

--- a/tests/entries/test_computed_entries.py
+++ b/tests/entries/test_computed_entries.py
@@ -51,6 +51,9 @@ def test_energy_adjustment_repr():
             f"generated_by='{label}')"
         )
 
+    # Make sure int uncertainty also works
+    assert "uncertainty=0.0" in repr(EnergyAdjustment(10, uncertainty=0))
+
 
 def test_manual_energy_adjustment():
     ea = ManualEnergyAdjustment(10)


### PR DESCRIPTION
## Summary

- Fix uncertainty as int for `EnergyAdjustment`:
  ```python
  from pymatgen.entries.computed_entries import EnergyAdjustment
  
  print(EnergyAdjustment(10, uncertainty=0))
  ```
  
  Gives:
  ```
  Traceback (most recent call last):
    File "/Users/yang/developer/pymatgen/test_json.py", line 25, in <module>
      print(EnergyAdjustment(10, uncertainty=0))
    File "/Users/yang/developer/pymatgen/src/pymatgen/entries/computed_entries.py", line 108, in __repr__
      return f"{type(self).__name__}({name=}, {value=:.3}, {uncertainty=:.3}, {description=}, {generated_by=})"
                                                           ^^^^^^^^^^^^^^^^^
  ValueError: Precision not allowed in integer format specifier
  ```
- [ ] More tests
- Avoid `==` or `!=` for possible float comparison