### PR TITLE
Deprecate `CifParser` init support of `filename` as `StringIO`

### DIFF
--- a/src/pymatgen/io/cif.py
+++ b/src/pymatgen/io/cif.py
@@ -10,7 +10,7 @@ import warnings
 from collections import defaultdict, deque
 from functools import partial
 from inspect import getfullargspec
-from io import StringIO, TextIOWrapper
+from io import StringIO
 from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
@@ -344,13 +344,6 @@ class CifParser:
         if isinstance(filename, (str | Path)):
             with zopen(filename, mode="rt", encoding="utf-8", errors="replace") as f:
                 cif_string: str = cast("str", f.read())
-        elif isinstance(filename, TextIOWrapper):
-            warnings.warn(
-                "Initializing CifParser from TextIOWrapper is deprecated, use str or Path instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            cif_string = filename.read()
         elif isinstance(filename, StringIO):
             warnings.warn(
                 "Initializing CifParser from StringIO is deprecated, use `from_str()` instead.",

--- a/tests/io/test_cif.py
+++ b/tests/io/test_cif.py
@@ -177,12 +177,6 @@ class TestCifIO(MatSciTest):
         with pytest.warns(DeprecationWarning, match="Initializing CifParser from StringIO"):
             parser = CifParser(StringIO(cif_text))
 
-        # Test init from TextIOWrapper
-        with (
-            pytest.warns(DeprecationWarning, match="Initializing CifParser from TextIOWrapper"),
-            open(f"{TEST_FILES_DIR}/cif/V2O3.cif") as file,
-        ):
-            parser = CifParser(file)
         for struct in parser.parse_structures():
             assert struct.formula == "V4 O6"
         bibtex_str = """


### PR DESCRIPTION
### Summary

- Move CIF parsing logics from `__init__` of `CifParser` to `from_str` 
- ~~Revert accidentally removed filename as `TextIOWrapper` support (though this may not be intended) in https://github.com/materialsproject/pymatgen/pull/3820, add a deprecation warning~~ reverted, guess this was not intended, also doesn't agree with type/docstring
- Currently the `filename` of `CifParser` constructor could also be the string for the CIF file itself (`StringIO`), it's a bit confusing (cc @ka-sarthak) but I guess this was intended to support `from_str`. After this refactoring this could be deprecated I guess


