### PR TITLE
Speed up pmg CLI startup with lazy imports

### DIFF
--- a/src/pymatgen/cli/pmg.py
+++ b/src/pymatgen/cli/pmg.py
@@ -6,23 +6,25 @@ from __future__ import annotations
 
 import argparse
 import itertools
+from importlib import import_module
 from typing import TYPE_CHECKING
 
 from tabulate import tabulate, tabulate_formats
-
-from pymatgen.cli.pmg_analyze import analyze
-from pymatgen.cli.pmg_config import configure_pmg
-from pymatgen.cli.pmg_plot import plot
-from pymatgen.cli.pmg_potcar import generate_potcar
-from pymatgen.cli.pmg_structure import analyze_structures
-from pymatgen.core import SETTINGS
-from pymatgen.core.structure import Structure
-from pymatgen.io.vasp import Incar, Potcar
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from collections.abc import Sequence
     from typing import Any
+
+
+def _lazy_func(module_name: str, func_name: str):
+    """Lazily import a CLI handler the first time it is invoked."""
+
+    def _runner(args: Namespace):
+        func = getattr(import_module(module_name), func_name)
+        return func(args)
+
+    return _runner
 
 
 def parse_view(args: Namespace) -> int:
@@ -31,6 +33,7 @@ def parse_view(args: Namespace) -> int:
     Args:
         args: Args from command.
     """
+    from pymatgen.core.structure import Structure
     from pymatgen.vis.structure_vtk import StructureVis
 
     excluded_bonding_elements = args.exclude_bonding[0].split(",") if args.exclude_bonding else []
@@ -47,6 +50,8 @@ def diff_incar(args: Namespace) -> int:
     Args:
         args: Args from command.
     """
+    from pymatgen.io.vasp.inputs import Incar
+
     filepath1 = args.incars[0]
     filepath2 = args.incars[1]
     incar1 = Incar.from_file(filepath1)
@@ -156,7 +161,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         help="Suffix to append to a backup of .pmgrc.yaml when changing this file. "
         "Defaults to '.bak'. Set to '' to disable.",
     )
-    parser_config.set_defaults(func=configure_pmg)
+    parser_config.set_defaults(func=_lazy_func("pymatgen.cli.pmg_config", "configure_pmg"))
 
     # `pmg analyze`
     parser_analyze = subparsers.add_parser("analyze", help="VASP calculation analysis tools.")
@@ -223,7 +228,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         default="energy_per_atom",
         help="Sort criteria. Defaults to energy / atom.",
     )
-    parser_analyze.set_defaults(func=analyze)
+    parser_analyze.set_defaults(func=_lazy_func("pymatgen.cli.pmg_analyze", "analyze"))
 
     # `pmg query`
     parser_query = subparsers.add_parser("query", help="Search for structures and data from the Materials Project.")
@@ -337,7 +342,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         type=str,
         help="Save plot to file instead of displaying.",
     )
-    parser_plot.set_defaults(func=plot)
+    parser_plot.set_defaults(func=_lazy_func("pymatgen.cli.pmg_plot", "plot"))
 
     # `pmg structure`
     parser_structure = subparsers.add_parser("structure", help="Structure conversion and analysis tools.")
@@ -394,7 +399,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         "Center Species-Ligand Species=max_dist, e.g. H-O=0.5.",
     )
 
-    parser_structure.set_defaults(func=analyze_structures)
+    parser_structure.set_defaults(func=_lazy_func("pymatgen.cli.pmg_structure", "analyze_structures"))
 
     # `pmg view`
     parser_view = subparsers.add_parser("view", help="Visualize structures")
@@ -429,8 +434,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         "--functional",
         dest="functional",
         type=str,
-        choices=sorted(Potcar.FUNCTIONAL_CHOICES),
-        default=SETTINGS.get("PMG_DEFAULT_FUNCTIONAL", "PBE"),
+        default=None,
         help="Functional to use. Unless otherwise stated (e.g., US), refers to PAW psuedopotential.",
     )
     group_potcar = parser_potcar.add_mutually_exclusive_group(required=True)
