### PR TITLE
Fix TranslateSitesTransformation

### DIFF
--- a/src/pymatgen/transformations/site_transformations.py
+++ b/src/pymatgen/transformations/site_transformations.py
@@ -166,8 +166,8 @@ class TranslateSitesTransformation(AbstractTransformation):
         """
         struct = structure.copy()
         if self.translation_vector.shape == (len(self.indices_to_move), 3):
-            for idx, idx in enumerate(self.indices_to_move):
-                struct.translate_sites(idx, self.translation_vector[idx], self.vector_in_frac_coords)
+            for idx, idx_to_move in enumerate(self.indices_to_move):
+                struct.translate_sites(idx_to_move, self.translation_vector[idx], self.vector_in_frac_coords)
         else:
             struct.translate_sites(
                 self.indices_to_move,

--- a/tests/transformations/test_site_transformations.py
+++ b/tests/transformations/test_site_transformations.py
@@ -55,14 +55,16 @@ class TestTranslateSitesTransformation(MatSciTest):
         assert_allclose(struct[1].frac_coords, [0.375, 0.375, 0.375])
 
     def test_apply_transformation_site_by_site(self):
-        trafo = TranslateSitesTransformation([0, 1], [[0.1, 0.2, 0.3], [-0.075, -0.075, -0.075]])
+        trafo = TranslateSitesTransformation([0, 1, 4], [[0.1, 0.2, 0.3], [-0.075, -0.075, -0.075], [0.1, -0.1, 0.05]])
         struct = trafo.apply_transformation(self.struct)
         assert_allclose(struct[0].frac_coords, [0.1, 0.2, 0.3])
         assert_allclose(struct[1].frac_coords, [0.3, 0.3, 0.3])
+        assert_allclose(struct[4].frac_coords, [0.225, 0.025, 0.175])
         inv_t = trafo.inverse
         struct = inv_t.apply_transformation(struct)
         assert struct[0].distance_and_image_from_frac_coords([0, 0, 0])[0] == 0
         assert_allclose(struct[1].frac_coords, [0.375, 0.375, 0.375])
+        assert_allclose(struct[4].frac_coords, [0.125, 0.125, 0.125])
 
     def test_as_from_dict(self):
         d1 = TranslateSitesTransformation([0], [0.1, 0.2, 0.3]).as_dict()


### PR DESCRIPTION
## Summary

There was a bug in the `TranslateSitesTransformation` class. Both index variables in `apply_transformation` are named identically. The test case did not capture this error. I changed the existing test case to fail when run with the old code and renamed the variables.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.