### PR TITLE
docs: document name parameter in TransformedPDEntry.__init__

### DIFF
--- a/src/pymatgen/analysis/phase_diagram.py
+++ b/src/pymatgen/analysis/phase_diagram.py
@@ -224,6 +224,7 @@ class TransformedPDEntry(PDEntry):
         Args:
             entry (PDEntry): Original entry to be transformed.
             sp_mapping ({Composition: DummySpecies}): dictionary mapping Terminal Compositions to Dummy Species.
+            name (str | None): Optional name for the entry. Defaults to the name of the original entry.
         """
         super().__init__(
             entry.composition,


### PR DESCRIPTION
## Summary
Add missing documentation for the `name` parameter in `TransformedPDEntry.__init__`.

## Problem
The constructor accepts a `name` parameter, but it is not documented in the docstring. This differs from `GrandPotPDEntry.__init__`, which follows the same pattern and does document `name`.

## Fix
Added documentation for `name` to align with existing conventions and clarify its usage for users.

## Checklist
- [x] Documentation-only change