### PR TITLE
[codex] Fix outer test fixture paths

### DIFF
--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -20,7 +20,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/connectivity/test_structure_connectivity.py
+++ b/tests/analysis/chemenv/connectivity/test_structure_connectivity.py
@@ -9,7 +9,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
     LightStructureEnvironments,
     StructureEnvironments,
 )
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
@@ -19,7 +19,8 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
     symmetry_measure,
 )
 from pymatgen.core.structure import Lattice, Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_read_write.py
+++ b/tests/analysis/chemenv/coordination_environments/test_read_write.py
@@ -21,7 +21,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 )
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
+++ b/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
@@ -17,7 +17,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
     StructureEnvironments,
 )
 from pymatgen.core import Species, Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_voronoi.py
+++ b/tests/analysis/chemenv/coordination_environments/test_voronoi.py
@@ -5,7 +5,8 @@ import numpy as np
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_weights.py
+++ b/tests/analysis/chemenv/coordination_environments/test_weights.py
@@ -15,7 +15,8 @@ from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies impo
     SelfCSMNbSetWeight,
 )
 from pymatgen.analysis.chemenv.coordination_environments.structure_environments import StructureEnvironments
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/utils/test_chemenv_config.py
+++ b/tests/analysis/chemenv/utils/test_chemenv_config.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pymatgen.analysis.chemenv.utils.chemenv_config import ChemEnvConfig
 from pymatgen.core import SETTINGS
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/compatibility/test_compatibility.py
+++ b/tests/analysis/compatibility/test_compatibility.py
@@ -33,7 +33,7 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.entries import ComputedEntry, ComputedStructureEntry, ConstantEnergyAdjustment
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 if TYPE_CHECKING:
     from pymatgen.util.typing import CompositionLike

--- a/tests/analysis/compatibility/test_correction_calculator.py
+++ b/tests/analysis/compatibility/test_correction_calculator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from pymatgen.analysis.compatibility.correction_calculator import CorrectionCalculator
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/entries/correction_calculator"
 

--- a/tests/analysis/compatibility/test_entry_tools.py
+++ b/tests/analysis/compatibility/test_entry_tools.py
@@ -14,7 +14,8 @@ from pymatgen.analysis.compatibility.entry_tools import (
 )
 from pymatgen.core import Element
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/entries"
 

--- a/tests/analysis/compatibility/test_exp_entries.py
+++ b/tests/analysis/compatibility/test_exp_entries.py
@@ -8,7 +8,7 @@ from monty.json import MontyDecoder
 from pytest import approx
 
 from pymatgen.analysis.compatibility.exp_entries import ExpEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 pytestmark = pytest.mark.skipif(not os.path.exists(f"{TEST_FILES_DIR}/entries"), reason="Requires test files")
 

--- a/tests/analysis/compatibility/test_mixing_scheme.py
+++ b/tests/analysis/compatibility/test_mixing_scheme.py
@@ -116,7 +116,7 @@ from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.entries.computed_entries import CompositionEnergyAdjustment, ComputedEntry, ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Ryan Kingsbury"
 __copyright__ = "Copyright 2019-2021, The Materials Project"

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -14,7 +14,7 @@ from pymatgen.analysis.magnetism import (
     magnetic_deformation,
 )
 from pymatgen.core import Element, Lattice, Species, Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -5,7 +5,7 @@ from pytest import approx
 
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/analysis/magnetism/test_jahnteller.py
+++ b/tests/analysis/magnetism/test_jahnteller.py
@@ -5,7 +5,7 @@ from pytest import approx
 
 from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species
 from pymatgen.core import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 class TestJahnTeller:

--- a/tests/analysis/solar/test_slme.py
+++ b/tests/analysis/solar/test_slme.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.solar.slme import optics, slme
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/solar"
 

--- a/tests/analysis/test_bond_dissociation.py
+++ b/tests/analysis/test_bond_dissociation.py
@@ -6,7 +6,7 @@ import pytest
 from monty.serialization import loadfn
 
 from pymatgen.analysis.bond_dissociation import BondDissociationEnergies
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/bond_dissociation"
 

--- a/tests/analysis/test_cost.py
+++ b/tests/analysis/test_cost.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.cost import CostAnalyzer, CostDBCSV, CostDBElements
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/cost"
 

