### PR TITLE
Fix missing sdist from PyPI

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   deploy:
     environment:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv with python version.
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    # run test.yml first to ensure that the test suite is passing
-    uses: ./.github/workflows/test.yml
+  # test:
+  #   # run test.yml first to ensure that the test suite is passing
+  #   uses: ./.github/workflows/test.yml
 
   build_sdist:
-    needs: test
+    # needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -43,7 +43,7 @@ jobs:
           path: dist/*.tar.gz
 
   build_wheels:
-    needs: test
+    # needs: test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest, ubuntu-24.04-arm]
@@ -85,6 +85,13 @@ jobs:
           pattern: dist-*
           merge-multiple: true
           path: dist
+
+      - name: Show what was downloaded (DEBUG)
+        run: |
+          echo "✅ Listing downloaded artifacts"
+          find dist -type f -print
+          echo ""
+          ls -lh dist
 
       - name: Publish to PyPI or TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.2.0
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -51,10 +51,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
 
@@ -75,12 +75,12 @@ jobs:
       id-token: write
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: dist-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: dist-sdist
           path: dist/*.tar.gz
 
   build_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ permissions:
   contents: read
 
 jobs:
-  # test:
-  #   # run test.yml first to ensure that the test suite is passing
-  #   uses: ./.github/workflows/test.yml
+  test:
+    # run test.yml first to ensure that the test suite is passing
+    uses: ./.github/workflows/test.yml
 
   build_sdist:
-    # needs: test
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -43,7 +43,7 @@ jobs:
           path: dist/*.tar.gz
 
   build_wheels:
-    # needs: test
+    needs: test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest, ubuntu-24.04-arm]
@@ -85,13 +85,6 @@ jobs:
           pattern: dist-*
           merge-multiple: true
           path: dist
-
-      - name: Show what was downloaded (DEBUG)
-        run: |
-          echo "✅ Listing downloaded artifacts"
-          find dist -type f -print
-          echo ""
-          ls -lh dist
 
       - name: Publish to PyPI or TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           pytest tests \
             --splits 10 --group ${{ matrix.split }} \
-            --durations-path tests/files/.pytest-split-durations \
+            --durations-path tests/files/.pytest-split-durations
 
   trigger_atomate2_ci:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,24 @@ name: test
 on:
   push:
     branches: [master]
-    paths: ["src/**/*.*", "tests/**/*.*", ".github/workflows/*" ,"pyproject.toml", "setup.py"]
+    paths:
+      [
+        "src/**/*.*",
+        "tests/**/*.*",
+        ".github/workflows/*",
+        "pyproject.toml",
+        "setup.py",
+      ]
   pull_request:
     branches: [master]
-    paths: ["src/**/*.*", "tests/**/*.*", ".github/workflows/*", "pyproject.toml", "setup.py" ]
+    paths:
+      [
+        "src/**/*.*",
+        "tests/**/*.*",
+        ".github/workflows/*",
+        "pyproject.toml",
+        "setup.py",
+      ]
   workflow_dispatch:
   workflow_call: # make this workflow reusable by release.yml
 
@@ -53,10 +67,10 @@ jobs:
 
     runs-on: ${{ matrix.config.os }}
     env:
-      OPT_BIN_DIR: ${{ github.workspace }}/opt/bin  # for optional Unix dependencies
+      OPT_BIN_DIR: ${{ github.workspace }}/opt/bin # for optional Unix dependencies
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create mamba environment
         uses: mamba-org/setup-micromamba@main
@@ -74,7 +88,7 @@ jobs:
             # openff-toolkit # TODO: doesn't support Python 3.13 yet
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
 
       - name: Install pymatgen and dependencies via uv
         run: |
@@ -98,10 +112,10 @@ jobs:
 
       - name: pytest split ${{ matrix.split }}
         env:
-          MPLBACKEND: Agg  # non-interactive backend for matplotlib
+          MPLBACKEND: Agg # non-interactive backend for matplotlib
           PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
           PMG_TEST_FILES_DIR: "${{ github.workspace }}/tests/files"
-          PYTHONWARNDEFAULTENCODING: "true"  # PEP 597: Enable optional EncodingWarning
+          PYTHONWARNDEFAULTENCODING: "true" # PEP 597: Enable optional EncodingWarning
         run: |
           pytest tests \
             --splits 10 --group ${{ matrix.split }} \


### PR DESCRIPTION
fix #4509


tested in my fork: https://github.com/DanielYang59/pymatgen/actions/runs/18279908313/job/52040659228

```diff
dist/pymatgen-2025.6.14-cp313-cp313-macosx_10_13_x86_64.whl
dist/pymatgen-2025.6.14-cp312-cp312-win32.whl
dist/pymatgen-2025.6.14-cp310-cp310-win_amd64.whl
dist/pymatgen-2025.6.14-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
dist/pymatgen-2025.6.14-cp311-cp311-win_amd64.whl
dist/pymatgen-2025.6.14-cp311-cp311-macosx_10_9_x86_64.whl
dist/pymatgen-2025.6.14-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
dist/pymatgen-2025.6.14-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
dist/pymatgen-2025.6.14-cp311-cp311-win32.whl
dist/pymatgen-2025.6.14-cp310-cp310-macosx_10_9_x86_64.whl
dist/pymatgen-2025.6.14-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
dist/pymatgen-2025.6.14-cp313-cp313-macosx_11_0_arm64.whl
+ dist/pymatgen-2025.6.14.tar.gz
dist/pymatgen-2025.6.14-cp312-cp312-macosx_10_13_x86_64.whl
dist/pymatgen-2025.6.14-cp310-cp310-macosx_11_0_arm64.whl
dist/pymatgen-2025.6.14-cp313-cp313-win_amd64.whl
dist/pymatgen-2025.6.14-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
dist/pymatgen-2025.6.14-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
dist/pymatgen-2025.6.14-cp313-cp313-win32.whl
dist/pymatgen-2025.6.14-cp310-cp310-win32.whl
dist/pymatgen-2025.6.14-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
dist/pymatgen-2025.6.14-cp311-cp311-macosx_11_0_arm64.whl
dist/pymatgen-2025.6.14-cp312-cp312-macosx_11_0_arm64.whl
dist/pymatgen-2025.6.14-cp312-cp312-win_amd64.whl
dist/pymatgen-2025.6.14-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
```