### PR TITLE
Various bug fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
           PYTHONWARNDEFAULTENCODING: "true"  # PEP 597: Enable optional EncodingWarning
         run: |
           pytest tests \
-            --splits 10 --group ${{ matrix.split }} \
+            -n auto --splits 10 --group ${{ matrix.split }} \
             --durations-path tests/files/.pytest-split-durations \
 
   trigger_atomate2_ci:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ include = ["pymatgen", "pymatgen.*"]
 
 [tool.pdm.dev-dependencies]
 lint = ["mypy>=1.10.0", "pre-commit>=3.7.1", "ruff>=0.4.9"]
-test = ["pytest-cov>=5.0.0", "pytest-split>=0.9.0", "pytest>=8.2.2"]
+test = ["pytest-cov>=5.0.0", "pytest-split>=0.9.0", "pytest>=8.2.2","pytest-xdist>=3.0.0"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto64"]
@@ -254,7 +254,7 @@ docstring-code-format = true
 "dev_scripts/*" = ["D"]
 
 [tool.pytest.ini_options]
-addopts = "--durations=30 --quiet -r xXs --color=yes --import-mode=importlib"
+addopts = "-n auto --durations=30 --quiet -r xXs --color=yes --import-mode=importlib"
 filterwarnings = [
     # NOTE: the LAST matching option would be used
     "ignore::UserWarning", # Ignore UserWarning
@@ -331,7 +331,8 @@ dev = [
 test = [
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
-    "pytest-split>=0.10.0"
+    "pytest-split>=0.10.0",
+    "pytest-xdist>=3.0.0"
 ]
 lint = [
     "mypy>=1.15.0",

--- a/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
@@ -127,26 +127,21 @@ def get_dopants_from_shannon_radii(bonded_structure, num_dopants=5, match_oxi_si
 
 def _get_dopants(substitutions, num_dopants, match_oxi_sign) -> dict:
     """Utility method to get n- and p-type dopants from a list of substitutions."""
-    n_type = [
-        pred
-        for pred in substitutions
-        if pred["dopant_species"].oxi_state > pred["original_species"].oxi_state
-        and (
-            not match_oxi_sign
-            or np.sign(pred["dopant_species"].oxi_state) == np.sign(pred["original_species"].oxi_state)
-        )
-    ]
-    p_type = [
-        pred
-        for pred in substitutions
-        if pred["dopant_species"].oxi_state < pred["original_species"].oxi_state
-        and (
-            not match_oxi_sign
-            or np.sign(pred["dopant_species"].oxi_state) == np.sign(pred["original_species"].oxi_state)
-        )
-    ]
-
-    return {"n_type": n_type[:num_dopants], "p_type": p_type[:num_dopants]}
+    dopants = {k: [] for k in ("n_type", "p_type")}
+    for k in dopants:  # noqa: PLC0206
+        for pred in substitutions:
+            if (
+                pred["dopant_species"].oxi_state > pred["original_species"].oxi_state
+                if k == "n_type"
+                else pred["dopant_species"].oxi_state < pred["original_species"].oxi_state
+            ) and (
+                not match_oxi_sign
+                or np.sign(pred["dopant_species"].oxi_state) == np.sign(pred["original_species"].oxi_state)
+            ):
+                dopants[k].append(pred)
+            if len(dopants[k]) == num_dopants:
+                break
+    return dopants
 
 
 def _shannon_radii_from_cn(species_list, cn_roman, radius_to_compare=0):
@@ -171,7 +166,7 @@ def _shannon_radii_from_cn(species_list, cn_roman, radius_to_compare=0):
 
             - "species": The species with charge state.
             - "radius": The Shannon radius for the species.
-            - "radius_diff": The difference between the Shannon radius and the
+            - "radii_diff": The difference between the Shannon radius and the
                 radius_to_compare optional argument.
     """
     shannon_radii = []

--- a/src/pymatgen/core/composition.py
+++ b/src/pymatgen/core/composition.py
@@ -370,7 +370,7 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
         e.g. Li4 Fe4 P4 O16.
         """
         sym_amt = self.get_el_amt_dict()
-        syms = sorted(sym_amt, key=lambda sym: get_el_sp(sym).X)
+        syms = sorted(sym_amt, key=lambda sym: (_electronegativity(sym), sym))
         formula = [f"{s}{formula_double_format(sym_amt[s], ignore_ones=False)}" for s in syms]
         return " ".join(formula)
 
@@ -1343,6 +1343,13 @@ class Composition(collections.abc.Hashable, collections.abc.Mapping, MSONable, S
                         yield match
 
 
+def _electronegativity(x: int | SpeciesLike) -> float:
+    """Return float infinity rather than NaN for undefined electronegativity."""
+    if math.isnan(e_neg := get_el_sp(x).X):
+        e_neg = float("inf")
+    return e_neg
+
+
 def reduce_formula(
     sym_amt: Mapping[str, float],
     iupac_ordering: bool = False,
@@ -1363,7 +1370,7 @@ def reduce_formula(
     Returns:
         tuple[str, int]: reduced formula and factor.
     """
-    syms: list[str] = sorted(sym_amt, key=lambda x: [get_el_sp(x).X, x])
+    syms: list[str] = sorted(sym_amt, key=lambda x: [_electronegativity(x), x])
 
     syms = list(filter(lambda x: abs(sym_amt[x]) > Composition.amount_tolerance, syms))
 
@@ -1374,7 +1381,7 @@ def reduce_formula(
 
     # If the composition contains polyanion
     poly_anions: list[str] = []
-    if len(syms) >= 3 and get_el_sp(syms[-1]).X - get_el_sp(syms[-2]).X < 1.65:
+    if len(syms) >= 3 and _electronegativity(syms[-1]) - _electronegativity(syms[-2]) < 1.65:
         poly_sym_amt: dict[str, float] = {syms[i]: sym_amt[syms[i]] / factor for i in (-2, -1)}
         poly_form, poly_factor = reduce_formula(poly_sym_amt, iupac_ordering=iupac_ordering)
 

--- a/src/pymatgen/io/vasp/inputs.py
+++ b/src/pymatgen/io/vasp/inputs.py
@@ -1246,12 +1246,15 @@ class Kpoints(MSONable):
                 (or negative), VASP automatically generates the KPOINTS.
             style: Style for generating KPOINTS. Use one of the
                 Kpoints.supported_modes enum types.
-            kpts (2D array): Array of kpoints. Even when only a single
+            kpts (2D sequence): Sequence of kpoints. Even when only a single
                 specification is required, e.g. in the automatic scheme,
-                the kpts should still be specified as a 2D array. e.g.
+                the kpts should still be specified as a 2D sequence. e.g.
                 [(20,),] or [(2, 2, 2),].
+
+                If using a numpy array, call tolist() on kpts first.
             kpts_shift (3x1 array): Shift for kpoints.
             kpts_weights (list[float]): Optional weights for explicit kpoints.
+                If using a numpy array, call tolist() on kpts first.
             coord_type: In line-mode, this variable specifies whether the
                 Kpoints were given in Cartesian or Reciprocal coordinates.
             labels: In line-mode, this should provide a list of labels for

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -869,6 +869,26 @@ class TestComposition(MatSciTest):
         }.items():
             assert Composition(formula).formula == expected
 
+    def test_formula_order(self):
+        ref_vals = {
+            "formula": "Zn2 C2 Br2 Ar2 Ne2",
+            "reduced_formula": "ZnCBrArNe",
+        }
+        assert all(
+            all(getattr(Composition(dict.fromkeys(ele_order, 2)), k) == v for k, v in ref_vals.items())
+            for ele_order in [
+                ("Br", "Ar", "Zn", "C", "Ne"),
+                (
+                    "Ne",
+                    "Br",
+                    "Ar",
+                    "Zn",
+                    "C",
+                ),
+                ("Ar", "Br", "Ne", "C", "Zn"),
+            ]
+        )
+
 
 def test_reduce_formula():
     assert reduce_formula({"Li": 2, "Mn": 4, "O": 8}) == ("LiMn2O4", 2)


### PR DESCRIPTION
Fixes / modifies:
- `analysis.structure_prediction.dopant_predictor._get_dopants`: only compute the first `num_dopants` of each doping type. Previously computed all then filtered down
- Close [#4405](https://github.com/materialsproject/pymatgen/issues/4405) by improving docstr in `io.vasp.inputs.Kpoints`
- Close [#4475](https://github.com/materialsproject/pymatgen/issues/4475) by ensuring consistent electronegativity + fallback alphabetical order in `Composition.formula` and `.reduced_formula`