--- a/tests/analysis/test_dimensionality.py
+++ b/tests/analysis/test_dimensionality.py
@@ -15,7 +15,8 @@ from pymatgen.analysis.dimensionality import (
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import CrystalNN
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 
 class TestLarsenDimensionality(MatSciTest):

--- a/tests/analysis/test_fragmenter.py
+++ b/tests/analysis/test_fragmenter.py
@@ -8,7 +8,8 @@ from pymatgen.analysis.fragmenter import Fragmenter
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core.structure import Molecule
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Samuel Blau"
 __email__ = "samblau1@gmail.com"

--- a/tests/analysis/test_functional_groups.py
+++ b/tests/analysis/test_functional_groups.py
@@ -8,7 +8,7 @@ from pymatgen.analysis.functional_groups import FunctionalGroupExtractor
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core.structure import Molecule
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/functional_groups"
 

--- a/tests/analysis/test_lobster_env.py
+++ b/tests/analysis/test_lobster_env.py
@@ -13,7 +13,7 @@ from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.cohp import Cohp, CompleteCohp
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.lobster import Charge, Icohplist
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Janine George"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/tests/analysis/test_optics.py
+++ b/tests/analysis/test_optics.py
@@ -4,7 +4,7 @@ import pytest
 
 from pymatgen.analysis.optics import DielectricAnalysis
 from pymatgen.io.vasp import Vasprun
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/vasp/outputs"
 

--- a/tests/analysis/test_piezo_sensitivity.py
+++ b/tests/analysis/test_piezo_sensitivity.py
@@ -17,7 +17,8 @@ from pymatgen.analysis.piezo_sensitivity import (
     rand_piezo,
 )
 from pymatgen.io.phonopy import get_phonopy_structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 try:
     from phonopy import Phonopy

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -18,7 +18,8 @@ from pymatgen.analysis.pourbaix_diagram import (
 from pymatgen.core.composition import Composition
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/pourbaix_diagram"
 

--- a/tests/analysis/test_quasirrho.py
+++ b/tests/analysis/test_quasirrho.py
@@ -6,7 +6,7 @@ from pytest import approx
 from pymatgen.analysis.quasirrho import QuasiRRHO, get_avg_mom_inertia
 from pymatgen.io.gaussian import GaussianOutput
 from pymatgen.io.qchem.outputs import QCOutput
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/quasirrho"
 

--- a/tests/analysis/test_surface_analysis.py
+++ b/tests/analysis/test_surface_analysis.py
@@ -9,7 +9,8 @@ from sympy import Number, Symbol
 
 from pymatgen.analysis.surface_analysis import NanoscaleStability, SlabEntry, SurfaceEnergyPlotter, WorkFunctionAnalyzer
 from pymatgen.entries.computed_entries import ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Richard Tran"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/analysis/test_transition_state.py
+++ b/tests/analysis/test_transition_state.py
@@ -7,7 +7,8 @@ from matplotlib import pyplot as plt
 from numpy.testing import assert_allclose
 
 from pymatgen.analysis.transition_state import NEBAnalysis, combine_neb_plots
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 """
 TODO: Modify unittest doc.

--- a/tests/analysis/test_wulff.py
+++ b/tests/analysis/test_wulff.py
@@ -8,7 +8,8 @@ from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Zihan Xu, Richard Tran, Balachandran Radhakrishnan"
 __copyright__ = "Copyright 2013, The Materials Virtual Lab"

--- a/tests/analysis/topological/test_spillage.py
+++ b/tests/analysis/topological/test_spillage.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.topological.spillage import SOCSpillage
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/topological"
 

--- a/tests/apps/battery/test_analyzer.py
+++ b/tests/apps/battery/test_analyzer.py
@@ -5,7 +5,8 @@ from pytest import approx
 
 from pymatgen.apps.battery.analyzer import BatteryAnalyzer
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 
 class TestBatteryAnalyzer(MatSciTest):

--- a/tests/apps/battery/test_conversion_battery.py
+++ b/tests/apps/battery/test_conversion_battery.py
@@ -7,7 +7,7 @@ from pytest import approx
 
 from pymatgen.apps.battery.conversion_battery import ConversionElectrode, ConversionVoltagePair
 from pymatgen.core.composition import Composition
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_insertion_battery.py
+++ b/tests/apps/battery/test_insertion_battery.py
@@ -7,7 +7,7 @@ from pytest import approx
 
 from pymatgen.apps.battery.insertion_battery import InsertionElectrode, InsertionVoltagePair
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_plotter.py
+++ b/tests/apps/battery/test_plotter.py
@@ -9,7 +9,7 @@ from pymatgen.apps.battery.insertion_battery import InsertionElectrode
 from pymatgen.apps.battery.plotter import VoltageProfilePlotter
 from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/borg/test_hive.py
+++ b/tests/apps/borg/test_hive.py
@@ -7,7 +7,8 @@ from pytest import approx
 
 from pymatgen.apps.borg.hive import SimpleVaspToComputedEntryDrone, VaspToComputedEntryDrone
 from pymatgen.entries.computed_entries import ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR, VASP_OUT_DIR
+from pymatgen.util.testing import VASP_OUT_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/borg"
 

--- a/tests/apps/borg/test_queen.py
+++ b/tests/apps/borg/test_queen.py
@@ -4,7 +4,7 @@ from pytest import approx
 
 from pymatgen.apps.borg.hive import VaspToComputedEntryDrone
 from pymatgen.apps.borg.queen import BorgQueen
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/cli/test_pmg_analyze.py
+++ b/tests/cli/test_pmg_analyze.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from pymatgen.cli import pmg
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 def test_pmg_analyze():

--- a/tests/cli/test_pmg_structure.py
+++ b/tests/cli/test_pmg_structure.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from pymatgen.cli import pmg
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 def test_pmg_structure():


### PR DESCRIPTION
## Summary
- switch outer-repo tests that read fixture data to use `tests.testing.TEST_FILES_DIR`
- keep `MatSciTest`, `VASP_OUT_DIR`, and related core testing helpers on `pymatgen.util.testing`
- restore outer test fixture resolution after the repo split so outer `analysis`, `apps`, and `cli` tests use outer `test-files`

## Root Cause
After the repo split, `pymatgen.util.testing.TEST_FILES_DIR` resolves to `pymatgen-core/test-files`. Some outer-repo tests still imported that variable for fixture paths, so they started looking for outer analysis/app fixtures inside `pymatgen-core/test-files`, which does not contain the corresponding outer fixture layout.

## Validation
- `uv run pytest tests/analysis/chemenv/connectivity/test_connected_components.py::TestConnectedComponent::test_coordination_sequences -q`
- `uv run pytest tests/analysis -x`
- `uv run pytest tests/vis -x`
- `uv run pytest tests/cli -x`
- `uv run pytest tests/apps -x`

## Question
One follow-up design question came up while fixing this:
Should the outer-repo fixture data eventually be migrated fully into `pymatgen-core`, or is the current split architecture the intended long-term layout, with outer tests continuing to use outer `tests/testing.py` and outer `test-files`?
