### PR TITLE
Fix jdftx.outputs usage of 3.11+ only syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,21 +31,21 @@ jobs:
         # newest version (currently 3.13) on ubuntu (to get complete coverage on unix).
         config:
           - os: windows-latest
-            python: "3.11"
+            python: "3.10"
             resolution: highest
             extras: ci,optional,prototypes
           - os: windows-latest
             python: "3.11"
             resolution: highest
             extras: ci,prototypes,optional,numpy-v1 # Test NP1 on Windows (quite buggy ATM)
-          - os: ubuntu-latest
-            python: "3.13"
-            resolution: lowest-direct
-            extras: ci,prototypes,optional
           - os: macos-latest
             python: "3.12"
             resolution: lowest-direct
             extras: ci,prototypes # test with only required dependencies installed
+          - os: ubuntu-latest
+            python: "3.13"
+            resolution: lowest-direct
+            extras: ci,prototypes,optional
 
         # pytest-split automatically distributes work load so parallel jobs finish in similar time
         # update durations file with `pytest --store-durations --durations-path tests/files/.pytest-split-durations`

--- a/src/pymatgen/io/jdftx/outputs.py
+++ b/src/pymatgen/io/jdftx/outputs.py
@@ -325,7 +325,8 @@ class JDFTXOutputs:
             projections[spins[i]] = np.zeros([nbands, nkpt, norbmax, len(self.outfile.structure)])
             # TODO: Consider jitting this loop
             for u in range(nproj):
-                projections[spins[i]][:, :, *u_to_oa_map[u]] += proj_sjku[i, :, :, u]
+                idx = (slice(None), slice(None),) + tuple(u_to_oa_map[u])
+                projections[spins[i]][idx] += proj_sjku[i, :, :, u]
         return projections
 
 

--- a/tests/io/abinit/test_netcdf.py
+++ b/tests/io/abinit/test_netcdf.py
@@ -122,4 +122,5 @@ class TestAbinitHeader(MatSciTest):
         assert str(head)
         assert head.to_str(verbose=2, title="title")
         # PLEASE DO NOT REMOVE THIS LINE AS THIS API HAS BEEN AROUND FOR SEVERAL YEARS,
-        assert head.to_string(verbose=2, title="title")
+        with pytest.warns(FutureWarning, match="to_string is deprecated"):
+            assert head.to_string(verbose=2, title="title")


### PR DESCRIPTION
## Summary

[Fix the following 3.11+ only syntax](https://docs.python.org/3/reference/expressions.html?utm_source=chatgpt.com#subscriptions):

> Changed in version 3.11: Expressions in an expression list may be starred. See [PEP 646](https://peps.python.org/pep-0646/).

```
E     File "/home/yang/pmg/src/pymatgen/io/jdftx/outputs.py", line 328
E       projections[spins[i]][:, :, *u_to_oa_map[u]] += proj_sjku[i, :, :, u]
E                                   ^
E   SyntaxError: invalid syntax
```

cc @benrich37 