### PR TITLE
Speed/stability improvements to chemenv/coordination_environments

### DIFF
--- a/src/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/chemenv_strategies.py
@@ -235,8 +235,8 @@ class AbstractChemenvStrategy(MSONable, abc.ABC):
         if not isinstance(self.structure_environments.voronoi, DetailedVoronoiContainer):
             raise TypeError('Voronoi Container not of type "DetailedVoronoiContainer"')
         self.prepare_symmetries()
-    
-    #AL:  Creating SpacegroupAnalyzer is expensive. Cache by a cheap structure fingerprint and skip when unchanged.
+
+    # AL:  Creating SpacegroupAnalyzer is expensive. Cache by a cheap structure fingerprint and skip when unchanged.
     def prepare_symmetries(self):
         """Prepare the symmetries for the structure contained in the structure environments."""
         try:
@@ -244,7 +244,7 @@ class AbstractChemenvStrategy(MSONable, abc.ABC):
             # cheap, deterministic fingerprint (no heavy symmetry ops)
             fp = (
                 tuple(s.lattice.matrix.ravel().round(10)),
-                tuple((sp.symbol for sp in s.species)),
+                tuple(sp.symbol for sp in s.species),
                 tuple(map(tuple, np.asarray(s.frac_coords).round(10))),
             )
             if getattr(self, "_symops_cache_fp", None) == fp and getattr(self, "symops", None) is not None:
@@ -257,8 +257,8 @@ class AbstractChemenvStrategy(MSONable, abc.ABC):
         except Exception:
             self.symops = []
             self._symops_cache_fp = None
-            
-    #AL The inner loop constructs many PeriodicSite objects and calls is_periodic_image repeatedly. Comparing fractional coordinates modulo 1 is enough and much cheaper.
+
+    # AL The inner loop constructs many PeriodicSite objects and calls is_periodic_image repeatedly. Comparing fractional coordinates modulo 1 is enough and much cheaper.
     def equivalent_site_index_and_transform(self, psite):
         """Get the equivalent site and corresponding symmetry+translation transformations.
 
@@ -420,8 +420,8 @@ class AbstractChemenvStrategy(MSONable, abc.ABC):
             solutions, this can return a list of coordination environments for the site.
         """
         raise NotImplementedError
