### PR TITLE
Commit to preserving backwards compatible imports

### DIFF
--- a/src/pymatgen/analysis/adsorption.py
+++ b/src/pymatgen/analysis/adsorption.py
@@ -1,16 +1,9 @@
-"""This module provides classes used to enumerate surface sites and to find
+"""Stub for backwards compatibility.
+
+This module provides classes used to enumerate surface sites and to find
 adsorption sites on slabs.
 """
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.adsorption module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.adsorption import *  # noqa: E402, F403
+from pymatgen.core.adsorption import *  # noqa: F403

--- a/src/pymatgen/analysis/bond_valence.py
+++ b/src/pymatgen/analysis/bond_valence.py
@@ -1,14 +1,8 @@
-"""This module implements classes to perform bond valence analyses."""
+"""Stub for backwards compatibility.
+
+This module implements classes to perform bond valence analyses.
+"""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.bond_valence module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.bond_valence import *  # noqa: E402, F403
+from pymatgen.core.bond_valence import *  # noqa: F403

--- a/src/pymatgen/analysis/elasticity/__init__.py
+++ b/src/pymatgen/analysis/elasticity/__init__.py
@@ -1,13 +1,7 @@
-"""Package for analyzing elastic tensors and properties."""
+"""Stub for backwards compatibility.
+
+Package for analyzing elastic tensors and properties."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.elasticity module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.elasticity import *  # noqa: E402, F403
+from pymatgen.core.elasticity import *  # noqa: F403

--- a/src/pymatgen/analysis/elasticity/elastic.py
+++ b/src/pymatgen/analysis/elasticity/elastic.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides a class used to describe the elastic tensor,
 including methods used to fit the elastic tensor from linear response
 stress-strain data.
@@ -6,12 +7,4 @@ stress-strain data.
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.elasticity.elastic module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.elasticity.elastic import *  # noqa: E402, F403
+from pymatgen.core.elasticity.elastic import *  # noqa: F403

--- a/src/pymatgen/analysis/elasticity/strain.py
+++ b/src/pymatgen/analysis/elasticity/strain.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides classes and methods used to describe deformations and
 strains, including applying those deformations to structure objects and
 generating deformed structure sets for further calculations.
@@ -6,12 +7,4 @@ generating deformed structure sets for further calculations.
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.elasticity.strain module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.elasticity.strain import *  # noqa: E402, F403
+from pymatgen.core.elasticity.strain import *  # noqa: F403

--- a/src/pymatgen/analysis/elasticity/stress.py
+++ b/src/pymatgen/analysis/elasticity/stress.py
@@ -1,16 +1,9 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides the Stress class used to create, manipulate, and
 calculate relevant properties of the stress tensor.
 """
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.elasticity.stress module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.elasticity.stress import *  # noqa: E402, F403
+from pymatgen.core.elasticity.stress import *  # noqa: F403

--- a/src/pymatgen/analysis/energy_models.py
+++ b/src/pymatgen/analysis/energy_models.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module implements a EnergyModel abstract class and some basic
 implementations. Basically, an EnergyModel is any model that returns an
 "energy" for any given structure.
@@ -6,13 +7,4 @@ implementations. Basically, an EnergyModel is any model that returns an
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.energy_models module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.energy_models import *  # noqa: E402, F403
+from pymatgen.core.energy_models import *  # noqa: F403

--- a/src/pymatgen/analysis/ewald.py
+++ b/src/pymatgen/analysis/ewald.py
@@ -1,14 +1,7 @@
-"""This module provides classes for calculating the Ewald sum of a structure."""
+"""Stub for backwards compatibility.
+
+This module provides classes for calculating the Ewald sum of a structure."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.ewald module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.ewald import *  # noqa: E402, F403
+from pymatgen.core.ewald import *  # noqa: F403

