### PR TITLE
Fix some test errors on FreeBSD

### DIFF
--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -1869,22 +1869,22 @@ direct
 
     def test_charge(self):
         struct = Structure.from_sites(self.struct)
-        assert struct.charge == 0, "Initial Structure not defaulting to behavior in SiteCollection"
+        assert struct.charge == approx(0), "Initial Structure not defaulting to behavior in SiteCollection"
         struct.add_oxidation_state_by_site([1, 1])
-        assert struct.charge == 2, "Initial Structure not defaulting to behavior in SiteCollection"
+        assert struct.charge == approx(2), "Initial Structure not defaulting to behavior in SiteCollection"
         struct = Structure.from_sites(struct, charge=1)
-        assert struct.charge == 1, "Overall charge not being stored in separate property"
+        assert struct.charge == approx(1), "Overall charge not being stored in separate property"
         struct = struct.copy()
-        assert struct.charge == 1, "Overall charge not being copied properly with no sanitization"
+        assert struct.charge == approx(1), "Overall charge not being copied properly with no sanitization"
         struct = struct.copy(sanitize=True)
-        assert struct.charge == 1, "Overall charge not being copied properly with sanitization"
+        assert struct.charge == approx(1), "Overall charge not being copied properly with sanitization"
         super_cell = struct * 3
-        assert super_cell.charge == 27, "Overall charge is not being properly multiplied in IStructure __mul__"
+        assert super_cell.charge == approx(27), "Overall charge is not being properly multiplied in IStructure __mul__"
         assert "Overall Charge: +1" in str(struct), "String representation not adding charge"
         sorted_s = super_cell.get_sorted_structure()
-        assert sorted_s.charge == 27, "Overall charge is not properly copied during structure sorting"
+        assert sorted_s.charge == approx(27), "Overall charge is not properly copied during structure sorting"
         super_cell.set_charge(25)
-        assert super_cell.charge == 25, "Set charge not properly modifying _charge"
+        assert super_cell.charge == approx(25), "Set charge not properly modifying _charge"
 
     def test_vesta_lattice_matrix(self):
         silica_zeolite = Molecule.from_file(f"{TEST_FILES_DIR}/core/structure/CON_vesta.xyz")


### PR DESCRIPTION
### Summary

Fix some test errors on FreeBSD, to close #4264


---


- [x] core/structure
- [ ] cli: cannot recreate (both `master` and `tags/v2025.1.23`)
- [ ] io/test_babel: cannot install `openbabel-wheel`




  ```

       - tests/analysis/test_bond_dissociation.py:545 TestBondDissociation.test_ec_neg_pcm_40
         - tests/analysis/test_bond_dissociation.py:539 TestBondDissociation.test_pc_neutral_pcm_65
         - tests/analysis/test_chempot_diagram.py:71 TestChemicalPotentialDiagram.test_pca
         - tests/analysis/test_fragmenter.py:72 TestFragmentMolecule.test_babel_pc_old_defaults
         - tests/analysis/test_fragmenter.py:115 TestFragmentMolecule.test_babel_pc_with_ro_depth_0_vs_depth_10
         - tests/analysis/test_fragmenter.py:159 TestFragmentMolecule.test_pc_then_ec_depth_10
         - tests/analysis/test_functional_groups.py:114 TestFunctionalGroupExtractor.test_categorize_functional_groups
         - tests/analysis/test_functional_groups.py:102 TestFunctionalGroupExtractor.test_get_all_functional_groups
         - tests/analysis/test_functional_groups.py:92 TestFunctionalGroupExtractor.test_get_basic_functional_groups
         - tests/analysis/test_functional_groups.py:54 TestFunctionalGroupExtractor.test_get_heteroatoms
         - tests/analysis/test_functional_groups.py:65 TestFunctionalGroupExtractor.test_get_special_carbon
         - tests/analysis/test_functional_groups.py:36 TestFunctionalGroupExtractor.test_init
         - tests/analysis/test_functional_groups.py:74 TestFunctionalGroupExtractor.test_link_marked_atoms
         - tests/cli/test_pmg_analyze.py:13 test_pmg_analyze
         - tests/cli/test_pmg_diff.py:12 test_pmg_diff
         - tests/cli/test_pmg_plot.py:15 test_plot_xrd
         - tests/cli/test_pmg_plot.py:31 test_plot_dos
         - tests/cli/test_pmg_plot.py:47 test_plot_chgint
         - tests/cli/test_pmg_plot.py:63 test_plot_wrong_arg
         - tests/cli/test_pmg_structure.py:13 test_pmg_structure
         - tests/core/test_structure.py:1770 TestStructure.test_charge
         - tests/io/test_babel.py:119 TestBabelMolAdaptor.test_confab_conformers
         - tests/io/test_babel.py:43 TestBabelMolAdaptor.test_from_file
         - tests/io/test_babel.py:48 TestBabelMolAdaptor.test_from_file_return_all_molecules
         - tests/io/test_babel.py:64 TestBabelMolAdaptor.test_from_str
         - tests/io/test_babel.py:70 TestBabelMolAdaptor.test_localopt
         - tests/io/test_babel.py:78 TestBabelMolAdaptor.test_make3d
         - tests/io/test_babel.py:110 TestBabelMolAdaptor.test_rotor_search_rrs
         - tests/io/test_babel.py:101 TestBabelMolAdaptor.test_rotor_search_srs
         - tests/io/test_babel.py:91 TestBabelMolAdaptor.test_rotor_search_wrs
         - tests/symmetry/test_kpath_hin.py:47 TestKPathSeek.test_kpath_acentered
         - tests/symmetry/test_kpath_hin.py:15 TestKPathSeek.test_kpath_generation
         - tests/symmetry/test_kpaths.py:21 TestHighSymmKpath.test_kpath_generation
         - tests/transformations/test_advanced_transformations.py:670 TestSQSTransformationIcet.test_enumeration
         - tests/transformations/test_advanced_transformations.py:681 TestSQSTransformationIcet.test_monte_carlo
         - tests/transformations/test_advanced_transformations.py:874 TestMonteCarloRattleTransformation.test_apply_transformation
         
```