@@ -450,7 +454,7 @@ def main(argv: Sequence[str] | None = None) -> Any:
         type=str,
         help="Dirname to find and generate from POTCAR.spec.",
     )
-    parser_potcar.set_defaults(func=generate_potcar)
+    parser_potcar.set_defaults(func=_lazy_func("pymatgen.cli.pmg_potcar", "generate_potcar"))
 
     try:
         import argcomplete  # TODO: this is not declared anywhere

--- a/src/pymatgen/cli/pmg_analyze.py
+++ b/src/pymatgen/cli/pmg_analyze.py
@@ -10,10 +10,6 @@ from typing import TYPE_CHECKING
 
 from tabulate import tabulate
 
-from pymatgen.apps.borg.hive import SimpleVaspToComputedEntryDrone, VaspToComputedEntryDrone
-from pymatgen.apps.borg.queen import BorgQueen
-from pymatgen.io.vasp import Outcar
-
 if TYPE_CHECKING:
     from argparse import Namespace
 
@@ -51,6 +47,9 @@ def get_energies(
     if verbose:
         log_fmt = "%(relativeCreated)d msecs : %(message)s"
         logger.basicConfig(level=logging.INFO, format=log_fmt)
+
+    from pymatgen.apps.borg.hive import SimpleVaspToComputedEntryDrone, VaspToComputedEntryDrone
+    from pymatgen.apps.borg.queen import BorgQueen
 
     if quick:
         drone: VaspToComputedEntryDrone = SimpleVaspToComputedEntryDrone(inc_structure=True)
@@ -114,6 +113,8 @@ def get_magnetizations(dirc: str, ion_list: list[int]) -> int:
     Returns:
         int: 0 if successful.
     """
+    from pymatgen.io.vasp.outputs import Outcar
+
     data = []
     max_row = 0
     for parent, _subdirs, files in os.walk(dirc):

--- a/src/pymatgen/cli/pmg_plot.py
+++ b/src/pymatgen/cli/pmg_plot.py
@@ -8,13 +8,6 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 
-from pymatgen.analysis.diffraction.xrd import XRDCalculator
-from pymatgen.core.structure import Structure
-from pymatgen.electronic_structure.plotter import DosPlotter
-from pymatgen.io.vasp import Chgcar, Vasprun
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.util.plotting import pretty_plot
-
 if TYPE_CHECKING:
     from argparse import Namespace
 
@@ -25,6 +18,9 @@ def get_dos_plot(args: Namespace) -> plt.Axes:
     Args:
         args (Namespace): Args from argparse.
     """
+    from pymatgen.electronic_structure.plotter import DosPlotter
+    from pymatgen.io.vasp.outputs import Vasprun
+
     vasp_run = Vasprun(args.dos_file)
     dos = vasp_run.complete_dos
 
@@ -61,6 +57,10 @@ def get_chgint_plot(args: Namespace, ax: plt.Axes | None = None) -> plt.Axes:
     Returns:
         plt.Axes: Matplotlib Axes object.
     """
+    from pymatgen.io.vasp.outputs import Chgcar
+    from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+    from pymatgen.util.plotting import pretty_plot
+
     chgcar = Chgcar.from_file(args.chgcar_file)
     struct = chgcar.structure
 
@@ -88,6 +88,9 @@ def get_xrd_plot(args: Namespace) -> plt.Axes:
     Args:
         args (Namespace): Args from argparse
     """
+    from pymatgen.analysis.diffraction.xrd import XRDCalculator
+    from pymatgen.core.structure import Structure
+
     struct = Structure.from_file(args.xrd_structure_file)
     calculator = XRDCalculator()
     return calculator.get_plot(struct)

--- a/src/pymatgen/cli/pmg_potcar.py
+++ b/src/pymatgen/cli/pmg_potcar.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from pymatgen.io.vasp import Potcar
-
 if TYPE_CHECKING:
     from argparse import Namespace
     from collections.abc import Callable
@@ -35,6 +33,8 @@ def gen_potcar(dirname: str, filename: str) -> None:
         dirname (str): Directory name.
         filename (str): Filename in directory.
     """
+    from pymatgen.io.vasp.inputs import Potcar
+
     if filename == "POTCAR.spec":
         fullpath = os.path.join(dirname, filename)
         with open(fullpath, encoding="utf-8") as file:
@@ -50,11 +50,19 @@ def generate_potcar(args: Namespace) -> None:
     Args:
         args (Namespace): Args from argparse.
     """
+    from pymatgen.core import SETTINGS
+    from pymatgen.io.vasp.inputs import Potcar
+
+    functional = args.functional or SETTINGS.get("PMG_DEFAULT_FUNCTIONAL", "PBE")
+
     if args.recursive:
         proc_dir(args.recursive, gen_potcar)
     elif args.symbols:
         try:
-            p = Potcar(args.symbols, functional=args.functional)
+            if functional not in Potcar.FUNCTIONAL_CHOICES:
+                raise ValueError(f"Invalid functional {functional!r}. Choose from: {sorted(Potcar.FUNCTIONAL_CHOICES)}")
+
+            p = Potcar(args.symbols, functional=functional)
             p.write_file("POTCAR")
         except Exception as exc:
             print(f"An error has occurred: {exc}")

--- a/src/pymatgen/cli/pmg_structure.py
+++ b/src/pymatgen/cli/pmg_structure.py
@@ -8,10 +8,6 @@ from typing import TYPE_CHECKING
 
 from tabulate import tabulate
 
-from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
-from pymatgen.core.structure import Structure
-from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-
 if TYPE_CHECKING:
     from argparse import Namespace
 
@@ -29,6 +25,8 @@ def convert_fmt(args: Namespace) -> None:
     Args:
         args (Namespace): Args from argparse.
     """
+    from pymatgen.core.structure import Structure
+
     if len(args.filenames) != 2:
         print("File format conversion takes in only two filenames.")
     struct = Structure.from_file(args.filenames[0], primitive="prim" in args.filenames[1].lower())
@@ -41,6 +39,9 @@ def analyze_symmetry(args: Namespace) -> None:
     Args:
         args (Namespace): Args from argparse.
     """
+    from pymatgen.core.structure import Structure
+    from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
     tolerance = args.symmetry
     table_rows = []
     for filename in args.filenames:
@@ -57,6 +58,8 @@ def analyze_localenv(args: Namespace) -> None:
     Args:
         args (Namespace): Args for argparse.
     """
+    from pymatgen.core.structure import Structure
+
     bonds = {}
     for bond in args.localenv:
         tokens = bond.split("=")
@@ -85,6 +88,9 @@ def compare_structures(args: Namespace) -> None:
     Args:
         args (Namespace): Args from argparse.
     """
+    from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
+    from pymatgen.core.structure import Structure
+
     filenames = args.filenames
     if len(filenames) < 2:
         raise SystemExit("You need more than one structure to compare!")

--- a/tests/analysis/chemenv/connectivity/test_connected_components.py
+++ b/tests/analysis/chemenv/connectivity/test_connected_components.py
@@ -20,7 +20,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.sites import PeriodicSite
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/connectivity/test_structure_connectivity.py
+++ b/tests/analysis/chemenv/connectivity/test_structure_connectivity.py
@@ -9,7 +9,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
     LightStructureEnvironments,
     StructureEnvironments,
 )
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
+++ b/tests/analysis/chemenv/coordination_environments/test_coordination_geometry_finder.py
@@ -19,7 +19,8 @@ from pymatgen.analysis.chemenv.coordination_environments.coordination_geometry_f
     symmetry_measure,
 )
 from pymatgen.core.structure import Lattice, Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_read_write.py