--- a/src/pymatgen/analysis/graphs.py
+++ b/src/pymatgen/analysis/graphs.py
@@ -1,14 +1,7 @@
-"""Module for graph representations of crystals and molecules."""
+"""Stub for backwards compatibility.
+
+Module for graph representations of crystals and molecules."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.graphs module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.graphs import *  # noqa: E402, F403
+from pymatgen.core.graphs import *  # noqa: F403

--- a/src/pymatgen/analysis/local_env.py
+++ b/src/pymatgen/analysis/local_env.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides classes to perform analyses of
 the local environments (e.g., finding near neighbors)
 of single sites in molecules and structures.
@@ -6,13 +7,4 @@ of single sites in molecules and structures.
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.local_env module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.local_env import *  # noqa: E402, F403
+from pymatgen.core.local_env import *  # noqa: F403

--- a/src/pymatgen/analysis/molecule_matcher.py
+++ b/src/pymatgen/analysis/molecule_matcher.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides classes to perform fitting of molecule with arbitrary
 atom orders.
 This module is supposed to perform exact comparisons without the atom order
@@ -11,13 +12,4 @@ you can find at https://github.com/charnley/rmsd.
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.molecule_matcher module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.molecule_matcher import *  # noqa: E402, F403
+from pymatgen.core.molecule_matcher import *  # noqa: F403

--- a/src/pymatgen/analysis/molecule_structure_comparator.py
+++ b/src/pymatgen/analysis/molecule_structure_comparator.py
@@ -1,4 +1,5 @@
-"""
+"""Stub for backwards compatibility.
+
 This module provides classes to comparison the structures of the two
 molecule. As long as the two molecule have the same bond connection tables,
 the molecules are deemed to be same. The atom in the two molecule must be
@@ -10,13 +11,4 @@ comparisons without the atom order correspondence prerequisite.
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.molecule_structure_comparator module. This stub will be removed"
-    " v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.molecule_structure_comparator import *  # noqa: E402, F403
+from pymatgen.core.molecule_structure_comparator import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_analyzer.py
+++ b/src/pymatgen/analysis/structure_analyzer.py
@@ -1,14 +1,7 @@
-"""This module provides classes to perform topological analyses of structures."""
+"""Stub for backwards compatibility.
+
+This module provides classes to perform topological analyses of structures."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_analyzer module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.structure_analyzer import *  # noqa: E402, F403
+from pymatgen.core.structure_analyzer import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_matcher.py
+++ b/src/pymatgen/analysis/structure_matcher.py
@@ -1,14 +1,7 @@
-"""This module provides classes to perform fitting of structures."""
+"""Stub for backwards compatibility.
+
+This module provides classes to perform fitting of structures."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_matcher module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
-from pymatgen.core.structure_matcher import *  # noqa: E402, F403
+from pymatgen.core.structure_matcher import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_prediction/__init__.py
+++ b/src/pymatgen/analysis/structure_prediction/__init__.py
@@ -1,13 +1,7 @@
-"""Utilities to predict new structures."""
+"""Stub for backwards compatibility.
+
+Utilities to predict new structures."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_prediction module. This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.structure_prediction import *  # noqa: E402, F403
+from pymatgen.core.structure_prediction import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/dopant_predictor.py
@@ -1,14 +1,7 @@
-"""Predicting potential dopants."""
+"""Stub for backwards compatibility.
+
+Predicting potential dopants."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_prediction.dopant_predictor module. "
-    "This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.structure_prediction.dopant_predictor import *  # noqa: E402, F403
+from pymatgen.core.structure_prediction.dopant_predictor import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_prediction/substitution_probability.py
+++ b/src/pymatgen/analysis/structure_prediction/substitution_probability.py
@@ -1,14 +1,7 @@
-"""This module provides classes for representing species substitution probabilities."""
+"""Stub for backwards compatibility.
+
+This module provides classes for representing species substitution probabilities."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_prediction.substitution_probability module. "
-    "This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.structure_prediction.substitution_probability import *  # noqa: E402, F403
+from pymatgen.core.structure_prediction.substitution_probability import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_prediction/substitutor.py
+++ b/src/pymatgen/analysis/structure_prediction/substitutor.py
@@ -1,14 +1,7 @@
-"""This module provides classes for predicting new structures from existing ones."""
+"""Stub for backwards compatibility.
+
+This module provides classes for predicting new structures from existing ones."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_prediction.substitutor module. "
-    "This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.structure_prediction.substitutor import *  # noqa: E402, F403
+from pymatgen.core.structure_prediction.substitutor import *  # noqa: F403

--- a/src/pymatgen/analysis/structure_prediction/volume_predictor.py
+++ b/src/pymatgen/analysis/structure_prediction/volume_predictor.py
@@ -1,14 +1,7 @@
-"""Predict volumes of crystal structures."""
+"""Stub for backwards compatibility.
+
+Predict volumes of crystal structures."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "This module has been moved to the pymatgen.core.structure_prediction.volume_predictor module. "
-    "This stub will be removed v2027.1. ",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from pymatgen.core.structure_prediction.volume_predictor import *  # noqa: E402, F403
+from pymatgen.core.structure_prediction.volume_predictor import *  # noqa: F403

