### PR TITLE
Update MatPESStaticSet docstring: PBE_54 to PBE_64

### DIFF
--- a/src/pymatgen/io/vasp/sets.py
+++ b/src/pymatgen/io/vasp/sets.py
@@ -1660,9 +1660,9 @@ class MatPESStaticSet(VaspInputSet):
     energies and also electronic structure (DOS). For PES data, force accuracy (and to some extent,
     stress accuracy) is of paramount importance.
 
-    The default POTCAR versions have been updated to PBE_54 from the old PBE set used in the
+    The default POTCAR versions have been updated to PBE_64 from the old PBE set used in the
     MPStaticSet. However, **U values** are still based on PBE. The implicit assumption here is that
-    the PBE_54 and PBE POTCARs are sufficiently similar that the U values fitted to the old PBE
+    the PBE_64 and PBE POTCARs are sufficiently similar that the U values fitted to the old PBE
     functional still applies.
 
     Args:


### PR DESCRIPTION
## Summary
Replace PBE_54 with PBE_64, since I believe this is what MatPESStaticSet uses (see MatPES paper and line below)

https://github.com/materialsproject/pymatgen/blob/682bfd855dd89264b0ff8d6bee4815f8834cc5ac/src/pymatgen/io/vasp/MatPESStaticSet.yaml#L4

I'm not familiar with the codebase so if there's other changes to be made I think it's best for others to take over. Apologies if I'm mistaken here.

Major changes: None

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))


