### PR TITLE
fix: correctly clear energy_adjustments in clean mode (avoid skipped removals)

### DIFF
--- a/src/pymatgen/analysis/compatibility/mixing_scheme.py
+++ b/src/pymatgen/analysis/compatibility/mixing_scheme.py
@@ -175,8 +175,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         # any corrections added by compat_1 or compat_2.
         if clean:
             for entry in entries:
-                for ea in entry.energy_adjustments:
-                    entry.energy_adjustments.remove(ea)
+                entry.energy_adjustments = []
 
         entries_type_1, entries_type_2 = self._filter_and_sort_entries(entries, verbose=verbose)
 

--- a/src/pymatgen/entries/mixing_scheme.py
+++ b/src/pymatgen/entries/mixing_scheme.py
@@ -175,8 +175,7 @@ class MaterialsProjectDFTMixingScheme(Compatibility):
         # any corrections added by compat_1 or compat_2.
         if clean:
             for entry in entries:
-                for ea in entry.energy_adjustments:
-                    entry.energy_adjustments.remove(ea)
+                entry.energy_adjustments = []
 
         entries_type_1, entries_type_2 = self._filter_and_sort_entries(entries, verbose=verbose)
 

--- a/tests/analysis/compatibility/test_mixing_scheme.py
+++ b/tests/analysis/compatibility/test_mixing_scheme.py
@@ -1569,6 +1569,60 @@ class TestMaterialsProjectDFTMixingSchemeArgs:
         for entry in entries:
             assert entry.correction == 0
 
+    def test_clean_multiple_adjustments(self, mixing_scheme_no_compat):
+        """Regression test: clean=True must remove ALL adjustments when an entry has more
+        than one. A list-mutation-while-iterating bug caused every other adjustment to be
+        skipped, leaving stale corrections when len(energy_adjustments) > 1.
+        """
+        lattice = Lattice.from_parameters(a=1, b=1, c=1, alpha=90, beta=90, gamma=60)
+        # Use the same valid Sn/Br chemical system as test_clean so the mixing scheme
+        # can build its phase diagram without error.
+        entries = [
+            ComputedStructureEntry(
+                Structure(lattice, ["Sn"], [[0, 0, 0]]),
+                0,
+                parameters={"run_type": "GGA"},
+                entry_id="multi-1",
+            ),
+            ComputedStructureEntry(
+                Structure(lattice, ["Br"], [[0, 0, 0]]),
+                0,
+                parameters={"run_type": "GGA"},
+                entry_id="multi-2",
+            ),
+            ComputedStructureEntry(
+                Structure(lattice, ["Sn", "Br", "Br"], [[0, 0, 0], [0.5, 0.5, 0.5], [1, 1, 1]]),
+                0,
+                parameters={"run_type": "GGA"},
+                entry_id="multi-3",
+            ),
+            ComputedStructureEntry(
+                Structure(
+                    lattice,
+                    ["Sn", "Br", "Br", "Br", "Br"],
+                    [[0, 0, 0], [0.2, 0.2, 0.2], [0.4, 0.4, 0.4], [0.7, 0.7, 0.7], [1, 1, 1]],
+                ),
+                0,
+                parameters={"run_type": "R2SCAN"},
+                entry_id="multi-4",
+            ),
+        ]
+
+        # Simulate entries that have already been through compat_1, which can append
+        # multiple adjustments per entry (e.g. oxide + anion + GGA/GGA+U corrections).
+        for entry in entries:
+            entry.energy_adjustments.append(CompositionEnergyAdjustment(-1.0, 1, name="adj-a"))
+            entry.energy_adjustments.append(CompositionEnergyAdjustment(-2.0, 1, name="adj-b"))
+
+        assert all(len(e.energy_adjustments) == 2 for e in entries)
+
+        mixing_scheme_no_compat.process_entries(entries, clean=True)
+
+        for entry in entries:
+            remaining = {ea.name for ea in entry.energy_adjustments}
+            assert "adj-a" not in remaining, f"stale adj-a left on {entry.entry_id}"
+            assert "adj-b" not in remaining, f"stale adj-b left on {entry.entry_id}"
+
     def test_no_run_type(self, mixing_scheme_no_compat):
         """
         If one of the entries doesn't have a run_type attribute, we should get a warning


### PR DESCRIPTION
## Summary
Fixes `clean=True` handling in the mixing scheme logic so all existing `energy_adjustments` are cleared correctly.

## Problem
The previous implementation removed items from `entry.energy_adjustments` while iterating over the same list. When multiple adjustments were present, this caused some entries to be skipped, leaving stale adjustments behind.

This meant `clean=True` could silently fail to fully reset entries before reprocessing.

## Fix
- Replace mutation-during-iteration with direct list reset via `entry.energy_adjustments = []`
- Apply the fix in both `mixing_scheme` modules
- Keep behavior aligned with the existing pattern already used in `Compatibility._process_entry_inplace`

## Tests
- Verified existing `test_clean` still passes
- Added a regression test covering entries with multiple energy adjustments
- Confirmed all pre-existing failures remain unrelated to this change