### PR TITLE
Replace `assert` to check int in `get_el_sp`

### DIFF
--- a/src/pymatgen/core/periodic_table.py
+++ b/src/pymatgen/core/periodic_table.py
@@ -1640,9 +1640,9 @@ def get_el_sp(obj: int | SpeciesLike) -> Element | Species | DummySpecies:
     # If obj is an integer, return the Element with atomic number obj
     try:
         flt = float(obj)
-        assert flt == int(flt)  # noqa: S101
-        return Element.from_Z(int(flt))
-    except (AssertionError, ValueError, TypeError, KeyError):
+        if flt.is_integer():
+            return Element.from_Z(int(flt))
+    except (ValueError, TypeError, KeyError):
         pass
 
     # If obj is a string, attempt to parse it as a Species


### PR DESCRIPTION
Currently `get_el_sp` uses `assert` to check if obj is integar, this could be bypassed by the optimization flag (-O) and results in surprising behaviour, for example:

```bash
python3 -c "from pymatgen.core.periodic_table import get_el_sp; print(get_el_sp(4.5))"
>>> ValueError: Can't parse Element or Species from 4.5
```

However with `-O` it bypasses assert and gives Be because of `int(flt)`:
```bash
python3 -O -c "from pymatgen.core.periodic_table import get_el_sp; print(get_el_sp(4.5))"
>>> Be
```

