### PR TITLE
Single source of truth for POTCAR directory structure

### DIFF
--- a/src/pymatgen/cli/pmg_config.py
+++ b/src/pymatgen/cli/pmg_config.py
@@ -17,6 +17,7 @@ from monty.serialization import dumpfn, loadfn
 from pymatgen.core import OLD_SETTINGS_FILE, SETTINGS_FILE, Element
 from pymatgen.io.cp2k.inputs import GaussianTypeOrbitalBasisSet, GthPotential
 from pymatgen.io.cp2k.utils import chunk
+from pymatgen.io.vasp.inputs import POTCAR_FUNCTIONAL_MAP
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -117,24 +118,29 @@ def setup_potcars(potcar_dirs: list[str]):
 
     print("Generating pymatgen resources directory...")
 
+    # name_mappings ensures consistency with the POTCAR directory structure
+    # expected by pymatgen.io.vasp.inputs.PotcarSingle
     name_mappings = {
-        "potpaw_PBE": "POT_GGA_PAW_PBE",
-        "potpaw_PBE_52": "POT_GGA_PAW_PBE_52",
-        "potpaw_PBE_54": "POT_GGA_PAW_PBE_54",
-        "potpaw_PBE.52": "POT_GGA_PAW_PBE_52",
-        "potpaw_PBE.54": "POT_GGA_PAW_PBE_54",
-        "potpaw_PBE_64": "POT_GGA_PAW_PBE_64",
-        "potpaw_PBE.64": "POT_GGA_PAW_PBE_64",
-        "potpaw_LDA": "POT_LDA_PAW",
-        "potpaw_LDA.52": "POT_LDA_PAW_52",
-        "potpaw_LDA.54": "POT_LDA_PAW_54",
-        "potpaw_LDA_52": "POT_LDA_PAW_52",
-        "potpaw_LDA_54": "POT_LDA_PAW_54",
-        "potpaw_LDA_64": "POT_LDA_PAW_64",
-        "potpaw_LDA.64": "POT_LDA_PAW_64",
-        "potUSPP_LDA": "POT_LDA_US",
-        "potpaw_GGA": "POT_GGA_PAW_PW91",
-        "potUSPP_GGA": "POT_GGA_US_PW91",
+        k: POTCAR_FUNCTIONAL_MAP[v]
+        for k, v in {
+            "potpaw_PBE": "PBE",
+            "potpaw_PBE_52": "PBE_52",
+            "potpaw_PBE.52": "PBE_52",
+            "potpaw_PBE_54": "PBE_54",
+            "potpaw_PBE.54": "PBE_54",
+            "potpaw_PBE_64": "PBE_64",
+            "potpaw_PBE.64": "PBE_64",
+            "potpaw_LDA": "LDA",
+            "potpaw_LDA.52": "LDA_52",
+            "potpaw_LDA_52": "LDA_52",
+            "potpaw_LDA.54": "LDA_54",
+            "potpaw_LDA_54": "LDA_54",
+            "potpaw_LDA_64": "LDA_64",
+            "potpaw_LDA.64": "LDA_64",
+            "potpaw_GGA": "PW91",
+            "potUSPP_LDA": "LDA_US",
+            "potUSPP_GGA": "PW91_US",
+        }.items()
     }
 
     for parent, subdirs, _files in os.walk(psp_dir):

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -450,12 +450,9 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         factor: float
         formula, factor = reduce_formula(el_amt_dict, iupac_ordering=iupac_ordering)
 
-        # Do not "completely reduce" certain formulas, unless they contain more
-        # more atoms than the specified composition
-        if (red_formula := type(self).special_formulas.get(formula)) and type(self)(
-            red_formula
-        ).num_atoms <= self.num_atoms:
-            formula = red_formula
+        # Do not "completely reduce" certain formulas
+        if formula in type(self).special_formulas:
+            formula = type(self).special_formulas[formula]
             factor /= 2
 
         return formula, factor

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -450,9 +450,12 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         factor: float
         formula, factor = reduce_formula(el_amt_dict, iupac_ordering=iupac_ordering)
 
