### PR TITLE
`VolumetricData.copy` preserve subclass type

### DIFF
--- a/src/pymatgen/io/common.py
+++ b/src/pymatgen/io/common.py
@@ -23,9 +23,7 @@ from pymatgen.core.units import ang_to_bohr, bohr_to_angstrom
 from pymatgen.electronic_structure.core import Spin
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    from numpy.typing import NDArray
+    from numpy.typing import ArrayLike, NDArray
     from typing_extensions import Any, Self
 
     from pymatgen.core.structure import IStructure
@@ -143,13 +141,13 @@ class VolumetricData(MSONable):
     def __sub__(self, other):
         return self.linear_add(other, -1.0)
 
-    def copy(self) -> VolumetricData:
+    def copy(self) -> Self:
         """Make a copy of VolumetricData object."""
-        return VolumetricData(
+        return type(self)(
             self.structure,
             {k: v.copy() for k, v in self.data.items()},
-            distance_matrix=self._distance_matrix,  # type:ignore[arg-type]
-            data_aug=self.data_aug,  # type:ignore[arg-type]
+            distance_matrix=self._distance_matrix,
+            data_aug=self.data_aug,
         )
 
     def linear_add(self, other, scale_factor=1.0) -> VolumetricData:
@@ -205,7 +203,7 @@ class VolumetricData(MSONable):
         """
         return self.interpolator([x, y, z])[0]
 
-    def linear_slice(self, p1: Sequence[float], p2: Sequence[float], n=100):
+    def linear_slice(self, p1: ArrayLike, p2: ArrayLike, n=100):
         """Get a linear slice of the volumetric data with n data points from
         point p1 to point p2, in the form of a list.
 

--- a/tests/io/vasp/test_outputs.py
+++ b/tests/io/vasp/test_outputs.py
@@ -1582,6 +1582,10 @@ class TestLocpot(MatSciTest):
         assert locpot.get_axis_grid(1)[-1] == approx(2.87629, abs=1e-2)
         assert locpot.get_axis_grid(2)[-1] == approx(2.87629, abs=1e-2)
 
+        # Test copy preserve type
+        locpot_copy = locpot.copy()
+        assert type(locpot_copy) is type(locpot)
+
         # make sure locpot constructor works with data_aug=None
         poscar, data, _data_aug = Locpot.parse_file(filepath)
         l2 = Locpot(poscar=poscar, data=data, data_aug=None)
@@ -1632,6 +1636,10 @@ class TestChgcar(MatSciTest):
         ]
         actual = self.chgcar_fe3o4.get_integrated_diff(0, 3, 6)
         assert_allclose(actual[:, 1], expected)
+
+        # Test copy preserve type
+        chgcar_copy = chgcar.copy()
+        assert type(chgcar_copy) is type(chgcar)
 
     def test_write(self):
         self.chgcar_spin.write_file(out_path := f"{self.tmp_path}/CHGCAR_pmg")
@@ -1745,6 +1753,10 @@ class TestElfcar(MatSciTest):
         reconstituted = Elfcar.from_dict(elfcar.as_dict())
         assert elfcar.data == reconstituted.data
         assert elfcar.poscar.structure == reconstituted.poscar.structure
+
+        # Test copy preserve type
+        elfcar_copy = elfcar.copy()
+        assert type(elfcar_copy) is type(elfcar)
 
     def test_alpha(self):
         elfcar = Elfcar.from_file(f"{VASP_OUT_DIR}/ELFCAR.gz")


### PR DESCRIPTION
## Summary

- `VolumetricData.copy` use dynamic type to preserve subclass type, fix #4523
- loosen `linear_slice` type requirement 