+++ b/tests/analysis/chemenv/coordination_environments/test_read_write.py
@@ -21,7 +21,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
 )
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
+++ b/tests/analysis/chemenv/coordination_environments/test_structure_environments.py
@@ -17,7 +17,8 @@ from pymatgen.analysis.chemenv.coordination_environments.structure_environments 
     StructureEnvironments,
 )
 from pymatgen.core import Species, Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_voronoi.py
+++ b/tests/analysis/chemenv/coordination_environments/test_voronoi.py
@@ -5,7 +5,8 @@ import numpy as np
 from pymatgen.analysis.chemenv.coordination_environments.voronoi import DetailedVoronoiContainer
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/coordination_environments/test_weights.py
+++ b/tests/analysis/chemenv/coordination_environments/test_weights.py
@@ -15,7 +15,8 @@ from pymatgen.analysis.chemenv.coordination_environments.chemenv_strategies impo
     SelfCSMNbSetWeight,
 )
 from pymatgen.analysis.chemenv.coordination_environments.structure_environments import StructureEnvironments
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/chemenv/utils/test_chemenv_config.py
+++ b/tests/analysis/chemenv/utils/test_chemenv_config.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pymatgen.analysis.chemenv.utils.chemenv_config import ChemEnvConfig
 from pymatgen.core import SETTINGS
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "waroquiers"
 

