### PR TITLE
Efficiency updates for `__str__()` methods

### DIFF
--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -1088,15 +1088,17 @@ class Species(MSONable, Stringify):
         return f"Species {self}"
 
     def __str__(self) -> str:
-        output = self.name if hasattr(self, "name") else self.symbol
-        if self.oxi_state is not None:
-            abs_charge = formula_double_format(abs(self.oxi_state))
+        name = getattr(self, "name", None)
+        output = name or self.symbol
+        oxi_state = self.oxi_state
+        if oxi_state is not None:
+            abs_charge = formula_double_format(abs(oxi_state))
             if isinstance(abs_charge, float):
                 abs_charge = f"{abs_charge:.2f}"  # type: ignore[assignment]
-            output += f"{abs_charge}{'+' if self.oxi_state >= 0 else '-'}"
+            output += f"{abs_charge}{'+' if oxi_state >= 0 else '-'}"
 
-        if self._spin is not None:
-            spin = self._spin
+        spin = self._spin
+        if spin is not None:
             output += f",{spin=}"
         return output
 
@@ -1484,10 +1486,11 @@ class DummySpecies(Species):
 
     def __str__(self) -> str:
         output = self.symbol
-        if self.oxi_state is not None:
-            output += f"{formula_double_format(abs(self.oxi_state))}{'+' if self.oxi_state >= 0 else '-'}"
-        if self._spin is not None:
-            spin = self._spin
+        oxi_state = self.oxi_state
+        if oxi_state is not None:
+            output += f"{formula_double_format(abs(oxi_state))}{'+' if oxi_state >= 0 else '-'}"
+        spin = self._spin
+        if spin is not None:
             output += f",{spin=}"
         return output
 


### PR DESCRIPTION
Small change to improve the efficiency of `Species.__str__`, which can become a bottleneck in some workflows which e.g. subselect sites in a structure based on the species, before doing further processing (e.g. defect site matching in `doped`).

Improves efficiency by reducing redundant `getattr` calls.