### PR TITLE
Fix `has_cobicar` when NcICOBILIST is present

### DIFF
--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -1130,10 +1130,9 @@ class Lobsterout(MSONable):
                     "writing COOPCAR.lobster..." in lines and "SKIPPING writing COOPCAR.lobster..." not in lines
                 )
                 self.has_cobicar = (
-                    ("writing COBICAR.lobster..." in lines
-                     or "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." in lines)
-                    and "SKIPPING writing COBICAR.lobster..." not in lines
-                )
+                    "writing COBICAR.lobster..." in lines
+                    or "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." in lines
+                ) and "SKIPPING writing COBICAR.lobster..." not in lines
 
             self.has_cobicar_lcfo = "writing COBICAR.LCFO.lobster..." in lines
             self.has_cohpcar_lcfo = "writing COHPCAR.LCFO.lobster..." in lines

--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -1130,7 +1130,9 @@ class Lobsterout(MSONable):
                     "writing COOPCAR.lobster..." in lines and "SKIPPING writing COOPCAR.lobster..." not in lines
                 )
                 self.has_cobicar = (
-                    ("writing COBICAR.lobster..." in lines or "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." in lines) and "SKIPPING writing COBICAR.lobster..." not in lines
+                    ("writing COBICAR.lobster..." in lines
+                     or "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." in lines)
+                    and "SKIPPING writing COBICAR.lobster..." not in lines
                 )
 
             self.has_cobicar_lcfo = "writing COBICAR.LCFO.lobster..." in lines

--- a/src/pymatgen/io/lobster/outputs.py
+++ b/src/pymatgen/io/lobster/outputs.py
@@ -1111,12 +1111,12 @@ class Lobsterout(MSONable):
                 version_number = 0.0
             if version_number < 5.1:
                 self.has_cohpcar = (
-                    "writing COOPCAR.lobster and ICOOPLIST.lobster..." in lines
-                    and "SKIPPING writing COOPCAR.lobster and ICOOPLIST.lobster..." not in lines
-                )
-                self.has_coopcar = (
                     "writing COHPCAR.lobster and ICOHPLIST.lobster..." in lines
                     and "SKIPPING writing COHPCAR.lobster and ICOHPLIST.lobster..." not in lines
+                )
+                self.has_coopcar = (
+                    "writing COOPCAR.lobster and ICOOPLIST.lobster..." in lines
+                    and "SKIPPING writing COOPCAR.lobster and ICOOPLIST.lobster..." not in lines
                 )
                 self.has_cobicar = (
                     "writing COBICAR.lobster and ICOBILIST.lobster..." in lines
@@ -1124,13 +1124,13 @@ class Lobsterout(MSONable):
                 )
             else:
                 self.has_cohpcar = (
-                    "writing COOPCAR.lobster..." in lines and "SKIPPING writing COOPCAR.lobster..." not in lines
-                )
-                self.has_coopcar = (
                     "writing COHPCAR.lobster..." in lines and "SKIPPING writing COHPCAR.lobster..." not in lines
                 )
+                self.has_coopcar = (
+                    "writing COOPCAR.lobster..." in lines and "SKIPPING writing COOPCAR.lobster..." not in lines
+                )
                 self.has_cobicar = (
-                    "writing COBICAR.lobster..." in lines and "SKIPPING writing COBICAR.lobster..." not in lines
+                    ("writing COBICAR.lobster..." in lines or "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." in lines) and "SKIPPING writing COBICAR.lobster..." not in lines
                 )
 
             self.has_cobicar_lcfo = "writing COBICAR.LCFO.lobster..." in lines


### PR DESCRIPTION
When `icobiBetween` is activated lobster prints out the `NcICOBILIST.lobster` file. In the lobster output we find "Writing COBICAR.lobster, ICOBILIST.lobster and NcICOBILIST.lobster..." instead of the regular line. The current parser then returns `False` even if the COBICAR.lobster is present.

Also, it seems that `has_cohpcar` and `has_coopcar` are flipped?

Switching to a regex approach on the whole files (not `\n` split) would allow much greater flexbility, performance and robustness.

@JaGeo @naik-aakash 

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
