### PR TITLE
Cache macos/ubuntu optional dependency install in CI pipeline, enable `mcsqs/pyzeo` tests

### DIFF
--- a/.github/workflows/_install_opt_unit_deps.sh
+++ b/.github/workflows/_install_opt_unit_deps.sh
@@ -8,7 +8,8 @@ tar -jxf BoltzTraP.tar.bz2
 echo "$(realpath boltztrap-1.2.5/src)" >> "$GITHUB_PATH"
 
 # Install Vampire 5.0
-wget https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
+# TODO: https://github.com/richard-evans/vampire/issues/122
+wget --no-check-certificate https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
 tar -zxf vampire-5.0-linux.tar.gz
 mv linux vampire-5.0
 echo "$(realpath vampire-5.0)" >> "$GITHUB_PATH"

--- a/.github/workflows/_install_opt_unit_deps.sh
+++ b/.github/workflows/_install_opt_unit_deps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Install BoltzTraP
+wget -O BoltzTraP.tar.bz2 https://owncloud.tuwien.ac.at/index.php/s/s2d55LYlZnioa3s/download
+tar -jxf BoltzTraP.tar.bz2
+echo "$(realpath boltztrap-1.2.5/src)" >> "$GITHUB_PATH"
+
+# Install Vampire 5.0
+wget https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
+tar -zxf vampire-5.0-linux.tar.gz
+mv linux vampire-5.0
+echo "$(realpath vampire-5.0)" >> "$GITHUB_PATH"
+
+# Install Voro++ and ZEO++
+wget http://www.zeoplusplus.org/zeo++-0.3.tar.gz
+tar -xzf zeo++-0.3.tar.gz
+
+make -C zeo++-0.3/voro++/src -s CFLAGS="-w"
+echo "$(realpath zeo++-0.3/voro++/src)" >> "$GITHUB_PATH"
+
+make -C zeo++-0.3 -s CFLAGS="-w"
+echo "$(realpath zeo++-0.3)" >> "$GITHUB_PATH"
+
+# TODO: Install mcsqs (from ATAT)
+# wget https://axelvandewalle.github.io/www-avdw/atat/atat3_50.tar.gz
+# tar -zxf atat3_50.tar.gz && cd atat

--- a/.github/workflows/_install_opt_unit_deps.sh
+++ b/.github/workflows/_install_opt_unit_deps.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 set -x
 
 # Use a custom bin directory for easier GitHub Actions caching
-BIN_DIR="$PWD/opt/bin"  && mkdir -p "$BIN_DIR"
+BIN_DIR="${1:-$PWD/opt/bin}" && mkdir -p "$BIN_DIR"
 
 # Install BoltzTraP
 wget --no-verbose -O BoltzTraP.tar.bz2 https://owncloud.tuwien.ac.at/index.php/s/s2d55LYlZnioa3s/download

--- a/.github/workflows/_install_opt_unit_deps.sh
+++ b/.github/workflows/_install_opt_unit_deps.sh
@@ -2,28 +2,29 @@
 set -euo pipefail
 set -x
 
+# Use a custom bin directory for easier GitHub Actions caching
+BIN_DIR="$PWD/opt/bin"  && mkdir -p "$BIN_DIR"
+
 # Install BoltzTraP
-wget -O BoltzTraP.tar.bz2 https://owncloud.tuwien.ac.at/index.php/s/s2d55LYlZnioa3s/download
+wget --no-verbose -O BoltzTraP.tar.bz2 https://owncloud.tuwien.ac.at/index.php/s/s2d55LYlZnioa3s/download
 tar -jxf BoltzTraP.tar.bz2
-echo "$(realpath boltztrap-1.2.5/src)" >> "$GITHUB_PATH"
+cp boltztrap-1.2.5/src/{BoltzTraP,x_trans} "$BIN_DIR"
 
 # Install Vampire 5.0
-# TODO: https://github.com/richard-evans/vampire/issues/122
-wget --no-check-certificate https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
-tar -zxf vampire-5.0-linux.tar.gz
-mv linux vampire-5.0
-echo "$(realpath vampire-5.0)" >> "$GITHUB_PATH"
+# TODO: Accepts self-signed cert (https://github.com/richard-evans/vampire/issues/122)
+wget --no-verbose --no-check-certificate https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
+tar -zxf vampire-5.0-linux.tar.gz && mv linux vampire-5.0
+cp vampire-5.0/vampire-serial "$BIN_DIR"
 
 # Install Voro++ and ZEO++