--- a/tests/analysis/compatibility/test_compatibility.py
+++ b/tests/analysis/compatibility/test_compatibility.py
@@ -33,7 +33,7 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.entries import ComputedEntry, ComputedStructureEntry, ConstantEnergyAdjustment
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 if TYPE_CHECKING:
     from pymatgen.util.typing import CompositionLike

--- a/tests/analysis/compatibility/test_correction_calculator.py
+++ b/tests/analysis/compatibility/test_correction_calculator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from pymatgen.analysis.compatibility.correction_calculator import CorrectionCalculator
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/entries/correction_calculator"
 

--- a/tests/analysis/compatibility/test_entry_tools.py
+++ b/tests/analysis/compatibility/test_entry_tools.py
@@ -14,7 +14,8 @@ from pymatgen.analysis.compatibility.entry_tools import (
 )
 from pymatgen.core import Element
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/entries"
 

--- a/tests/analysis/compatibility/test_exp_entries.py
+++ b/tests/analysis/compatibility/test_exp_entries.py
@@ -8,7 +8,7 @@ from monty.json import MontyDecoder
 from pytest import approx
 
 from pymatgen.analysis.compatibility.exp_entries import ExpEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 pytestmark = pytest.mark.skipif(not os.path.exists(f"{TEST_FILES_DIR}/entries"), reason="Requires test files")
 

--- a/tests/analysis/compatibility/test_mixing_scheme.py
+++ b/tests/analysis/compatibility/test_mixing_scheme.py
@@ -116,7 +116,7 @@ from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.entries.computed_entries import CompositionEnergyAdjustment, ComputedEntry, ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Ryan Kingsbury"
 __copyright__ = "Copyright 2019-2021, The Materials Project"

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -14,7 +14,7 @@ from pymatgen.analysis.magnetism import (
     magnetic_deformation,
 )
 from pymatgen.core import Element, Lattice, Species, Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -5,7 +5,7 @@ from pytest import approx
 
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 

--- a/tests/analysis/magnetism/test_jahnteller.py
+++ b/tests/analysis/magnetism/test_jahnteller.py
@@ -5,7 +5,7 @@ from pytest import approx
 
 from pymatgen.analysis.magnetism.jahnteller import JahnTellerAnalyzer, Species
 from pymatgen.core import Structure
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 class TestJahnTeller:

--- a/tests/analysis/solar/test_slme.py
+++ b/tests/analysis/solar/test_slme.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.solar.slme import optics, slme
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/solar"
 

--- a/tests/analysis/test_bond_dissociation.py
+++ b/tests/analysis/test_bond_dissociation.py
@@ -6,7 +6,7 @@ import pytest
 from monty.serialization import loadfn
 
 from pymatgen.analysis.bond_dissociation import BondDissociationEnergies
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/bond_dissociation"
 

--- a/tests/analysis/test_cost.py
+++ b/tests/analysis/test_cost.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.cost import CostAnalyzer, CostDBCSV, CostDBElements
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/cost"
 

