### PR TITLE
Speed up symmetry functions with faster `is_periodic_image` algorithm

### DIFF
--- a/src/pymatgen/core/sites.py
+++ b/src/pymatgen/core/sites.py
@@ -514,7 +514,10 @@ class PeriodicSite(Site, MSONable):
             return False
 
         frac_diff = pbc_diff(self.frac_coords, other.frac_coords, self.lattice.pbc)
-        return np.allclose(frac_diff, [0, 0, 0], atol=tolerance)
+        for diff in frac_diff:  # pure Python loop faster than np.allclose here
+            if abs(diff) > tolerance:  # break early if outside tolerance
+                return False
+        return True
 
     def distance_and_image_from_frac_coords(
         self,


### PR DESCRIPTION
I noticed that in some of our `doped` testing workflows, `SpacegroupAnalyzer.get_primitive_standard_structure()` is one of the main bottlenecks (as to be expected). One of the dominant cost factors here is the usage of `is_periodic_image`, which can be expensive for large structures due to many `np.allclose()` calls.
This PR implements a small change to instead use an equivalent (but faster) pure Python loop, which also breaks early if the tolerance is exceeded.

In my test case, this reduced the time spent on `is_periodic_image` (and thus `SpacegroupAnalyzer.get_primitive_standard_structure()`) from 35s to 10s.