-wget http://www.zeoplusplus.org/zeo++-0.3.tar.gz
+wget --no-verbose http://www.zeoplusplus.org/zeo++-0.3.tar.gz
 tar -xzf zeo++-0.3.tar.gz
-
 make -C zeo++-0.3/voro++/src -s CFLAGS="-w"
-echo "$(realpath zeo++-0.3/voro++/src)" >> "$GITHUB_PATH"
-
 make -C zeo++-0.3 -s CFLAGS="-w"
-echo "$(realpath zeo++-0.3)" >> "$GITHUB_PATH"
+cp zeo++-0.3/voro++/src/voro++ "$BIN_DIR"
+cp zeo++-0.3/network "$BIN_DIR"
 
-# TODO: Install mcsqs (from ATAT)
-# wget https://axelvandewalle.github.io/www-avdw/atat/atat3_50.tar.gz
-# tar -zxf atat3_50.tar.gz && cd atat
+# TODO: Install mcsqs
+
+# Add to path
+echo "$BIN_DIR" >> "$GITHUB_PATH"

--- a/.github/workflows/_install_opt_unit_deps.sh
+++ b/.github/workflows/_install_opt_unit_deps.sh
@@ -24,7 +24,18 @@ make -C zeo++-0.3 -s CFLAGS="-w"
 cp zeo++-0.3/voro++/src/voro++ "$BIN_DIR"
 cp zeo++-0.3/network "$BIN_DIR"
 
-# TODO: Install mcsqs
+# Install mcsqs (from ATAT)
+# TODO: cannot build on MacOS
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  wget --no-verbose https://axelvandewalle.github.io/www-avdw/atat/atat3_50.tar.gz
+  tar -zxf atat3_50.tar.gz
+
+  # Replace `BINDIR` in makefile
+  sed -i "s|^BINDIR=.*|BINDIR=$BIN_DIR|" atat/makefile
+
+  sudo apt install csh -y -q
+  make -C atat && make -C atat install
+fi
 
 # Add to path
 echo "$BIN_DIR" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,8 +94,16 @@ jobs:
           pip install --upgrade matgl>=1.2.6
           pip install torch==2.2.0 torchdata==0.7.1
 
-      - name: Install optional Ubuntu and macOS dependencies
+      - name: Restore cache for optional Ubuntu/MacOS dependencies
         if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
