### PR TITLE
Avoid dict mutation in VaspInputSet.structure setter

### DIFF
--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -427,7 +427,7 @@ class VaspInputSet(InputGenerator, abc.ABC):
                 get_valid_magmom_struct(structure, spin_mode="auto")
 
             struct_has_Yb = any(specie.symbol == "Yb" for site in structure for specie in site.species)
-            potcar_settings = self._config_dict.get("POTCAR", {})
+            potcar_settings = self._config_dict.get("POTCAR", {}).copy()
             if self.user_potcar_settings:
                 potcar_settings.update(self.user_potcar_settings)
             uses_Yb_2_psp = potcar_settings.get("Yb", None) == "Yb_2"


### PR DESCRIPTION
`_config_dict["POTCAR"]` was being modified in-place during `Yb` PSP warning check
this caused `user_potcar_settings` to be permanently merged into  `_config_dict["POTCAR"]`. no known downstream repercussions but could in principle lead to incorrect POTCAR settings in subsequent operations