-        # Do not "completely reduce" certain formulas
-        if formula in type(self).special_formulas:
-            formula = type(self).special_formulas[formula]
+        # Do not "completely reduce" certain formulas, unless they contain more
+        # more atoms than the specified composition
+        if (red_formula := type(self).special_formulas.get(formula)) and type(self)(
+            red_formula
+        ).num_atoms <= self.num_atoms:
+            formula = red_formula
             factor /= 2
 
         return formula, factor

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -54,6 +54,30 @@ __copyright__ = "Copyright 2011, The Materials Project"
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# Note: there are multiple releases of the {LDA,PBE} {52,54} POTCARs
+#     the original (UNIVIE) releases include no SHA256 hashes nor COPYR fields
+#     in the PSCTR/header field.
+# We indicate the older release in `functional_dir` as PBE_52, PBE_54, LDA_52, LDA_54.
+# The newer release is indicated as PBE_52_W_HASH, etc.
+POTCAR_FUNCTIONAL_MAP: dict[str, str] = {
+    "PBE": "POT_GGA_PAW_PBE",
+    "PBE_52": "POT_GGA_PAW_PBE_52",
+    "PBE_52_W_HASH": "POTPAW_PBE_52",
+    "PBE_54": "POT_GGA_PAW_PBE_54",
+    "PBE_54_W_HASH": "POTPAW_PBE_54",
+    "PBE_64": "POT_PAW_PBE_64",
+    "LDA": "POT_LDA_PAW",
+    "LDA_52": "POT_LDA_PAW_52",
+    "LDA_52_W_HASH": "POTPAW_LDA_52",
+    "LDA_54": "POT_LDA_PAW_54",
+    "LDA_54_W_HASH": "POTPAW_LDA_54",
+    "LDA_64": "POT_LDA_PAW_64",
+    "PW91": "POT_GGA_PAW_PW91",
+    "LDA_US": "POT_LDA_US",
+    "PW91_US": "POT_GGA_US_PW91",
+    "Perdew_Zunger81": "POT_LDA_PAW",
+}
+
 
 class Poscar(MSONable):
     """Represent the data in a POSCAR or CONTCAR file.
@@ -1935,29 +1959,7 @@ class PotcarSingle:
     are raised if validation fails.
     """
 
-    # Note: there are multiple releases of the {LDA,PBE} {52,54} POTCARs
-    #     the original (UNIVIE) releases include no SHA256 hashes nor COPYR fields
-    #     in the PSCTR/header field.
-    # We indicate the older release in `functional_dir` as PBE_52, PBE_54, LDA_52, LDA_54.
-    # The newer release is indicated as PBE_52_W_HASH, etc.
-    functional_dir: ClassVar[dict[str, str]] = {
-        "PBE": "POT_GGA_PAW_PBE",
-        "PBE_52": "POT_GGA_PAW_PBE_52",
-        "PBE_52_W_HASH": "POTPAW_PBE_52",
-        "PBE_54": "POT_GGA_PAW_PBE_54",
-        "PBE_54_W_HASH": "POTPAW_PBE_54",
-        "PBE_64": "POT_PAW_PBE_64",
-        "LDA": "POT_LDA_PAW",
-        "LDA_52": "POT_LDA_PAW_52",
-        "LDA_52_W_HASH": "POTPAW_LDA_52",
-        "LDA_54": "POT_LDA_PAW_54",
-        "LDA_54_W_HASH": "POTPAW_LDA_54",
-        "LDA_64": "POT_LDA_PAW_64",
-        "PW91": "POT_GGA_PAW_PW91",
-        "LDA_US": "POT_LDA_US",
-        "PW91_US": "POT_GGA_US_PW91",
-        "Perdew_Zunger81": "POT_LDA_PAW",
-    }
+    functional_dir: ClassVar[dict[str, str]] = POTCAR_FUNCTIONAL_MAP
 
     functional_tags: ClassVar[dict[str, dict[Literal["name", "class"], str]]] = {
         "pe": {"name": "PBE", "class": "GGA"},

--- a/tests/io/vasp/test_help.py
+++ b/tests/io/vasp/test_help.py
@@ -12,12 +12,12 @@ BeautifulSoup = pytest.importorskip("bs4").BeautifulSoup
 
 
 try:
-    website_down = requests.get("https://www.vasp.at", timeout=5).status_code != 200
+    website_down = requests.get("https://www.vasp.at/wiki/index.php/The_VASP_Manual", timeout=5).status_code != 200
 except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
     website_down = True
 
 
-@pytest.mark.skipif(website_down, reason="www.vasp.at is down")
+@pytest.mark.skipif(website_down, reason="www.vasp.at or the VASP manual is down")
 class TestVaspDoc:
     @pytest.mark.parametrize("tag", ["ISYM"])
     def test_print_help(self, tag):


### PR DESCRIPTION
Modifies the pymatgen CLI to use the same POTCAR library directory structure as in `pymatgen.io.vasp.inputs` to close #4430. Possibly breaking from the CLI side (the directory structure will change)

Pinging @mkhorton since #4424 was probably motivated by similar concerns?