+        id: optbin-cache
+        uses: actions/cache@v4
+        with:
+          path: opt/bin
+          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
+
+      - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
+        if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
         run: bash .github/workflows/_install_opt_unit_deps.sh
 
       - name: pytest split ${{ matrix.split }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,18 +60,6 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Restore cache for optional Ubuntu/MacOS dependencies
-        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
-        id: optbin-cache
-        uses: actions/cache@v4
-        with:
-          path: opt/bin
-          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
-
-      - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
-        if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
-        run: bash .github/workflows/_install_opt_unit_deps.sh
-
       - name: Create mamba environment
         uses: mamba-org/setup-micromamba@main
         with:
@@ -105,6 +93,18 @@ jobs:
           pip install --upgrade dgl -f https://data.dgl.ai/wheels/torch-2.4/repo.html
           pip install --upgrade matgl>=1.2.6
           pip install torch==2.2.0 torchdata==0.7.1
+
+      - name: Restore cache for optional Ubuntu/MacOS dependencies
+        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
+        id: optbin-cache
+        uses: actions/cache@v4
+        with:
+          path: opt/bin
+          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
+
+      - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
+        if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
+        run: bash .github/workflows/_install_opt_unit_deps.sh
 
       - name: pytest split ${{ matrix.split }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
       MPLBACKEND: Agg  # non-interactive backend for matplotlib
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
       PYTHONWARNDEFAULTENCODING: "true"  # PEP 597: Enable optional EncodingWarning
+      OPT_BIN_DIR: ${{ github.workspace }}/opt/bin  # for optional Unix dependencies
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -99,12 +100,12 @@ jobs:
         id: optbin-cache
         uses: actions/cache@v4
         with:
-          path: opt/bin
+          path: ${{ env.OPT_BIN_DIR }}
           key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
 
       - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
         if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
-        run: bash .github/workflows/_install_opt_unit_deps.sh
+        run: bash .github/workflows/_install_opt_unit_deps.sh "$OPT_BIN_DIR"
 
       - name: pytest split ${{ matrix.split }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,21 +96,7 @@ jobs:
 
       - name: Install optional Ubuntu and macOS dependencies
         if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
-        run: |
-          # Install BoltzTraP
-          wget -q -O BoltzTraP.tar.bz2 https://owncloud.tuwien.ac.at/index.php/s/s2d55LYlZnioa3s/download
-          tar -jxf BoltzTraP.tar.bz2 && realpath boltztrap-1.2.5/src/ >> $GITHUB_PATH
-
-          # Install Vampire 5.0
-          wget -q https://vampire.york.ac.uk/resources/release-5/vampire-5.0-linux.tar.gz
-          tar -zxf vampire-5.0-linux.tar.gz && mv linux vampire-5.0
-          realpath vampire-5.0/ >> $GITHUB_PATH
-
-          # Install Voro++ and ZEO++
-          wget -q http://www.zeoplusplus.org/zeo++-0.3.tar.gz && tar -xzf zeo++-0.3.tar.gz
-
-          cd zeo++-0.3/voro++/src && make -s CFLAGS="-w" && realpath . >> $GITHUB_PATH && cd ../..
-          make -s CFLAGS="-w" && realpath . >> $GITHUB_PATH
+        run: bash .github/workflows/_install_opt_unit_deps.sh
 
       - name: pytest split ${{ matrix.split }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.OPT_BIN_DIR }}
-          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
+          key: opt-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
 
       - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
         if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,18 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
+      - name: Restore cache for optional Ubuntu/MacOS dependencies
+        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
+        id: optbin-cache
+        uses: actions/cache@v4
+        with:
+          path: opt/bin
+          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
+
+      - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
+        if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
+        run: bash .github/workflows/_install_opt_unit_deps.sh
+
       - name: Create mamba environment
         uses: mamba-org/setup-micromamba@main
         with:
@@ -93,18 +105,6 @@ jobs:
           pip install --upgrade dgl -f https://data.dgl.ai/wheels/torch-2.4/repo.html
           pip install --upgrade matgl>=1.2.6
           pip install torch==2.2.0 torchdata==0.7.1
-
-      - name: Restore cache for optional Ubuntu/MacOS dependencies
-        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
-        id: optbin-cache
-        uses: actions/cache@v4
-        with:
-          path: opt/bin
-          key: ${{ runner.os }}-optbin-${{ hashFiles('.github/workflows/_install_opt_unit_deps.sh') }}
-
-      - name: Build optional Ubuntu/MacOS dependencies (when cache misses)
-        if: (matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest') && steps.optbin-cache.outputs.cache-hit != 'true'
-        run: bash .github/workflows/_install_opt_unit_deps.sh
 
       - name: pytest split ${{ matrix.split }}
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ mlp = ["matgl>=1.2.7 ; python_version<'3.13'"]
 numba = ["numba>=0.55"]
 numpy-v1 = ["numpy>=1.25.0,<2"] # Test NP1 on Windows (quite buggy ATM)
 optional = [
-    "pymatgen[abinit,ase,mlp,tblite,matcalc]",
+    "pymatgen[abinit,ase,matcalc,mlp,tblite,zeopp]",
     "beautifulsoup4",
     # PR4347: BoltzTraP2 needs to bump cmake version for spglib build
     # "BoltzTraP2>=24.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ symmetry = ["moyopy[interface]>=0.3", "spglib>=2.5"]
 # https://github.com/tblite/tblite/issues/175
 tblite = ["tblite[ase]>=0.3.0; platform_system=='Linux' and python_version<'3.12'"]
 vis = ["vtk>=6.0.0"]
-zeopp = ["pyzeo"]  # Note: requires Voro++ and Zeo++ to be installed
+zeopp = ["pyzeo; platform_system != 'Windows'"]  # Note: requires Voro++ and Zeo++ to be installed
 
 [project.scripts]
 pmg = "pymatgen.cli.pmg:main"

--- a/src/pymatgen/command_line/mcsqs_caller.py
+++ b/src/pymatgen/command_line/mcsqs_caller.py
@@ -146,7 +146,7 @@ def run_mcsqs(
 
         raise RuntimeError("mcsqs exited before timeout reached")
 
-    except TimeoutExpired:
+    except TimeoutExpired as exc:
         for process in mcsqs_find_sqs_processes:
             process.kill()
             process.communicate()
@@ -157,7 +157,7 @@ def run_mcsqs(
                 raise RuntimeError(
                     "mcsqs did not generate output files, "
                     "is search_time sufficient or are number of instances too high?"
-                )
+                ) from exc
 
             process = Popen(["mcsqs", "-best"])
             process.communicate()
@@ -166,7 +166,7 @@ def run_mcsqs(
             return _parse_sqs_path(".")
 
         os.chdir(original_directory)
-        raise TimeoutError("Cluster expansion took too long.")
+        raise TimeoutError("Cluster expansion took too long.") from exc
 
 
 def _parse_sqs_path(path) -> Sqs:

--- a/src/pymatgen/io/zeopp.py
+++ b/src/pymatgen/io/zeopp.py
@@ -41,8 +41,8 @@ try:
     from zeo.cluster import prune_voronoi_network_close_node
     from zeo.netstorage import AtomNetwork
 
-    zeo_found = True
-    zeo_source: str | None = "zeo"
+    zeo_found: bool = True
+    zeo_source: Literal["zeo", "pyzeo"] | None = "zeo"
 except ImportError:
     try:
         from pyzeo import AtomNetwork
@@ -58,6 +58,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Literal
 
     from typing_extensions import Self
 

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
@@ -166,12 +166,12 @@ class TestCoordinationGeometryFinder(MatSciTest):
                     # Check that the environment found is the expected one
                     assert coord_env == expected_geoms[ienv]
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_simplest_chemenv_strategy(self):
         strategy = SimplestChemenvStrategy()
         self._strategy_test(strategy)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_simple_abundance_chemenv_strategy(self):
         strategy = SimpleAbundanceChemenvStrategy()
         self._strategy_test(strategy)

--- a/tests/analysis/test_graphs.py
+++ b/tests/analysis/test_graphs.py
@@ -239,7 +239,7 @@ class TestStructureGraph(MatSciTest):
 
         assert len(list(struct_graph.graph.edges(data=True))) == 3
 
-    @pytest.mark.skip(reason="Need someone to fix this, see issue 4206")
+    @pytest.mark.xfail(reason="Need someone to fix this, see issue 4206")
     def test_str(self):
         square_sg_str_ref = """Structure Graph
 Structure:

--- a/tests/analysis/test_molecule_structure_comparator.py
+++ b/tests/analysis/test_molecule_structure_comparator.py
@@ -139,7 +139,7 @@ class TestMoleculeStructureComparator:
         d2 = MoleculeStructureComparator.from_dict(d1).as_dict()
         assert d1 == d2
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_structural_change_in_geom_opt(self):
         qcout_path = f"{TEST_DIR}/mol_1_3_bond.qcout"
         qcout = QCOutput(qcout_path)

--- a/tests/analysis/test_piezo_sensitivity.py
+++ b/tests/analysis/test_piezo_sensitivity.py
@@ -208,7 +208,7 @@ class TestPiezoSensitivity(MatSciTest):
             assert_allclose(asum1, np.zeros([3, 3]), atol=1e-5)
             assert_allclose(asum2, np.zeros([3, 3]), atol=1e-5)
 
-    @pytest.mark.skipif(
+    @pytest.mark.xfail(
         platform.system() == "Windows" and int(np.__version__[0]) >= 2,
         reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
     )
@@ -262,7 +262,7 @@ class TestPiezoSensitivity(MatSciTest):
         piezo = get_piezo(self.BEC, self.IST, self.FCM)
         assert_allclose(piezo, self.piezo, atol=1e-5)
 
-    @pytest.mark.skipif(
+    @pytest.mark.xfail(
         platform.system() == "Windows" and int(np.__version__[0]) >= 2,
         reason="See https://github.com/conda-forge/phonopy-feedstock/pull/158#issuecomment-2227506701",
     )

--- a/tests/analysis/test_surface_analysis.py
+++ b/tests/analysis/test_surface_analysis.py
@@ -253,21 +253,21 @@ class TestSurfaceEnergyPlotter(MatSciTest):
         surf_ene_plotter = SurfaceEnergyPlotter(all_Pt_slab_entries, self.Pt_analyzer.ucell_entry)
         assert surf_ene_plotter.list_of_chempots == self.Pt_analyzer.list_of_chempots
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_monolayer_vs_BE(self):
         for el in self.Oads_analyzer_dict:
             # Test WulffShape for adsorbed surfaces
             analyzer = self.Oads_analyzer_dict[el]
             analyzer.monolayer_vs_BE()
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_area_frac_vs_chempot_plot(self):
         for el in self.Oads_analyzer_dict:
             # Test WulffShape for adsorbed surfaces
             analyzer = self.Oads_analyzer_dict[el]
             analyzer.area_frac_vs_chempot_plot(x_is_u_ads=True)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_chempot_vs_gamma_clean(self):
         self.Cu_analyzer.chempot_vs_gamma_clean()
         for el in self.Oads_analyzer_dict:
@@ -275,7 +275,7 @@ class TestSurfaceEnergyPlotter(MatSciTest):
             analyzer = self.Oads_analyzer_dict[el]
             analyzer.chempot_vs_gamma_clean(x_is_u_ads=True)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_chempot_vs_gamma_facet(self):
         for el, val in self.metals_O_entry_dict.items():
             for hkl in val:
@@ -283,7 +283,7 @@ class TestSurfaceEnergyPlotter(MatSciTest):
                 analyzer = self.Oads_analyzer_dict[el]
                 analyzer.chempot_vs_gamma_facet(hkl)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_surface_chempot_range_map(self):
         for el, val in self.metals_O_entry_dict.items():
             for hkl in val:

--- a/tests/command_line/test_gulp_caller.py
+++ b/tests/command_line/test_gulp_caller.py
@@ -271,7 +271,7 @@ class TestGulpIO:
         assert struct.lattice.a == approx(4.212)
         assert struct.lattice.alpha == approx(90)
 
-    @pytest.mark.skip("Test later")
+    @pytest.mark.xfail(reason="Test later")
     def test_tersoff_input(self):
         self.gio.tersoff_input(self.structure)
 

--- a/tests/command_line/test_mcsqs_caller.py
+++ b/tests/command_line/test_mcsqs_caller.py
@@ -98,7 +98,7 @@ class TestMcsqsCaller(MatSciTest):
 
         assert sqs.objective_function == "Perfect_match"
 
-    @pytest.mark.skip("Fix later #4455")
+    @pytest.mark.xfail(reason="Fix later #4455")
     def test_mcsqs_caller_runtime_error(self):
         struct = self.struct.copy()
         struct.replace_species({"Ti": {"Ti": 0.5, "Zr": 0.5}, "Zr": {"Ti": 0.5, "Zr": 0.5}})

--- a/tests/command_line/test_mcsqs_caller.py
+++ b/tests/command_line/test_mcsqs_caller.py
@@ -104,4 +104,4 @@ class TestMcsqsCaller(MatSciTest):
         struct.replace_species({"Pb": {"Ti": 0.2, "Pb": 0.8}})
         struct.replace_species({"O": {"F": 0.8, "O": 0.2}})
         with pytest.raises(RuntimeError, match="mcsqs did not generate output files"):
-            run_mcsqs(struct, {2: 6, 3: 4}, 10, 0.000001)
+            run_mcsqs(struct, {2: 6, 3: 4}, 10, search_time=0.000001)

--- a/tests/command_line/test_mcsqs_caller.py
+++ b/tests/command_line/test_mcsqs_caller.py
@@ -103,5 +103,5 @@ class TestMcsqsCaller(MatSciTest):
         struct.replace_species({"Ti": {"Ti": 0.5, "Zr": 0.5}, "Zr": {"Ti": 0.5, "Zr": 0.5}})
         struct.replace_species({"Pb": {"Ti": 0.2, "Pb": 0.8}})
         struct.replace_species({"O": {"F": 0.8, "O": 0.2}})
-        with pytest.raises(RuntimeError, match="mcsqs exited before timeout reached"):
+        with pytest.raises(RuntimeError, match="mcsqs did not generate output files"):
             run_mcsqs(struct, {2: 6, 3: 4}, 10, 0.000001)

--- a/tests/command_line/test_mcsqs_caller.py
+++ b/tests/command_line/test_mcsqs_caller.py
@@ -98,10 +98,11 @@ class TestMcsqsCaller(MatSciTest):
 
         assert sqs.objective_function == "Perfect_match"
 
+    @pytest.mark.skip("Fix later #4455")
     def test_mcsqs_caller_runtime_error(self):
         struct = self.struct.copy()
         struct.replace_species({"Ti": {"Ti": 0.5, "Zr": 0.5}, "Zr": {"Ti": 0.5, "Zr": 0.5}})
         struct.replace_species({"Pb": {"Ti": 0.2, "Pb": 0.8}})
         struct.replace_species({"O": {"F": 0.8, "O": 0.2}})
-        with pytest.raises(RuntimeError, match="mcsqs did not generate output files"):
+        with pytest.raises(RuntimeError, match="mcsqs exited before timeout reached"):
             run_mcsqs(struct, {2: 6, 3: 4}, 10, search_time=0.000001)

--- a/tests/command_line/test_vampire_caller.py
+++ b/tests/command_line/test_vampire_caller.py
@@ -31,7 +31,7 @@ class TestVampireCaller(MatSciTest):
             cls.structure_inputs.append(ordered_structures)
             cls.energy_inputs.append(energies)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_vampire(self):
         for structs, energies in zip(self.structure_inputs, self.energy_inputs, strict=True):
             settings = {"start_t": 0, "end_t": 500, "temp_increment": 50}

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -714,7 +714,7 @@ Direct
             assert_allclose(cy_indices2, py_indices2)
             assert len(cy_offsets) == len(py_offsets)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     @pytest.mark.skipif(not os.getenv("CI"), reason="Only run this in CI tests")
     def test_get_all_neighbors_crosscheck_old(self):
         rng = np.random.default_rng()
@@ -1988,7 +1988,7 @@ direct
         assert traj[0] != traj[-1]
         assert os.path.isfile(traj_file)
 
-    @pytest.mark.skip("TODO: #3958 wait for matgl resolve of torch dependency")
+    @pytest.mark.xfail(reason="TODO: #3958 wait for matgl resolve of torch dependency")
     def test_calculate_matgl(self):
         pytest.importorskip("matgl")
         calculator = self.get_structure("Si").calculate()
@@ -2668,7 +2668,7 @@ class TestMolecule(MatSciTest):
         assert calculator.results["energy"] == approx(-113.61022434200855)
         assert mol_copy == self.mol, "Molecule should not have been modified by calculation"
 
-    @pytest.mark.skip("Pytorch and TBLite clash. https://github.com/materialsproject/pymatgen/pull/3060")
+    @pytest.mark.xfail(reason="Pytorch and TBLite clash. https://github.com/materialsproject/pymatgen/pull/3060")
     def test_relax_gfnxtb(self):
         pytest.importorskip("tblite")
         mol = self.mol

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -634,7 +634,7 @@ class TestSlabGenerator(MatSciTest):
         assert slabs[1].energy == approx(24.0)
 
 
-class ReconstructionGeneratorTests(MatSciTest):
+class TestReconstructionGenerator(MatSciTest):
     def setup_method(self):
         lattice = Lattice.cubic(3.51)
         species = ["Ni"]

--- a/tests/core/test_surface.py
+++ b/tests/core/test_surface.py
@@ -697,7 +697,7 @@ class ReconstructionGeneratorTests(MatSciTest):
         s2 = recon2.get_unreconstructed_slabs()[0]
         assert get_d(s1) == approx(get_d(s2))
 
-    @pytest.mark.skip("This test relies on neighbor orders and is hard coded. Disable temporarily")
+    @pytest.mark.xfail(reason="This test relies on neighbor orders and is hard coded. Disable temporarily")
     def test_previous_reconstructions(self):
         # Test to see if we generated all reconstruction types correctly and nothing changes
 

--- a/tests/core/test_xcfunc.py
+++ b/tests/core/test_xcfunc.py
@@ -53,7 +53,7 @@ class TestLibxcFunc(MatSciTest):
         # Test if object can be serialized with Pickle
         self.serialize_with_pickle(self.ixc_11)
 
-    @pytest.mark.skip(reason="TODO:")
+    @pytest.mark.xfail(reason="TODO:")
     def test_msonable(self):
         # Test if object supports MSONable
         self.ixc_11.x.as_dict()

--- a/tests/electronic_structure/test_boltztrap.py
+++ b/tests/electronic_structure/test_boltztrap.py
@@ -215,7 +215,7 @@ class TestBoltztrapAnalyzer:
             assert len(sbs_bzt.bands[Spin.up]) == approx(20)
             assert len(sbs_bzt.bands[Spin.up][1]) == approx(143)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_check_acc_bzt_bands(self):
         structure = loadfn(f"{TEST_DIR}/structure_mp-12103.json")
         sbs = loadfn(f"{TEST_DIR}/dft_bs_sym_line.json")

--- a/tests/electronic_structure/test_boltztrap2.py
+++ b/tests/electronic_structure/test_boltztrap2.py
@@ -96,7 +96,7 @@ class TestBandstructureLoader:
     def test_get_volume(self):
         assert self.loader.get_volume() == approx(477.6256714925874, abs=1e-5)
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_set_upper_lower_bands(self):
         min_bnd = min(self.loader_sp_up.ebands.min(), self.loader_sp_dn.ebands.min())
         max_bnd = max(self.loader_sp_up.ebands.max(), self.loader_sp_dn.ebands.max())

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -300,7 +300,7 @@ class TestPlotBZ:
         )
 
 
-@pytest.mark.skip("TODO: need someone to fix this")
+@pytest.mark.xfail(reason="TODO: need someone to fix this")
 @pytest.mark.skipif(not which("x_trans"), reason="No x_trans executable found")
 class TestBoltztrapPlotter:
     def setup_method(self):

--- a/tests/io/qchem/test_outputs.py
+++ b/tests/io/qchem/test_outputs.py
@@ -313,7 +313,7 @@ class TestQCOutput(MatSciTest):
 
     # PR#3985: the following unit test is failing, and it seems that
     # the array dimension from out_data and SINGLE_JOB_DICT mismatch
-    @pytest.mark.skip(reason="TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     @pytest.mark.skipif(openbabel is None, reason="OpenBabel not installed.")
     def test_all(self):
         single_outs = {file: QCOutput(f"{TEST_DIR}/{file}").data for file in SINGLE_JOB_OUT_NAMES}

--- a/tests/io/test_zeopp.py
+++ b/tests/io/test_zeopp.py
@@ -166,7 +166,7 @@ class TestGetVoronoiNodes:
         assert isinstance(vor_face_center_struct, Structure)
 
 
-@pytest.mark.skip("TODO: file free_sph.cif not present")
+@pytest.mark.xfail(reason="TODO: file free_sph.cif not present")
 class TestGetFreeSphereParams:
     def setup_method(self):
         filepath = f"{TEST_FILES_DIR}/cif/free_sph.cif"

--- a/tests/io/test_zeopp.py
+++ b/tests/io/test_zeopp.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import importlib.util
-
 import pytest
 from pytest import approx
 
@@ -14,14 +12,10 @@ from pymatgen.io.zeopp import (
     get_high_accuracy_voronoi_nodes,
     get_voronoi_nodes,
     zeo_found,
-    zeo_source,
 )
 from pymatgen.util.testing import TEST_FILES_DIR, VASP_IN_DIR
 
-# Check if either zeo or pyzeo is available
-HAS_ZEO = importlib.util.find_spec("zeo") is not None or importlib.util.find_spec("pyzeo") is not None
-
-if not HAS_ZEO:
+if not zeo_found:
     pytest.skip("neither zeo nor pyzeo is installed", allow_module_level=True)
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/zeopp"
@@ -235,15 +229,3 @@ class TestGetVoronoiNodesMultiOxi:
         assert isinstance(vor_node_struct, Structure)
         assert isinstance(vor_edge_center_struct, Structure)
         assert isinstance(vor_face_center_struct, Structure)
-
-
-class TestZeoSource:
-    """Test for zeo_source to verify which library was imported."""
-
-    def test_zeo_source_is_defined(self):
-        """Test that zeo_source is defined and is either 'zeo' or 'pyzeo'."""
-        assert zeo_source in ["zeo", "pyzeo"]
-
-    def test_zeo_found_is_true(self):
-        """Test that zeo_found is True when either library is imported."""
-        assert zeo_found is True

--- a/tests/io/vasp/test_inputs.py
+++ b/tests/io/vasp/test_inputs.py
@@ -1743,7 +1743,7 @@ class TestPotcar(MatSciTest):
         assert self.potcar.symbols == ["Fe_pv", "O"]
         assert self.potcar[0].nelectrons == 14
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     def test_default_functional(self):
         potcar = Potcar(["Fe", "P"])
         assert potcar[0].functional_class == "GGA"

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1626,7 +1626,6 @@ class TestMPHSERelaxSet(MatSciTest):
         assert not vis.incar["LASPH"], "LASPH user setting not applied"
         assert vis.incar["VDW_SR"] == approx(1.5), "VDW_SR user setting not applied"
 
-    @pytest.mark.skipif(not os.path.exists(TEST_DIR), reason="Test files are not present.")
     def test_from_prev_calc(self):
         prev_run = os.path.join(TEST_DIR, "fixtures", "relaxation")
 
@@ -1643,7 +1642,6 @@ class TestMPHSERelaxSet(MatSciTest):
         assert "VDW_A2" in vis_bj.incar
         assert "VDW_S8" in vis_bj.incar
 
-    @pytest.mark.skipif(not os.path.exists(TEST_DIR), reason="Test files are not present.")
     def test_override_from_prev_calc(self):
         prev_run = os.path.join(TEST_DIR, "fixtures", "relaxation")
 

--- a/tests/io/vasp/test_sets.py
+++ b/tests/io/vasp/test_sets.py
@@ -1756,7 +1756,7 @@ class TestMVLScanRelaxSet(MatSciTest):
         ):
             MVLScanRelaxSet(self.struct, user_potcar_functional="PBE")
 
-    @pytest.mark.skip("TODO: need someone to fix this")
+    @pytest.mark.xfail(reason="TODO: need someone to fix this")
     @skip_if_no_psp_dir
     def test_potcar_need_fix(self):
         test_potcar_set_1 = self.set(self.struct, user_potcar_functional="PBE_54")

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -185,7 +185,7 @@ class TestEnumerateStructureTransformation:
         for struct_trafo in all_structs:
             assert "energy" not in struct_trafo
 
-    @pytest.mark.skip(reason="dgl don't support torch 2.4.1+, #4073")
+    @pytest.mark.xfail(reason="dgl don't support torch 2.4.1+, #4073")
     def test_m3gnet(self):
         pytest.importorskip("matgl")
         enum_trans = EnumerateStructureTransformation(refine_structure=True, sort_criteria="m3gnet_relax")
@@ -204,7 +204,7 @@ class TestEnumerateStructureTransformation:
             <= all_structs[-1]["energy"] / all_structs[-1]["num_sites"]
         )
 
-    @pytest.mark.skip(reason="dgl don't support torch 2.4.1+, #4073")
+    @pytest.mark.xfail(reason="dgl don't support torch 2.4.1+, #4073")
     def test_callable_sort_criteria(self):
         matgl = pytest.importorskip("matgl")
         from matgl.ext.ase import Relaxer


### PR DESCRIPTION
Current we have a few issues with the optional ubuntu/macos dependency install in CI pipeline:
- [x] [Download/build optional dependency is not cached](https://docs.github.com/en/actions/reference/dependency-caching-reference), and [is taking significant amount of time](https://github.com/materialsproject/pymatgen/actions/runs/16221549527/job/45803054691): on ubuntu optional dep install time is around 1 min while the `pytest` step runs for 1-2 min
- [x] We didn't set `pipefail` and part of this is silently failing owing to [vampire download](https://github.com/richard-evans/vampire/issues/122) (`tar (child): vampire-5.0-linux.tar.gz: Cannot open: No such file or directory`)
- [x] Would be good if we also test `mcsqs`: https://github.com/materialsproject/pymatgen/blob/f9d9fe8e0ce09ef30cc03bcc4e9937d27afd5a6a/tests/command_line/test_mcsqs_caller.py#L20
- [x] Enable test for `pyzeo` 
- [Replace some `skip` marks with `xfail`](https://docs.pytest.org/en/stable/how-to/skipping.html), personally I think with `xfail` mark it's easiler to find tests that we want to do something about it (broken test to be fixed and so on), while for `skip` it's something we expect we work as is (skip windows for non-windows compatible function, or skip when dependency not available):
    > An xfail means that you expect a test to fail for some reason. A common example is a test for a feature not yet implemented, or a bug not yet fixed.