--- a/src/pymatgen/entries/__init__.py
+++ b/src/pymatgen/entries/__init__.py
@@ -1,4 +1,6 @@
-"""Entries are containers for calculated information, which is used in
+"""Stub entries from pymatgen-core for backwards compatibility.
+
+Entries are containers for calculated information, which is used in
 many analyses. This module contains entry related tools and implements
 the base Entry class, which is the basic entity that can be used to
 store calculated information. Other Entry classes such as ComputedEntry
@@ -16,12 +18,3 @@ __maintainer__ = "Shyue Ping Ong"
 __email__ = "shyuep@gmail.com"
 __status__ = "Production"
 __date__ = "Mar 03, 2020"
-
-import warnings
-
-warnings.warn(
-    "Entry, ComputedEntry and ComputedStructureEntry have been moved to pymatgen.core.entries module. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/pymatgen/entries/compatibility.py
+++ b/src/pymatgen/entries/compatibility.py
@@ -1,16 +1,9 @@
-"""This module implements Compatibility corrections for mixing runs of different
+"""Stub compatibility from pymatgen-core for backwards compatibility.
+
+This module implements Compatibility corrections for mixing runs of different
 functionals.
 """
 
 from __future__ import annotations
 
-import warnings
-
 from pymatgen.analysis.compatibility import *  # noqa: F403
-
-warnings.warn(
-    "All compatibility have been moved to the pymatgen.analysis.compatibility module. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/pymatgen/entries/computed_entries.py
+++ b/src/pymatgen/entries/computed_entries.py
@@ -1,4 +1,6 @@
-"""This module implements equivalents of the basic ComputedEntry objects, which
+"""Stub computed_entries from pymatgen-core for backwards compatibility.
+
+This module implements equivalents of the basic ComputedEntry objects, which
 is the basic entity that can be used to perform many analyses. ComputedEntries
 contain calculated information, typically from VASP or other electronic
 structure codes. For example, ComputedEntries can be used as inputs for phase
@@ -7,14 +9,5 @@ diagram analysis.
 
 from __future__ import annotations
 
-import warnings
-
 from pymatgen.analysis.compatibility.computed_entries import *  # noqa: F403
 from pymatgen.core.entries import *  # noqa: F403
-
-warnings.warn(
-    "Entry, ComputedEntry and ComputedStructureEntry have been moved to pymatgen.core.entries module. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/pymatgen/entries/correction_calculator.py
+++ b/src/pymatgen/entries/correction_calculator.py
@@ -1,16 +1,9 @@
-"""This module calculates corrections for the species listed below, fitted to the experimental and computed
+"""Stub correction_calculator from pymatgen-core for backwargs compatibility.
+
+This module calculates corrections for the species listed below, fitted to the experimental and computed
 entries given to the CorrectionCalculator constructor.
 """
 
 from __future__ import annotations
 
-import warnings
-
 from pymatgen.analysis.compatibility.correction_calculator import *  # noqa: F403
-
-warnings.warn(
-    "All entry_tools have been moved to the pymatgen.analysis.compatibility.entry_tools module. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/pymatgen/entries/entry_tools.py
+++ b/src/pymatgen/entries/entry_tools.py
@@ -1,16 +1,9 @@
-"""This module implements functions to perform various useful operations on
+"""Stub entry_tools from pymatgen-core for backwargs compatibility.
+
+This module implements functions to perform various useful operations on
 entries, such as grouping entries by structure.
 """
 
 from __future__ import annotations
 
-import warnings
-
 from pymatgen.analysis.compatibility.entry_tools import *  # noqa: F403
-
-warnings.warn(
-    "All CorrectionCalculators have been moved to the pymatgen.analysis.compatibility.correction_calculator package. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/pymatgen/entries/exp_entries.py
+++ b/src/pymatgen/entries/exp_entries.py
@@ -1,14 +1,8 @@
-"""This module defines Entry classes for containing experimental data."""
+"""Stub exp_entries from pymatgen-core for backwargs compatibility.
+
+This module defines Entry classes for containing experimental data.
+"""
 
 from __future__ import annotations
 
-import warnings
-
 from pymatgen.analysis.compatibility.exp_entries import *  # noqa: F403
-
-warnings.warn(
-    "All exp_entries have been moved to the pymatgen.analysis.compatibility.exp_entries module. "
-    "This stub will be removed v2027.1.",
-    DeprecationWarning,
-    stacklevel=2,
-)


### PR DESCRIPTION
Removes deprecation warnings for import shims for critical, base infrastructure in pymatgen. Commits to preserving backwards compatible, if aesthetically unappealing, imports

These classes/functionalities have existed under the same imports for many years at this point, removing those imports would constitute a severely breaking change

This would also lead to a huge impact on database users, since their monty-deocded classes will break without them completely migrating collections