### PR TITLE
Update analyzer.py

### DIFF
--- a/src/pymatgen/symmetry/analyzer.py
+++ b/src/pymatgen/symmetry/analyzer.py
@@ -586,7 +586,7 @@ class SpacegroupAnalyzer:
         lattice = Lattice(np.dot(transf, conv.lattice.matrix))
         for site in conv:
             new_s = PeriodicSite(
-                site.specie,
+                site.species,
                 site.coords,
                 lattice,
                 to_unit_cell=True,


### PR DESCRIPTION
Missing a letter "s" for `site.species` in pymatgen.symmetry.analyser.SpacegroupAnalyzer.get_primitive_standard_structure()

## Summary

Major changes:

- feature 0: 
- fix 1: Missing a letter "s" for `site.species` in pymatgen.symmetry.analyser.SpacegroupAnalyzer.get_primitive_standard_structure()

## Checklist

I only added a single letter...

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
