### PR TITLE
docs: fix incorrect method reference in get_phase_separation_energy docstring

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -1025,7 +1025,7 @@ class PhaseDiagram(MSONable):
 
         Args:
             entry (PDEntry): A PDEntry like object
-            **kwargs: Keyword args passed to `get_decomp_and_decomp_energy`
+            **kwargs: Keyword args passed to `get_decomp_and_phase_separation_energy`
                 space_limit (int): The maximum number of competing entries to consider.
                 stable_only (bool): Only use stable materials as competing entries
                 tol (float): The tolerance for convergence of the SLSQP optimization


### PR DESCRIPTION
## Summary
Fix incorrect method reference in docstring for get_phase_separation_energy.

## Problem
The docstring referenced `get_decomp_and_decomp_energy`, which does not exist.

## Fix
Updated the reference to `get_decomp_and_phase_separation_energy`, which is the correct method used in the implementation.

## Checklist
- [x] Documentation-only change