### PR TITLE
suppress runtime warning from boltztrap2

### DIFF
--- a/src/pymatgen/electronic_structure/boltztrap2.py
+++ b/src/pymatgen/electronic_structure/boltztrap2.py
@@ -445,6 +445,12 @@ class BztInterpolator:
             bands_loaded = self.load(fname)
         else:
             self.equivalences = sphere.get_equivalences(self.data.atoms, self.data.magmom, num_kpts * lpfac)
+            warnings.filterwarnings(
+                "ignore",
+                category=RuntimeWarning,
+                module=r"BoltzTraP2\.fite",
+                message=r".*(divide by zero|invalid value|overflow) encountered in matmul.*",
+            )
             self.coeffs = fite.fitde3D(self.data, self.equivalences)
 
         if not bands_loaded:


### PR DESCRIPTION
close #2317

Filter the following warnings:
```
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:68: RuntimeWarning: divide by zero encountered in matmul
  R = np.linalg.norm(Rvec @ lattvec.T, axis=1)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:68: RuntimeWarning: overflow encountered in matmul
  R = np.linalg.norm(Rvec @ lattvec.T, axis=1)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:68: RuntimeWarning: invalid value encountered in matmul
  R = np.linalg.norm(Rvec @ lattvec.T, axis=1)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:81: RuntimeWarning: divide by zero encountered in matmul
  phase0 = np.exp(tpii * kp @ equiv.T)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:81: RuntimeWarning: overflow encountered in matmul
  phase0 = np.exp(tpii * kp @ equiv.T)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:81: RuntimeWarning: invalid value encountered in matmul
  phase0 = np.exp(tpii * kp @ equiv.T)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:94: RuntimeWarning: divide by zero encountered in matmul
  Hmat = (phaseR[:, 1:] @ (phaseR[:, 1:] * rhoi[1:]).conj().T).real
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:94: RuntimeWarning: overflow encountered in matmul
  Hmat = (phaseR[:, 1:] @ (phaseR[:, 1:] * rhoi[1:]).conj().T).real
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:94: RuntimeWarning: invalid value encountered in matmul
  Hmat = (phaseR[:, 1:] @ (phaseR[:, 1:] * rhoi[1:]).conj().T).real
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:96: RuntimeWarning: divide by zero encountered in matmul
  coeffs = rhoi * (rlambda.T @ phaseR)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:96: RuntimeWarning: overflow encountered in matmul
  coeffs = rhoi * (rlambda.T @ phaseR)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:96: RuntimeWarning: invalid value encountered in matmul
  coeffs = rhoi * (rlambda.T @ phaseR)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:174: RuntimeWarning: divide by zero encountered in matmul
  np.matmul(dallvec, lattvec.T, out=allvec)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:174: RuntimeWarning: overflow encountered in matmul
  np.matmul(dallvec, lattvec.T, out=allvec)
/Users/yang/developer/pmg/.venv/lib/python3.13/site-packages/BoltzTraP2/fite.py:174: RuntimeWarning: invalid value encountered in matmul
  np.matmul(dallvec, lattvec.T, out=allvec)
```

Generated plot:
<img width="2966" height="2368" alt="boltztrap2_C_mu_temp" src="https://github.com/user-attachments/assets/bc75d08f-205d-4792-9016-706fc95cc7b8" />

Boltztrap2 was installed from my fork: `"BoltzTraP2 @ git+https://gitlab.com/DanielYang59/BoltzTraP2.git@bump-min-cmake-ver"`
- https://gitlab.com/sousaw/BoltzTraP2/-/merge_requests/28