-    
-    #AL Tight path during many-site scans. Cache locals and build neighbor list without intermediate dict churn.
+
+    # AL Tight path during many-site scans. Cache locals and build neighbor list without intermediate dict churn.
     def get_site_ce_fractions_and_neighbors(self, site, full_ce_info=False, strategy_info=False):
         site_idx, dist_equiv_site, dist_this_site, mysym = self.equivalent_site_index_and_transform(site)
         geoms_and_maps_list = self.get_site_coordination_environments_fractions(
@@ -632,8 +632,8 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
             continuous_symmetry_measure_cutoff: CSM cutoff
         """
         self._continuous_symmetry_measure_cutoff = CSMFloat(continuous_symmetry_measure_cutoff)
-        
-    # AL: prebind + listcomp 
+
+    # AL: prebind + listcomp
     def get_site_neighbors(self, site, isite=None, dequivsite=None, dthissite=None, mysym=None):
         if isite is None:
             isite, dequivsite, dthissite, mysym = self.equivalent_site_index_and_transform(site)
@@ -654,8 +654,8 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
         de = dequivsite
         dt = dthissite
         return [PeriodicSite(ps._species, op(ps.frac_coords + de) + dt, ps._lattice) for ps in eq_site_ps]
-    
-    #build (idp,iap)->(cn,inb) map once per site/AC 
+
+    # build (idp,iap)->(cn,inb) map once per site/AC
     def _get_cn_map_cache(self, isite):
         cache = getattr(self, "_cn_map_cache", None)
         if cache is None:
@@ -674,7 +674,7 @@ class SimplestChemenvStrategy(AbstractChemenvStrategy):
                         mapping[(src["idp"], src["iap"])] = (cn, inb_set)
         cache[key] = mapping
         return mapping
-    
+
     # faster index find + cached map
     def get_site_coordination_environment(
         self,
@@ -905,7 +905,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
         "The coordination environment is then given as the one with the \n"
         "lowest continuous symmetry measure."
     )
-    
+
     # AL cache key for default surface params
     _DEFAULT_SURFACE_CALC = {
         "distance_parameter": ("initial_normalized", None),
@@ -933,7 +933,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
     def uniquely_determines_coordination_environments(self):
         """Whether this strategy uniquely determines coordination environments."""
         return True
-    
+
     def get_site_neighbors(self, site):
         isite, dequivsite, dthissite, mysym = self.equivalent_site_index_and_transform(site)
         cn_map = self._get_map(isite)
@@ -942,7 +942,6 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
         de = dequivsite
         dt = dthissite
         return [PeriodicSite(ps._species, op(ps.frac_coords + de) + dt, ps._lattice) for ps in eqsite_ps]
-
 
     def get_site_coordination_environment(
         self,
@@ -974,7 +973,6 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
             return cn
         return ce.minimum_geometry(symmetry_measure_type=self._symmetry_measure_type)
 
-
     def get_site_coordination_environments(
         self,
         site,
@@ -994,7 +992,6 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
                 return_map=return_maps,
             )
         ]
-
 
     def _get_map(self, isite):
         # cache best map per (isite, additional_condition)
@@ -1025,7 +1022,6 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
         cache[key] = best_map
         return best_map
 
-
     def _get_maps_surfaces(self, isite, surface_calculation_type=None):
         # cache maps/surfaces per isite when default calc is used
         if surface_calculation_type is None:
@@ -1050,7 +1046,7 @@ class SimpleAbundanceChemenvStrategy(AbstractChemenvStrategy):
             surface_calculation_type=surface_calculation_type,
             max_dist=self.DEFAULT_MAX_DIST,
         )
-    
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
             return NotImplemented
@@ -1132,7 +1128,7 @@ class TargetedPenaltiedAbundanceChemenvStrategy(SimpleAbundanceChemenvStrategy):
         self.target_environments = target_environments
         self.target_penalty_type = target_penalty_type
         self.max_csm = max_csm
-        
+
     def get_site_coordination_environment(
         self,
         site,
@@ -1163,7 +1159,6 @@ class TargetedPenaltiedAbundanceChemenvStrategy(SimpleAbundanceChemenvStrategy):
         if chemical_environments.coord_geoms is None:
             return cn_map[0]
         return chemical_environments.minimum_geometry(symmetry_measure_type=self._symmetry_measure_type)
-
 
     def _get_map(self, isite):
         # cache by inputs that affect choice
@@ -1241,6 +1236,7 @@ class TargetedPenaltiedAbundanceChemenvStrategy(SimpleAbundanceChemenvStrategy):
 
         cache[cache_key] = best_map
         return best_map
+
     # def get_site_coordination_environment(
     #     self,
     #     site,
@@ -1472,11 +1468,11 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
     """Weight of neighbors set based on the normalized angle/distance."""
 
     SHORT_NAME = "NormAngleDistWeight"
-    
+
     # AL:
     ## All the branching logic is flatter and easier to follow.
     ## Dictionary lookups make average type resolution O(1) and avoid multiple comparisons.
-    ## No redundant double-checking of the same conditions.    
+    ## No redundant double-checking of the same conditions.
     def __init__(self, average_type, aa, bb):
         """Initialize NormalizedAngleDistanceNbSetWeight.
 
@@ -1486,10 +1482,7 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
             bb: Exponent for distance values.
         """
         # eval function selection
-        eval_map = {
-            "geometric": self.gweight,
-            "arithmetic": self.aweight
-        }
+        eval_map = {"geometric": self.gweight, "arithmetic": self.aweight}
         try:
             self.eval = eval_map[average_type]
         except KeyError:
@@ -1545,26 +1538,25 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
             NormalizedAngleDistanceNbSetWeight.
         """
         return cls(average_type=dct["average_type"], aa=dct["aa"], bb=dct["bb"])
-    
+
     # AL vectorized inner ops
     @staticmethod
     def invdist(nb_set):
         nd = np.asarray(nb_set.normalized_distances, dtype=float)
         return 1.0 / nd
-    
+
     def invndist(self, nb_set):
         nd = np.asarray(nb_set.normalized_distances, dtype=float)
-        return 1.0 / (nd ** self.bb)
+        return 1.0 / (nd**self.bb)
 
-    
     @staticmethod
     def ang(nb_set):
         return np.asarray(nb_set.normalized_angles, dtype=float)
-    
+
     def angn(self, nb_set):
         na = np.asarray(nb_set.normalized_angles, dtype=float)
-        return na ** self.aa
-    
+        return na**self.aa
+
     @staticmethod
     def anginvdist(nb_set):
         na = np.asarray(nb_set.normalized_angles, dtype=float)
@@ -1574,17 +1566,17 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
     def anginvndist(self, nb_set):
         na = np.asarray(nb_set.normalized_angles, dtype=float)
         nd = np.asarray(nb_set.normalized_distances, dtype=float)
-        return na / (nd ** self.bb)
+        return na / (nd**self.bb)
 
     def angninvdist(self, nb_set):
         na = np.asarray(nb_set.normalized_angles, dtype=float)
         nd = np.asarray(nb_set.normalized_distances, dtype=float)
-        return (na ** self.aa) / nd
+        return (na**self.aa) / nd
 
     def angninvndist(self, nb_set):
         na = np.asarray(nb_set.normalized_angles, dtype=float)
         nd = np.asarray(nb_set.normalized_distances, dtype=float)
-        return (na ** self.aa) / (nd ** self.bb)
+        return (na**self.aa) / (nd**self.bb)
 
     def weight(self, nb_set, structure_environments, cn_map=None, additional_info=None):
         fda_vals = self.fda(nb_set=nb_set)
@@ -1615,13 +1607,14 @@ class NormalizedAngleDistanceNbSetWeight(NbSetWeight):
         return np.mean(fda_list)
 
 
-# AL: 
+# AL:
 # Replaced try/except cache read with a direct dict cache (setdefault + .get) -->  no exception overhead.
 # Cached per-site map once (eff_map) and wrote back directly --> fewer nested dict hits.
 # Prebound hot callables/attrs (mean_estimator, ce_list_site) --> fewer attribute lookups.
 # Used truthiness checks (if not mingeoms) instead of len(...)==0 --> cheaper.
 # Tight loop over mingeoms with a single get and threshold check --> fewer dict walks and temporaries.
 # Early returns for cached values and empty/None cases --> less work on common paths.
+
 
 def get_effective_csm(
     nb_set,
@@ -1633,13 +1626,13 @@ def get_effective_csm(
     effective_csm_estimator_ratio_function,
 ):
     """Get the effective continuous symmetry measure of a given neighbors set."""
-    #  fast cache path without exceptions 
+    #  fast cache path without exceptions
     eff_map = additional_info.setdefault("effective_csms", {}).setdefault(nb_set.isite, {})
     cached = eff_map.get(cn_map)
     if cached is not None:
         return cached
 
-    #  locals to reduce attribute lookups in hot path 
+    #  locals to reduce attribute lookups in hot path
     ce_list_site = structure_environments.ce_list[nb_set.isite]
     mean_estimator = effective_csm_estimator_ratio_function.mean_estimator
 
@@ -1666,6 +1659,7 @@ def get_effective_csm(
     # store in cache and return
     eff_map[cn_map] = eff
     return eff
+
 
 def set_info(additional_info, field, isite, cn_map, value) -> None:
     """Set additional information for the weights.
@@ -1720,7 +1714,7 @@ class SelfCSMNbSetWeight(NbSetWeight):
         self.weight_estimator_rf = CSMFiniteRatioFunction.from_dict(weight_estimator)
         self.symmetry_measure_type = symmetry_measure_type
         self.max_effective_csm = self.effective_csm_estimator["options"]["max_csm"]
-    
+
     # AL: micro-optimization of Python call overhead, the big performance gains will come from making get_effective_csm faster, since that’s the heavy part this method calls every time.
     def weight(self, nb_set, structure_environments, cn_map=None, additional_info=None):
         # Bind locals to cut attribute lookups in hot path
@@ -1801,7 +1795,7 @@ class DeltaCSMNbSetWeight(NbSetWeight):
         "function": "smootherstep",
         "options": {"delta_csm_min": 0.5, "delta_csm_max": 3.0},
     }
-    
+
     # AL
     def __init__(
         self,
@@ -1856,7 +1850,7 @@ class DeltaCSMNbSetWeight(NbSetWeight):
         for cn2, nb_sets in se.neighbors_sets[isite].items():
             if cn2 <= cn:
                 continue
-            
+
             dcn = cn2 - cn
             rf = eval_per_dcn.get(dcn)
             eval_fn = rf.evaluate if rf is not None else eval_default
@@ -2513,7 +2507,7 @@ class DistanceNbSetWeight(NbSetWeight):
         if nbs_source not in ["nb_sets", "voronoi"]:
             raise ValueError('"nbs_source" should be one of ["nb_sets", "voronoi"]')
         self.nbs_source = nbs_source
-        
+
     def weight(self, nb_set, structure_environments, cn_map=None, additional_info=None):
         """Get the weight of a given neighbors set."""
         cn = cn_map[0]
@@ -2594,7 +2588,7 @@ class DeltaDistanceNbSetWeight(NbSetWeight):
         if nbs_source not in ["nb_sets", "voronoi"]:
             raise ValueError('"nbs_source" should be one of ["nb_sets", "voronoi"]')
         self.nbs_source = nbs_source
-        
+
     def weight(self, nb_set, structure_environments, cn_map=None, additional_info=None):
         """Get the weight of a given neighbors set."""
         cn = cn_map[0]
@@ -2615,14 +2609,12 @@ class DeltaDistanceNbSetWeight(NbSetWeight):
                     for idx in nb2.site_voronoi_indices:
                         if idx not in exclude:
                             d = voro_site[idx]["normalized_distance"]
-                            if d < min_other:
-                                min_other = d
+                            min_other = min(min_other, d)
         elif self.nbs_source == "voronoi":
             for idx, rec in enumerate(voro_site):
                 if idx not in exclude:
                     d = rec["normalized_distance"]
-                    if d < min_other:
-                        min_other = d
+                    min_other = min(min_other, d)
         else:
             raise ValueError('"nbs_source" should be one of ["nb_sets", "voronoi"]')
 
@@ -2668,7 +2660,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
         "function": "power2_inverse_power2_decreasing",
         "options": {"max_csm": 8.0},
     }
-    
+
     def __init__(
         self,
         structure_environments=None,
@@ -2692,7 +2684,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
     def uniquely_determines_coordination_environments(self):
         """Whether this strategy uniquely determines coordination environments."""
         return False
-    
+
     def get_site_coordination_environments_fractions(
         self,
         site,
@@ -2742,6 +2734,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
 
         # product of weights per nb_set (avoid list conversion)
         from math import prod
+
         for cn_map, d in weights_isite.items():
             d["Product"] = prod(d.values())
 
@@ -2788,7 +2781,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
                     ce_dict_fractions.append(d)
                     ce_maps.append(cn_map)
                 else:
-                    for (sym, ced), frac in zip(mingeoms, fractions):
+                    for (sym, ced), frac in zip(mingeoms, fractions, strict=False):
                         ce_symbols.append(sym)
                         ce_dicts.append(ced)
                         frac_tot = nb_set_fraction * frac
@@ -2809,7 +2802,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
                     continue
                 csms = [ced["other_symmetry_measures"][smt] for _sym, ced in mingeoms]
                 fractions = self.ce_estimator_fractions(csms)
-                for (sym, ced), frac in zip(mingeoms, fractions):
+                for (sym, ced), frac in zip(mingeoms, fractions, strict=False):
                     if frac > 0:
                         frac_tot = nb_set_fraction * frac
                         ce_symbols.append(sym)
@@ -2844,6 +2837,7 @@ class WeightedNbSetChemenvStrategy(AbstractChemenvStrategy):
                     j += 1
 
         return fractions_info_list
+
     def get_site_coordination_environment(self, site):
         """Get the coordination environment of a given site.
 
@@ -2951,7 +2945,7 @@ class MultiWeightsChemenvStrategy(WeightedNbSetChemenvStrategy):
         "function": "power2_inverse_power2_decreasing",
         "options": {"max_csm": 8.0},
     }
-    
+
     def __init__(
         self,
         structure_environments=None,

--- a/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/coordination_geometries.py
@@ -178,7 +178,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
     #         len(plane_points),
     #         len(point_groups[1]),
     #     )
-    
+
     def __init__(
         self,
         plane_points,
@@ -222,8 +222,6 @@ class SeparationPlane(AbstractChemenvAlgorithm):
         self._ref_separation_perm = list(self.point_groups[0]) + list(self.plane_points) + list(self.point_groups[1])
         self._argsorted_ref_separation_perm = list(np.argsort(self._ref_separation_perm))
         self.separation = (len(point_groups[0]), len(plane_points), len(point_groups[1]))
-
-
 
     @property
     def permutations(self) -> list[list[int]]:
@@ -317,7 +315,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
     #                         perm.extend(list(perm_side1))
     #                         self._safe_permutations.append(perm)
     #     return self._safe_permutations
-    
+
     def safe_separation_permutations(self, ordered_plane=False, ordered_point_groups=None, add_opposite=False):
         """
         Simple and safe permutations for this separation plane.
@@ -325,7 +323,12 @@ class SeparationPlane(AbstractChemenvAlgorithm):
         # cache by inputs (can be called repeatedly with same flags)
         if ordered_point_groups is None:
             ordered_point_groups = [False, False]
-        cache_key = (bool(ordered_plane), bool(ordered_point_groups[0]), bool(ordered_point_groups[1]), bool(add_opposite))
+        cache_key = (
+            bool(ordered_plane),
+            bool(ordered_point_groups[0]),
+            bool(ordered_point_groups[1]),
+            bool(add_opposite),
+        )
         if self._safe_permutations is not None and self._safe_perm_cache_key == cache_key:
             return self._safe_permutations
 
@@ -349,10 +352,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
             return out
 
         # build permutations for each block with minimal work
-        if ordered_plane and self.ordered_plane:
-            plane_perms = rotations(plane)
-        else:
-            plane_perms = list(itertools.permutations(plane))
+        plane_perms = rotations(plane) if ordered_plane and self.ordered_plane else list(itertools.permutations(plane))
 
         if ordered_point_groups[0] and self.ordered_point_groups[0]:
             s0_perms = rotations(s0)
@@ -377,7 +377,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
         self._safe_permutations = perms
         self._safe_perm_cache_key = cache_key
         return perms
-    
+
     def as_dict(self):
         return {
             "@module": type(self).__module__,
@@ -388,7 +388,9 @@ class SeparationPlane(AbstractChemenvAlgorithm):
             "point_groups": self.point_groups,
             "ordered_point_groups": self.ordered_point_groups,
             "explicit_permutations": (
-                [eperm.tolist() for eperm in self.explicit_permutations] if self.explicit_permutations is not None else None
+                [eperm.tolist() for eperm in self.explicit_permutations]
+                if self.explicit_permutations is not None
+                else None
             ),
             "explicit_optimized_permutations": (
                 [eoperm.tolist() for eoperm in self.explicit_optimized_permutations]
@@ -399,8 +401,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
             "other_plane_points": self.other_plane_points,
             "minimum_number_of_points": self.minimum_number_of_points,
         }
-        
-    
+
     @classmethod
     def from_dict(cls, dct: dict) -> Self:
         eop_raw = dct.get("explicit_optimized_permutations")
@@ -419,7 +420,7 @@ class SeparationPlane(AbstractChemenvAlgorithm):
             other_plane_points=dct.get("other_plane_points"),
             minimum_number_of_points=dct["minimum_number_of_points"],
         )
-    
+
     # def as_dict(self):
     #     """
     #     Returns:
@@ -479,13 +480,14 @@ class SeparationPlane(AbstractChemenvAlgorithm):
     #     out += f"[{'-'.join(map(str, [self.plane_points]))}] | "
     #     out += f"[{'-'.join(map(str, [self.point_groups[1]]))}]"
     #     return out
-    
+
     def __str__(self):
         # avoid building intermediate lists/strings awkwardly
         return (
             "Separation plane algorithm with the following reference separation :\n"
             f"[{self.point_groups[0]}] | [{self.plane_points}] | [{self.point_groups[1]}]"
         )
+
 
 class CoordinationGeometry:
     """Store the ideal representation of a chemical environment or "coordination geometry"."""
@@ -702,7 +704,7 @@ class CoordinationGeometry:
         self.equivalent_indices = equivalent_indices
         self.neighbors_sets_hints = neighbors_sets_hints
         self._pauling_stability_ratio = None
-    
+
     def as_dict(self):
         """A JSON-serializable dict representation of this CoordinationGeometry."""
         return {
@@ -722,7 +724,9 @@ class CoordinationGeometry:
             "_algorithms": ([algo.as_dict() for algo in self._algorithms] if self._algorithms is not None else None),
             "equivalent_indices": self.equivalent_indices,
             "neighbors_sets_hints": (
-                [nbsh.as_dict() for nbsh in self.neighbors_sets_hints] if self.neighbors_sets_hints is not None else None
+                [nbsh.as_dict() for nbsh in self.neighbors_sets_hints]
+                if self.neighbors_sets_hints is not None
+                else None
             ),
         }
 
@@ -809,7 +813,7 @@ class CoordinationGeometry:
 
     def __len__(self):
         return self.coordination
-    
+
     @property
     def distfactor_max(self):
         """The maximum distfactor for the perfect CoordinationGeometry (usually 1.0 for symmetric polyhedrons)."""
@@ -904,7 +908,6 @@ class CoordinationGeometry:
         # faster than sort(): compute min tuple directly
         return min(tuple(permutation[i] for i in eqv) for eqv in self.equivalent_indices)
 
-
     @property
     def algorithms(self):
         """The list of algorithms that are used to identify this coordination geometry."""
@@ -913,15 +916,12 @@ class CoordinationGeometry:
     def get_central_site(self):
         """Get the central site of this coordination geometry."""
         return self.central_site
-    
+
     def faces(self, sites, permutation=None):
         """List of faces; each face is a list of vertex coords."""
-        if permutation is None:
-            coords = [site.coords for site in sites]
-        else:
-            coords = [sites[i].coords for i in permutation]
+        coords = [site.coords for site in sites] if permutation is None else [sites[i].coords for i in permutation]
         return [[coords[i] for i in face] for face in self._faces]
-    
+
     def edges(self, sites, permutation=None, input="sites"):  # noqa: A002
         """List of edges; each edge is a list of end-vertex coords."""
         if input == "sites":
@@ -941,7 +941,7 @@ class CoordinationGeometry:
         if permutation is None:
             return self._solid_angles
         return [self._solid_angles[ii] for ii in permutation]
-    
+
     def get_pmeshes(self, sites, permutation=None):
         """Get the pmesh strings used for jmol to show this geometry."""
         p_meshes = []
@@ -1000,7 +1000,7 @@ class AllCoordinationGeometries(dict):
     """Store all the reference "coordination geometries" (list with instances
     of the CoordinationGeometry classes).
     """
-    
+
     def __init__(self, permutations_safe_override=False, only_symbols=None):
         """Initialize the list of Coordination Geometries.
 
@@ -1011,7 +1011,7 @@ class AllCoordinationGeometries(dict):
         dict.__init__(self)
         self.cg_list: list[CoordinationGeometry] = []
 
-        #  load geometries (I/O unchanged) 
+        #  load geometries (I/O unchanged)
         if only_symbols is None:
             # iterate lines directly (no .readlines() list) -> lower peak memory
             with open(f"{MODULE_DIR}/coordination_geometries_files/allcg.txt", encoding="utf-8") as file:
@@ -1051,10 +1051,10 @@ class AllCoordinationGeometries(dict):
             if cg.IUCr_symbol:
                 self._by_iucr[cg.IUCr_symbol] = cg
             self._by_name[cg.name] = cg
-            for alt in (cg.alternative_names or ()):
+            for alt in cg.alternative_names or ():
                 self._by_name.setdefault(alt, cg)
 
-        #  one-pass aggregation for separations/min/max 
+        #  one-pass aggregation for separations/min/max
         # reason: replaces nested loops over cn + get_implemented_geometries (which
         # itself scans the full list); does O(N) instead of O(CN*N).
         self.minpoints: dict[int, int] = {}
@@ -1097,20 +1097,18 @@ class AllCoordinationGeometries(dict):
 
                 mn = algo.minimum_number_of_points
                 mx = algo.maximum_number_of_points
-                if mn < self.minpoints[cn]:
-                    self.minpoints[cn] = mn
-                if mx > self.maxpoints[cn]:
-                    self.maxpoints[cn] = mx
+                self.minpoints[cn] = min(self.minpoints[cn], mn)
+                self.maxpoints[cn] = max(self.maxpoints[cn], mx)
 
         # derived dict computed once (same result as before)
-        self.maxpoints_inplane = {cn: max(sep[1] for sep in seps) for cn, seps in self.separations_cg.items()}        
+        self.maxpoints_inplane = {cn: max(sep[1] for sep in seps) for cn, seps in self.separations_cg.items()}
 
     # def __getitem__(self, key):
     #     return self.get_geometry_from_mp_symbol(key)
     def __getitem__(self, key):
         # reason: delegate to O(1) map-based getter (and keep same error semantics)
         return self.get_geometry_from_mp_symbol(key)
-    
+
     def __contains__(self, item):
         # reason: O(1) membership via map instead of try/except + scan
         return item in self._by_symbol
@@ -1142,16 +1140,18 @@ class AllCoordinationGeometries(dict):
         outs.extend(str(cg) for cg in self.cg_list if cg.is_implemented())
 
         return "\n".join(outs)
-    
+
     def get_geometries(self, coordination=None, returned="cg"):
         # reason: generator + comprehension avoids repeated appends + branching in loop
-        it = self.cg_list if coordination is None else (
-            cg for cg in self.cg_list if cg.get_coordination_number() == coordination
+        it = (
+            self.cg_list
+            if coordination is None
+            else (cg for cg in self.cg_list if cg.get_coordination_number() == coordination)
         )
         if returned == "cg":
             return list(it)
         return [cg.mp_symbol for cg in it]
-    
+
     def get_symbol_name_mapping(self, coordination=None):
         # reason: dict comprehensions are faster/clearer
         if coordination is None:
@@ -1162,8 +1162,10 @@ class AllCoordinationGeometries(dict):
         # reason: dict comprehensions
         if coordination is None:
             return {cg.mp_symbol: cg.coordination_number for cg in self.cg_list}
-        return {cg.mp_symbol: cg.coordination_number for cg in self.cg_list if cg.get_coordination_number() == coordination}
-    
+        return {
+            cg.mp_symbol: cg.coordination_number for cg in self.cg_list if cg.get_coordination_number() == coordination
+        }
+
     def get_implemented_geometries(self, coordination=None, returned="cg", include_deactivated=False):
         # reason: single pass with filter predicates; avoids nested if/elses
         def ok(cg):
@@ -1171,13 +1173,11 @@ class AllCoordinationGeometries(dict):
                 return False
             if not include_deactivated and cg.deactivate:
                 return False
-            if coordination is not None and cg.get_coordination_number() != coordination:
-                return False
-            return True
+            return not (coordination is not None and cg.get_coordination_number() != coordination)
 
         it = (cg for cg in self.cg_list if ok(cg))
         return list(it) if returned == "cg" else [cg.mp_symbol for cg in it]
-    
+
     def get_not_implemented_geometries(self, coordination=None, returned="mp_symbol"):
         # reason: comprehension + simple predicate
         def not_impl(cg):
@@ -1185,28 +1185,28 @@ class AllCoordinationGeometries(dict):
 
         it = (cg for cg in self.cg_list if not_impl(cg))
         return list(it) if returned == "cg" else [cg.mp_symbol for cg in it]
-    
+
     def get_geometry_from_name(self, name: str) -> CoordinationGeometry:
         # reason: O(1) lookup instead of full-list scan
         try:
             return self._by_name[name]
         except KeyError:
             raise LookupError(f"No coordination geometry found with name {name!r}")
-        
+
     def get_geometry_from_IUPAC_symbol(self, IUPAC_symbol: str) -> CoordinationGeometry:
         # reason: O(1) map lookup
         try:
             return self._by_iupac[IUPAC_symbol]
         except KeyError:
             raise LookupError(f"No coordination geometry found with IUPAC symbol {IUPAC_symbol!r}")
-    
+
     def get_geometry_from_IUCr_symbol(self, IUCr_symbol: str) -> CoordinationGeometry:
         # reason: O(1) map lookup
         try:
             return self._by_iucr[IUCr_symbol]
         except KeyError:
             raise LookupError(f"No coordination geometry found with IUCr symbol {IUCr_symbol!r}")
-    
+
     def get_geometry_from_mp_symbol(self, mp_symbol: str) -> CoordinationGeometry:
         # reason: O(1) map lookup
         try:
@@ -1249,7 +1249,7 @@ class AllCoordinationGeometries(dict):
         if cg is None:
             return True
         return not (cn is not None and cn != cg.coordination_number)
-    
+
     def pretty_print(self, type="implemented_geometries", maxcn=8, additional_info=None):  # noqa: A002
         if type == "all_geometries_latex_images":
             out = []

--- a/src/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
+++ b/src/pymatgen/analysis/chemenv/coordination_environments/structure_environments.py
@@ -49,11 +49,17 @@ class StructureEnvironments(MSONable):
 
     class NeighborsSet:
         """Store a given set of neighbors of a given site (based on the detailed_voronoi)."""
-        
+
         # reduce per-instance overhead
         __slots__ = (
-            "structure", "isite", "detailed_voronoi", "voronoi",
-            "site_voronoi_indices", "sources", "local_planes", "separations"
+            "detailed_voronoi",
+            "isite",
+            "local_planes",
+            "separations",
+            "site_voronoi_indices",
+            "sources",
+            "structure",
+            "voronoi",
         )
 
         def __init__(self, structure: Structure, isite, detailed_voronoi, site_voronoi_indices, sources=None):
@@ -116,7 +122,7 @@ class StructureEnvironments(MSONable):
                 {"site": self.voronoi[inb]["site"], "index": self.voronoi[inb]["index"]}
                 for inb in self.site_voronoi_indices
             ]
-        
+
         @property
         def coords(self):
             # build list in one go (avoid list.extend)
@@ -201,7 +207,7 @@ class StructureEnvironments(MSONable):
             if plateau is None:
                 raise ValueError("Plateau not found ...")
             return plateau
-        
+
         def angle_plateau(self):
             all_nbs_normalized_angles_sorted = sorted(nb["normalized_angle"] for nb in self.voronoi)
             min_ang = np.min(self.normalized_angles)
@@ -353,8 +359,7 @@ class StructureEnvironments(MSONable):
             return len(self.site_voronoi_indices)
 
         def __hash__(self) -> int:
-             return len(self.site_voronoi_indices)
-
+            return len(self.site_voronoi_indices)
 
         def __eq__(self, other: object) -> bool:
             needed_attrs = ("isite", "site_voronoi_indices")
@@ -440,7 +445,7 @@ class StructureEnvironments(MSONable):
         else:
             self.neighbors_sets = neighbors_sets
         self.info = info
-        
+
     def init_neighbors_sets(self, isite, additional_conditions=None, valences=None):
         site_voronoi = self.voronoi.voronoi_list2[isite]
         if site_voronoi is None:
@@ -450,7 +455,8 @@ class StructureEnvironments(MSONable):
             additional_conditions = self.AC.ALL
         if (self.AC.ONLY_ACB in additional_conditions or self.AC.ONLY_ACB_AND_NO_E2SEB) and valences is None:
             raise ChemenvError(
-                "StructureEnvironments", "init_neighbors_sets",
+                "StructureEnvironments",
+                "init_neighbors_sets",
                 "Valences are not given while only_anion_cation_bonds are allowed. Cannot continue",
             )
 
@@ -469,9 +475,7 @@ class StructureEnvironments(MSONable):
                 cond = self.AC.check_condition(
                     condition=ac,
                     structure=self.structure,
-                    parameters={"valences": valences,
-                                "neighbor_index": voro_nb_dict["index"],
-                                "site_index": isite},
+                    parameters={"valences": valences, "neighbor_index": voro_nb_dict["index"], "site_index": isite},
                 )
                 if cond:
                     indices.append(len(indices))  # local index in site_voronoi order
@@ -482,9 +486,7 @@ class StructureEnvironments(MSONable):
                 cond = self.AC.check_condition(
                     condition=ac,
                     structure=self.structure,
-                    parameters={"valences": valences,
-                                "neighbor_index": voro_nb_dict["index"],
-                                "site_index": isite},
+                    parameters={"valences": valences, "neighbor_index": voro_nb_dict["index"], "site_index": isite},
                 )
                 if cond:
                     true_positions.append(pos)
@@ -1361,7 +1363,7 @@ class LightStructureEnvironments(MSONable):
         Class used to store a given set of neighbors of a given site (based on a list of sites, the voronoi
         container is not part of the LightStructureEnvironments object).
         """
-        
+
         def __init__(self, structure: Structure, isite, all_nbs_sites, all_nbs_sites_indices):
             self.structure = structure
             self.isite = isite
@@ -1490,7 +1492,7 @@ class LightStructureEnvironments(MSONable):
         self.structure = structure
         self.valences = valences
         self.valences_origin = valences_origin
-        
+
     @classmethod
     def from_structure_environments(cls, strategy, structure_environments, valences=None, valences_origin=None) -> Self:
         structure = structure_environments.structure
@@ -1526,12 +1528,14 @@ class LightStructureEnvironments(MSONable):
             for ce_and_neighbors in site_ces_and_nbs_list:
                 # build CE record (all keys preserved)
                 ced = ce_and_neighbors.get("ce_dict")
-                site_ces.append({
-                    "ce_symbol": ce_and_neighbors["ce_symbol"],
-                    "ce_fraction": ce_and_neighbors["ce_fraction"],
-                    "csm": None if ced is None else ced["other_symmetry_measures"][strategy.symmetry_measure_type],
-                    "permutation": None if ced is None else ced.get("permutation"),
-                })
+                site_ces.append(
+                    {
+                        "ce_symbol": ce_and_neighbors["ce_symbol"],
+                        "ce_fraction": ce_and_neighbors["ce_fraction"],
+                        "csm": None if ced is None else ced["other_symmetry_measures"][strategy.symmetry_measure_type],
+                        "permutation": None if ced is None else ced.get("permutation"),
+                    }
+                )
 
                 # build neighbor-set indices using O(1) keyed reuse
                 _all_nbs_sites_indices: list = []
@@ -1552,11 +1556,13 @@ class LightStructureEnvironments(MSONable):
                     pos = nb_key_to_pos.get(key)
                     if pos is None:
                         pos = len(_all_nbs_sites)
-                        _all_nbs_sites.append({
-                            "site": nb_site,
-                            "index": nb_index_unitcell,
-                            "image_cell": np.array(img_tup, dtype=int),
-                        })
+                        _all_nbs_sites.append(
+                            {
+                                "site": nb_site,
+                                "index": nb_index_unitcell,
+                                "image_cell": np.array(img_tup, dtype=int),
+                            }
+                        )
                         nb_key_to_pos[key] = pos
 
                     _all_nbs_sites_indices.append(pos)
@@ -1586,9 +1592,18 @@ class LightStructureEnvironments(MSONable):
     def setup_statistic_lists(self):
         d = self.statistics_dict = {
             "valences_origin": self.valences_origin,
-            "anion_list": {}, "anion_number": None, "anion_atom_list": {}, "anion_atom_number": None,
-            "cation_list": {}, "cation_number": None, "cation_atom_list": {}, "cation_atom_number": None,
-            "neutral_list": {}, "neutral_number": None, "neutral_atom_list": {}, "neutral_atom_number": None,
+            "anion_list": {},
+            "anion_number": None,
+            "anion_atom_list": {},
+            "anion_atom_number": None,
+            "cation_list": {},
+            "cation_number": None,
+            "cation_atom_list": {},
+            "cation_atom_number": None,
+            "neutral_list": {},
+            "neutral_number": None,
+            "neutral_atom_list": {},
+            "neutral_atom_number": None,
             "atom_coordination_environments_present": {},
             "ion_coordination_environments_present": {},
             "coordination_environments_ion_present": {},
@@ -1738,7 +1753,7 @@ class LightStructureEnvironments(MSONable):
                         csms.append(ce_dict["csm"])
                         fractions.append(ce_dict["ce_fraction"])
         return {"isites": isites, "fractions": fractions, "csms": csms}
-    
+
     def get_site_info_for_specie_ce(self, specie, ce_symbol):
         element = specie.symbol
         oxi_state = specie.oxi_state
@@ -1809,12 +1824,14 @@ class LightStructureEnvironments(MSONable):
         else:
             dd = {field: self.statistics_dict[field] for field in statistics_fields}
         return dd
-    
+
     def contains_only_one_anion_atom(self, anion_atom):
         if self.statistics_dict is None:
             self.setup_statistic_lists()
-        return len(self.statistics_dict["anion_atom_list"]) == 1 and anion_atom in self.statistics_dict["anion_atom_list"]
-    
+        return (
+            len(self.statistics_dict["anion_atom_list"]) == 1 and anion_atom in self.statistics_dict["anion_atom_list"]
+        )
+
     def contains_only_one_anion(self, anion):
         if self.statistics_dict is None:
             self.setup_statistic_lists()
@@ -1975,23 +1992,25 @@ class LightStructureEnvironments(MSONable):
         this_indices = [ss["index"] for ss in self._all_nbs_sites]
         other_indices = [ss["index"] for ss in other._all_nbs_sites]
         return is_equal and this_sites == other_sites and this_indices == other_indices
-    
+
     def as_dict(self):
         dec_sites = []
         for nb_site in self._all_nbs_sites:
             s = nb_site["site"]
-            dec_sites.append({
-                "site": PeriodicSite(
-                    species=s.species,
-                    coords=s.frac_coords,
-                    lattice=s.lattice,
-                    to_unit_cell=False,
-                    coords_are_cartesian=False,
-                    properties=s.properties,
-                ).as_dict(),
-                "index": nb_site["index"],
-                "image_cell": [int(ii) for ii in nb_site["image_cell"]],
-            })
+            dec_sites.append(
+                {
+                    "site": PeriodicSite(
+                        species=s.species,
+                        coords=s.frac_coords,
+                        lattice=s.lattice,
+                        to_unit_cell=False,
+                        coords_are_cartesian=False,
+                        properties=s.properties,
+                    ).as_dict(),
+                    "index": nb_site["index"],
+                    "image_cell": [int(ii) for ii in nb_site["image_cell"]],
+                }
+            )
 
         return {
             "@module": type(self).__module__,
@@ -2086,7 +2105,7 @@ class ChemicalEnvironments(MSONable):
 
     def __iter__(self):
         yield from self.coord_geoms.items()
-        
+
     def minimum_geometry(self, symmetry_measure_type=None, max_csm=None):
         """Get the geometry with the minimum continuous symmetry measure."""
 
@@ -2114,7 +2133,7 @@ class ChemicalEnvironments(MSONable):
             return None
 
         return best_key, best_item
-    
+
     def minimum_geometries(self, n=None, symmetry_measure_type=None, max_csm=None):
         """Get geometries sorted by increasing continuous symmetry measure."""
 
@@ -2142,7 +2161,6 @@ class ChemicalEnvironments(MSONable):
 
         # Return (symbol, dict) pairs as before
         return [(key, dct) for _val, key, dct in items]
-
 
     def add_coord_geom(
         self,


### PR DESCRIPTION
## Summary

Major changes:

- Deterministic neighbor ordering
- O(1) lookups instead of linear scans
- Fewer temporary allocations: Reuse lists; avoid building parallel arrays multiple times; prefer list appends over repeated concatenations.
- Precomputation + tighter loops
- Safer normalization
- Serialization robustness
- Minor consistency fixes

## Performance notes
- Fewer sorts
- O(1) lookups for neighbor index mapping instead of O(n) scans inside inner loops
- Reduced allocations in grouping and condition precomputation

## Backward compatibility
- No public API changes
- All behavior is deterministic where previously order could vary across runs/platforms

## Tests
All unit tests for `chemenv/coordination_environments` (same as before)
