### PR TITLE
Publish Sphinx objects.inv with GitHub Pages docs

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -56,6 +56,7 @@ jobs:
           rm apidoc/*.rst
           mv html/pymatgen*.html .
           mv html/modules.html .
+          mv html/objects.inv .
           cp -r html/_static _static
           touch .nojekyll
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,4 @@ kramdown:
 
 include:
   - _static
+  - objects.inv


### PR DESCRIPTION
## Summary
The docs build already generates `html/objects.inv`, but the GitHub Pages workflow currently only moves the HTML pages, `modules.html`, and `_static` into the published docs tree. This two-line PR also publishes `objects.inv` so downstream projects can use pymatgen with `intersphinx`.
