### PR TITLE
Fix unstable entries sorting in `PhaseDiagram` causing intermittent CI failure

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -449,7 +449,9 @@ class PhaseDiagram(MSONable):
         elements = list(self.elements)
         dim = len(elements)
 
-        entries = sorted(self.entries, key=lambda e: e.composition.reduced_composition)
+        entries = sorted(
+            self.entries, key=lambda e: (e.composition.reduced_composition, e.energy_per_atom, str(e.name))
+        )
 
         el_refs: dict[Element, PDEntry] = {}
         min_entries: list[PDEntry] = []


### PR DESCRIPTION
Fix currently intermittent CI failure, cc @Andrew-S-Rosen :
```
    def test_as_from_dict(self):
        # test round-trip for other entry types such as ComputedEntry
        entry = ComputedEntry("H", 0.0, 0.0, entry_id="test")
        pd = PhaseDiagram([entry])
        pd_dict = pd.as_dict()
        pd_roundtrip = PhaseDiagram.from_dict(pd_dict)
        assert pd.all_entries[0].entry_id == pd_roundtrip.all_entries[0].entry_id
        dd = self.pd.as_dict()
        new_pd = PhaseDiagram.from_dict(dd)
        new_pd_dict = new_pd.as_dict()
        assert len(new_pd_dict) == len(dd)
        for k, v in new_pd_dict.items():
>           assert v == dd[k]
E           AssertionError: assert {'all_entries...2), ...], ...} == {'all_entries...2), ...], ...}
E             
E             (pytest_assertion plugin: representation of details failed: /Users/runner/micromamba/envs/pmg/lib/python3.13/site-packages/_pytest/assertion/util.py:494: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all().
E              Probably an object has a faulty __repr__.)
```

I tried to extract the mismatch:
```
E                       AssertionError: Mismatch in computed_data['qhull_entries']

E                         - 4, 296, 302, 308, 31
E                         ?           ^
E                         + 4, 296, 300, 308, 31
E                         ? 
```

Looks like when entries have the same composition, their sorting sort might be unstable