### PR TITLE
patch ReDOS vulnerability in GaussianInput.from_string

### DIFF
--- a/src/pymatgen/io/gaussian.py
+++ b/src/pymatgen/io/gaussian.py
@@ -86,7 +86,7 @@ class GaussianInput:
     """A Gaussian input file."""
 
     # Commonly used regex patterns
-    _zmat_patt = re.compile(r"^(\w+)*([\s,]+(\w+)[\s,]+(\w+))*[\-\.\s,\w]*$")
+    _zmat_patt = re.compile(r"^(\w+)([\s,]+(\w+)[\s,]+(\w+)){0,3}[\-\.\s,\w]*$")
     _xyz_patt = re.compile(r"^(\w+)[\s,]+([\d\.eE\-]+)[\s,]+([\d\.eE\-]+)[\s,]+([\d\.eE\-]+)[\-\.\s,\w.]*$")
 
     def __init__(


### PR DESCRIPTION
## Summary

Major changes:

- Patches ReDOS vulnerability mentioned in #2755

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
