### PR TITLE
remove `jupyter` from dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,7 +323,6 @@ default-groups = ["dev", "test", "lint", "docs"]
 [dependency-groups]
 dev = [
     "invoke>=2.2.0",
-    "jupyter>=1.1.1",
     "openai>=2.2.0",
     "pre-commit>=4.2.0",
 ]


### PR DESCRIPTION
Added in https://github.com/materialsproject/pymatgen/commit/69deca542b4d28b3e86aee9278b4399800d45372 but I don't see jupyter being used in the codebase (maybe I'm wrong)
