### PR TITLE
Add `ISEARCH` parameter to `incar_parameters.json`

### DIFF
--- a/src/pymatgen/io/vasp/incar_parameters.json
+++ b/src/pymatgen/io/vasp/incar_parameters.json
@@ -402,6 +402,13 @@
       4
      ]
  },
+ "ISEARCH": {
+   "type": "int",
+   "values": [
+      0,
+      1
+     ]
+ },
  "ISIF": {
    "type": "int",
    "values": [


### PR DESCRIPTION
## Summary

VASP 6.5 introduces the `ISEARCH` parameter: https://www.vasp.at/wiki/index.php/ISEARCH

This PR add `ISEARCH` to `incar_parameters.json`, so that it is recognised as a valid INCAR flag.