--- a/tests/analysis/test_dimensionality.py
+++ b/tests/analysis/test_dimensionality.py
@@ -15,7 +15,8 @@ from pymatgen.analysis.dimensionality import (
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import CrystalNN
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 
 class TestLarsenDimensionality(MatSciTest):

--- a/tests/analysis/test_fragmenter.py
+++ b/tests/analysis/test_fragmenter.py
@@ -8,7 +8,8 @@ from pymatgen.analysis.fragmenter import Fragmenter
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core.structure import Molecule
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Samuel Blau"
 __email__ = "samblau1@gmail.com"

--- a/tests/analysis/test_functional_groups.py
+++ b/tests/analysis/test_functional_groups.py
@@ -8,7 +8,7 @@ from pymatgen.analysis.functional_groups import FunctionalGroupExtractor
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN
 from pymatgen.core.structure import Molecule
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/functional_groups"
 

--- a/tests/analysis/test_lobster_env.py
+++ b/tests/analysis/test_lobster_env.py
@@ -13,7 +13,7 @@ from pymatgen.core.structure import Structure
 from pymatgen.electronic_structure.cohp import Cohp, CompleteCohp
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.lobster import Charge, Icohplist
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Janine George"
 __copyright__ = "Copyright 2021, The Materials Project"

--- a/tests/analysis/test_optics.py
+++ b/tests/analysis/test_optics.py
@@ -4,7 +4,7 @@ import pytest
 
 from pymatgen.analysis.optics import DielectricAnalysis
 from pymatgen.io.vasp import Vasprun
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/io/vasp/outputs"
 

--- a/tests/analysis/test_piezo_sensitivity.py
+++ b/tests/analysis/test_piezo_sensitivity.py
@@ -17,7 +17,8 @@ from pymatgen.analysis.piezo_sensitivity import (
     rand_piezo,
 )
 from pymatgen.io.phonopy import get_phonopy_structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 try:
     from phonopy import Phonopy

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -18,7 +18,8 @@ from pymatgen.analysis.pourbaix_diagram import (
 from pymatgen.core.composition import Composition
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/pourbaix_diagram"
 

--- a/tests/analysis/test_quasirrho.py
+++ b/tests/analysis/test_quasirrho.py
@@ -6,7 +6,7 @@ from pytest import approx
 from pymatgen.analysis.quasirrho import QuasiRRHO, get_avg_mom_inertia
 from pymatgen.io.gaussian import GaussianOutput
 from pymatgen.io.qchem.outputs import QCOutput
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/quasirrho"
 

--- a/tests/analysis/test_surface_analysis.py
+++ b/tests/analysis/test_surface_analysis.py
@@ -9,7 +9,8 @@ from sympy import Number, Symbol
 
 from pymatgen.analysis.surface_analysis import NanoscaleStability, SlabEntry, SurfaceEnergyPlotter, WorkFunctionAnalyzer
 from pymatgen.entries.computed_entries import ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Richard Tran"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/analysis/test_transition_state.py
+++ b/tests/analysis/test_transition_state.py
@@ -7,7 +7,8 @@ from matplotlib import pyplot as plt
 from numpy.testing import assert_allclose
 
 from pymatgen.analysis.transition_state import NEBAnalysis, combine_neb_plots
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 """
 TODO: Modify unittest doc.

--- a/tests/analysis/test_wulff.py
+++ b/tests/analysis/test_wulff.py
@@ -8,7 +8,8 @@ from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.util.coord import in_coord_list
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Zihan Xu, Richard Tran, Balachandran Radhakrishnan"
 __copyright__ = "Copyright 2013, The Materials Virtual Lab"

--- a/tests/analysis/topological/test_spillage.py
+++ b/tests/analysis/topological/test_spillage.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pytest import approx
 
 from pymatgen.analysis.topological.spillage import SOCSpillage
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/topological"
 

--- a/tests/apps/battery/test_analyzer.py
+++ b/tests/apps/battery/test_analyzer.py
@@ -5,7 +5,8 @@ from pytest import approx
 
 from pymatgen.apps.battery.analyzer import BatteryAnalyzer
 from pymatgen.core.structure import Structure
-from pymatgen.util.testing import TEST_FILES_DIR, MatSciTest
+from pymatgen.util.testing import MatSciTest
+from tests.testing import TEST_FILES_DIR
 
 
 class TestBatteryAnalyzer(MatSciTest):

--- a/tests/apps/battery/test_conversion_battery.py
+++ b/tests/apps/battery/test_conversion_battery.py
@@ -7,7 +7,7 @@ from pytest import approx
 
 from pymatgen.apps.battery.conversion_battery import ConversionElectrode, ConversionVoltagePair
 from pymatgen.core.composition import Composition
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_insertion_battery.py
+++ b/tests/apps/battery/test_insertion_battery.py
@@ -7,7 +7,7 @@ from pytest import approx
 
 from pymatgen.apps.battery.insertion_battery import InsertionElectrode, InsertionVoltagePair
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/battery/test_plotter.py
+++ b/tests/apps/battery/test_plotter.py
@@ -9,7 +9,7 @@ from pymatgen.apps.battery.insertion_battery import InsertionElectrode
 from pymatgen.apps.battery.plotter import VoltageProfilePlotter
 from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/battery"
 

--- a/tests/apps/borg/test_hive.py
+++ b/tests/apps/borg/test_hive.py
@@ -7,7 +7,8 @@ from pytest import approx
 
 from pymatgen.apps.borg.hive import SimpleVaspToComputedEntryDrone, VaspToComputedEntryDrone
 from pymatgen.entries.computed_entries import ComputedStructureEntry
-from pymatgen.util.testing import TEST_FILES_DIR, VASP_OUT_DIR
+from pymatgen.util.testing import VASP_OUT_DIR
+from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/apps/borg"
 

--- a/tests/apps/borg/test_queen.py
+++ b/tests/apps/borg/test_queen.py
@@ -4,7 +4,7 @@ from pytest import approx
 
 from pymatgen.apps.borg.hive import VaspToComputedEntryDrone
 from pymatgen.apps.borg.queen import BorgQueen
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 __author__ = "Shyue Ping Ong"
 __copyright__ = "Copyright 2012, The Materials Project"

--- a/tests/cli/test_pmg_analyze.py
+++ b/tests/cli/test_pmg_analyze.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from pymatgen.cli import pmg
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 def test_pmg_analyze():

--- a/tests/cli/test_pmg_structure.py
+++ b/tests/cli/test_pmg_structure.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from pymatgen.cli import pmg
-from pymatgen.util.testing import TEST_FILES_DIR
+from tests.testing import TEST_FILES_DIR
 
 
 def test_pmg_structure():

--- a/tmp-pr-notes-cli-perf.md
+++ b/tmp-pr-notes-cli-perf.md
@@ -1,0 +1,69 @@
+# Temporary PR Notes: CLI Startup Perf
+
+## Scope
+
+- Optimize `pmg` startup by lazily importing subcommand handlers.
+- Reduce import-time overhead in `pmg analyze`, `pmg plot`, `pmg structure`, and `pmg potcar`.
+- Keep behavior unchanged while shifting heavy scientific imports onto the command paths that actually use them.
+
+## Main Code Changes
+
+- `src/pymatgen/cli/pmg.py`
+  - Add lazy handler dispatch via `_lazy_func(...)`.
+  - Defer `Structure` and `Incar` imports for `view` and `diff`.
+  - Remove eager `SETTINGS` / `Potcar` dependency from parser construction.
+
+- `src/pymatgen/cli/pmg_plot.py`
+  - Move `XRDCalculator`, `Structure`, `DosPlotter`, `Vasprun`, `Chgcar`, `SpacegroupAnalyzer`, and `pretty_plot` into per-command functions.
+
+- `src/pymatgen/cli/pmg_analyze.py`
+  - Move `BorgQueen`, VASP drones, and `Outcar` imports into runtime paths.
+
+- `src/pymatgen/cli/pmg_structure.py`
+  - Move `Structure`, `SpacegroupAnalyzer`, and `StructureMatcher` imports into runtime paths.
+
+- `src/pymatgen/cli/pmg_potcar.py`
+  - Move `SETTINGS` and `Potcar` imports into runtime paths.
+  - Resolve default functional at execution time instead of parser construction time.
+
+## Benchmarks
+
+### `pmg` cold import
+
+- Before optimization: about `0.97 s`
+- After optimization: about `0.055 s` mean over 8 cold runs
+
+### `pymatgen.cli.pmg_plot` import
+
+- Before optimization: about `2.13 s`
+- After optimization: about `0.56 s`
+
+### Cold-run subcommand samples
+
+- `pmg plot --chgint ...`
+  - before: about `2.214 s`
+  - after: about `1.824 s`
+
+- `pmg plot --dos ...`
+  - after lazy-import refactor: about `1.280 s`
+
+- `pmg plot --xrd ...`
+  - after lazy-import refactor: about `1.562 s`
+  - observed some run-to-run variance
+
+- `pmg structure --symmetry ...`
+  - before: about `0.408 s`
+  - after: about `0.314 s`
+
+## Validation
+
+- `uv run pytest tests/cli/test_pmg.py tests/cli/test_pmg_plot.py tests/cli/test_pmg_structure.py tests/cli/test_pmg_analyze.py`
+- `uv run pytest tests/cli/test_pmg_plot.py`
+- `uv run pytest tests/cli/test_pmg_analyze.py tests/cli/test_pmg_structure.py`
+
+All relevant CLI tests passed during local verification.
+
+## PR Framing Ideas
+
+- Improve `pmg` startup performance by lazily importing CLI handlers and heavy scientific dependencies.
+- Reduce import-time overhead for `pmg analyze`, `pmg plot`, `pmg structure`, and `pmg potcar` without changing command behavior.


### PR DESCRIPTION
## Summary

This PR reduces `pmg` startup overhead by deferring heavy imports until the selected subcommand is actually executed.

The main change is to lazily import CLI handlers and move several expensive scientific imports from module import time to runtime paths. The goal is to improve responsiveness for `pmg --help`, command discovery, and general CLI invocation, without changing command behavior.

## Changes

- lazily import subcommand handlers from `pmg.py`
- defer heavy imports in:
  - `pmg_plot.py`
  - `pmg_analyze.py`
  - `pmg_structure.py`
  - `pmg_potcar.py`
- resolve some command-specific dependencies only when the relevant command path is used

## Benchmarks

Local measurements showed substantial improvement in cold startup/import cost:

- `pmg` cold import:
  - before: ~0.97 s
  - after: ~0.055 s mean over 8 runs

- `pymatgen.cli.pmg_plot` import:
  - before: ~2.13 s
  - after: ~0.56 s

A few subcommand cold-run samples also improved, for example:

- `pmg plot --chgint ...`
  - before: ~2.214 s
  - after: ~1.824 s

- `pmg structure --symmetry ...`
  - before: ~0.408 s
  - after: ~0.314 s

These are local numbers, but they suggest that most of the previous cost came from eager imports.

## Validation

I ran:

- `uv run pytest tests/cli/test_pmg.py tests/cli/test_pmg_plot.py tests/cli/test_pmg_structure.py tests/cli/test_pmg_analyze.py`
- `uv run pytest tests/cli/test_pmg_plot.py`
- `uv run pytest tests/cli/test_pmg_analyze.py tests/cli/test_pmg_structure.py`

All relevant CLI tests passed locally.

## Question For Maintainers: future direction of `pmg`

This PR is intentionally limited to startup performance, but while working on it I noticed a broader CLI maintenance question and wanted to ask for maintainer guidance before exploring anything further.

At the moment, `pmg` is still quite useful and seems to have room for additional functionality, but the current `argparse` layout also means that:
- top-level parser construction in `pmg.py` keeps growing
- adding new commands/options can become verbose
- shell completion and help formatting are somewhat limited
- some workflows that could grow further, especially I/O / extraction / conversion tasks, do not fit especially cleanly into the current layout

One concrete example I am interested in is adding CLI support for extracting data such as `LOCPOT` from `vaspwave.h5`, with output to VASP volumetric format, XSF, or optionally compressed output.

Before attempting any larger CLI change, I wanted to ask:

- Is `pmg` expected to remain a lightweight convenience CLI only?
- Or is there interest in continuing to expand it as a more structured interface for common workflows?
- If expansion is welcome, would maintainers be open to evaluating a separate `Typer` prototype with feature parity to the current CLI, and comparing:
  - startup cost
  - maintainability
  - shell completion
  - help output
- If such a prototype looked reasonable, would a gradual migration path with compatibility aliases be acceptable?

I am not proposing to mix any of that into this PR. I only wanted to ask whether that direction would be considered in scope before doing exploratory work.

Thanks for taking a look.
