### PR TITLE
Deprecate lobsterenv __init__  (file and object based ) in favour of __init__ purely based on objects 

### DIFF
--- a/src/pymatgen/analysis/lobster_env.py
+++ b/src/pymatgen/analysis/lobster_env.py
@@ -66,192 +66,6 @@ class LobsterNeighbors(NearNeighbors):
 
     def __init__(
         self,
-        structure: Structure | IStructure,
-        filename_icohp: PathLike | None = "ICOHPLIST.lobster",
-        obj_icohp: Icohplist | None = None,
-        are_coops: bool = False,
-        are_cobis: bool = False,
-        valences: list[float] | None = None,
-        limits: tuple[float, float] | None = None,
-        additional_condition: Literal[0, 1, 2, 3, 4, 5, 6] = 0,
-        only_bonds_to: list[str] | None = None,
-        perc_strength_icohp: float = 0.15,
-        noise_cutoff: float = 0.1,
-        valences_from_charges: bool = False,
-        filename_charge: PathLike | None = None,
-        obj_charge: Charge | None = None,
-        which_charge: Literal["Mulliken", "Loewdin"] = "Mulliken",
-        adapt_extremum_to_add_cond: bool = False,
-        add_additional_data_sg: bool = False,
-        filename_blist_sg1: PathLike | None = None,
-        filename_blist_sg2: PathLike | None = None,
-        id_blist_sg1: Literal["icoop", "icobi"] = "icoop",
-        id_blist_sg2: Literal["icoop", "icobi"] = "icobi",
-        backward_compatibility: bool = False,
-    ) -> None:
-        """
-        Args:
-            filename_icohp (PathLike): Path to ICOHPLIST.lobster or
-                ICOOPLIST.lobster or ICOBILIST.lobster.
-            obj_icohp (Icohplist): Icohplist object.
-            structure (Structure): Typically constructed by Structure.from_file("POSCAR").
-            are_coops (bool): Whether the file is a ICOOPLIST.lobster (True) or a
-                ICOHPLIST.lobster (False). Only tested for ICOHPLIST.lobster so far.
-            are_cobis (bool): Whether the file is a ICOBILIST.lobster (True) or
-                a ICOHPLIST.lobster (False).
-            valences (list[float]): Valence/charge for each element.
-            limits (tuple[float, float]): Range to decide which ICOHPs (ICOOP
-                or ICOBI) should be considered.
-            additional_condition (int): Additional condition that decides
-                which kind of bonds will be considered:
-                    0 - NO_ADDITIONAL_CONDITION
-                    1 - ONLY_ANION_CATION_BONDS
-                    2 - NO_ELEMENT_TO_SAME_ELEMENT_BONDS
-                    3 - ONLY_ANION_CATION_BONDS_AND_NO_ELEMENT_TO_SAME_ELEMENT_BONDS
-                    4 - ONLY_ELEMENT_TO_OXYGEN_BONDS
-                    5 - DO_NOT_CONSIDER_ANION_CATION_BONDS
-                    6 - ONLY_CATION_CATION_BONDS
-            only_bonds_to (list[str]): Only consider bonds to certain elements (e.g. ["O"] for oxygen).
-            perc_strength_icohp (float): If no "limits" are given, this will decide
-                which ICOHPs will be considered (relative to the strongest ICOHP/ICOOP/ICOBI).
-            noise_cutoff (float): The lower limit of ICOHPs considered.
-            valences_from_charges (bool): If True and path to CHARGE.lobster is provided,
-                will use LOBSTER charges (Mulliken) instead of valences.
-            filename_charge (PathLike): Path to Charge.lobster.
-            obj_charge (Charge): Charge object.
-            which_charge ("Mulliken" | "Loewdin"): Source of charge.
-            adapt_extremum_to_add_cond (bool): Whether to adapt the limits to only
-                focus on the bonds determined by the additional condition.
-            add_additional_data_sg (bool): Add the information from filename_add_bondinglist_sg1.
-            filename_blist_sg1 (PathLike): Path to additional ICOOP, ICOBI data for structure graphs.
-            filename_blist_sg2 (PathLike): Path to additional ICOOP, ICOBI data for structure graphs.
-            id_blist_sg1 ("icoop" | "icobi"): Identity of data in filename_blist_sg1.
-            id_blist_sg2 ("icoop" | "icobi"): Identity of data in filename_blist_sg2.
-            backward_compatibility (bool): compatibility with neighbor detection  prior 2025 (less strict).
-        """
-        warnings.warn(
-            "Instantiation with file paths (filename_icohp, filename_charge, filename_blist_sg1, filename_blist_sg2.) "
-            "is deprecated and will be removed on 31-03-2026. "
-            "Please use `LobsterNeighbors.from_file` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        warnings.warn(
-            "Class init args obj_icohp, obj_charge will be "
-            "renamed to icoxxlist_obj and charge_obj respectively on 31-03-2026.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if filename_icohp is not None:
-            self.ICOHP = Icohplist(are_coops=are_coops, are_cobis=are_cobis, filename=filename_icohp)
-        elif obj_icohp is not None:
-            self.ICOHP = obj_icohp
-        else:
-            raise ValueError("Please provide either filename_icohp or obj_icohp")
-
-        self.Icohpcollection = self.ICOHP.icohpcollection
-        self.structure = structure
-        self.limits = limits
-        self.only_bonds_to = only_bonds_to
-        self.adapt_extremum_to_add_cond = adapt_extremum_to_add_cond
-        self.are_coops = are_coops
-        self.are_cobis = are_cobis
-        self.add_additional_data_sg = add_additional_data_sg
-        self.filename_blist_sg1 = filename_blist_sg1
-        self.filename_blist_sg2 = filename_blist_sg2
-        self.noise_cutoff = noise_cutoff
-
-        self.id_blist_sg1 = id_blist_sg1.lower()
-        self.id_blist_sg2 = id_blist_sg2.lower()
-        self.backward_compatibility = backward_compatibility
-
-        allowed_arguments = {"icoop", "icobi"}
-        if self.id_blist_sg1 not in allowed_arguments or self.id_blist_sg2 not in allowed_arguments:
-            raise ValueError("Algorithm can only work with ICOOPs, ICOBIs")
-
-        if add_additional_data_sg:
-            if self.id_blist_sg1 == "icoop":
-                are_coops_id1 = True
-                are_cobis_id1 = False
-            else:
-                are_coops_id1 = False
-                are_cobis_id1 = True
-
-            self.bonding_list_1 = Icohplist(
-                filename=self.filename_blist_sg1,
-                are_coops=are_coops_id1,
-                are_cobis=are_cobis_id1,
-            )
-
-            if self.id_blist_sg2 == "icoop":
-                are_coops_id2 = True
-                are_cobis_id2 = False
-            else:
-                are_coops_id2 = False
-                are_cobis_id2 = True
-
-            self.bonding_list_2 = Icohplist(
-                filename=self.filename_blist_sg2,
-                are_coops=are_coops_id2,
-                are_cobis=are_cobis_id2,
-            )
-
-        # Check the additional condition
-        if additional_condition not in range(7):
-            raise ValueError(f"Unexpected {additional_condition=}, must be one of {list(range(7))}")
-        self.additional_condition = additional_condition
-
-        # Read in valences, will prefer manual setting of valences
-        self.valences: list[float] | None
-        if valences is None:
-            if valences_from_charges and filename_charge is not None:
-                chg = Charge(filename=filename_charge)
-                if which_charge == "Mulliken":
-                    self.valences = chg.mulliken
-                elif which_charge == "Loewdin":
-                    self.valences = chg.loewdin
-
-            elif valences_from_charges and obj_charge is not None:
-                chg = obj_charge
-                if which_charge == "Mulliken":
-                    self.valences = chg.mulliken
-                elif which_charge == "Loewdin":
-                    self.valences = chg.loewdin
-
-            else:
-                bv_analyzer = BVAnalyzer()
-                try:
-                    self.valences = bv_analyzer.get_valences(structure=self.structure)  # type:ignore[arg-type]
-                except ValueError as exc:
-                    self.valences = None
-                    if additional_condition in {1, 3, 5, 6}:
-                        raise ValueError(
-                            "Valences cannot be assigned, additional_conditions 1, 3, 5 and 6 will not work"
-                        ) from exc
-        else:
-            self.valences = valences
-
-        if np.allclose(self.valences or [], np.zeros_like(self.valences)) and additional_condition in {1, 3, 5, 6}:
-            raise ValueError("All valences are equal to 0, additional_conditions 1, 3, 5 and 6 will not work")
-
-        if limits is None:
-            self.lowerlimit = self.upperlimit = None
-        else:
-            self.lowerlimit, self.upperlimit = limits
-
-        # Evaluate coordination environments
-        self._evaluate_ce(
-            lowerlimit=self.lowerlimit,
-            upperlimit=self.upperlimit,
-            only_bonds_to=only_bonds_to,
-            additional_condition=self.additional_condition,
-            perc_strength_icohp=perc_strength_icohp,
-            adapt_extremum_to_add_cond=adapt_extremum_to_add_cond,
-        )
-
-    def __init_new__(
-        self,
         structure: Structure,
         icoxxlist_obj: Icohplist,
         are_coops: bool = False,
@@ -337,21 +151,27 @@ class LobsterNeighbors(NearNeighbors):
         if additional_condition not in range(7):
             raise ValueError(f"Unexpected {additional_condition=}, must be one of {list(range(7))}")
 
-        if self.valences is None and valences_from_charges:
-            if which_charge == "Mulliken":
-                self.valences = charge_obj.mulliken
-            elif which_charge == "Loewdin":
-                self.valences = charge_obj.loewdin
-        else:
-            bv_analyzer = BVAnalyzer()
-            try:
-                self.valences = bv_analyzer.get_valences(structure=self.structure)  # type:ignore[arg-type]
-            except ValueError as exc:
-                self.valences = None
-                if additional_condition in {1, 3, 5, 6}:
-                    raise ValueError(
-                        "Valences cannot be assigned, additional_conditions 1, 3, 5 and 6 will not work"
-                    ) from exc
+        # Read in valences, will prefer manual setting of valences over charges
+        # if not provided, will try to read in from CHARGE.lobster if valences_from_charges is True,
+        # otherwise will try to assign them based on bond valence analysis.
+        self.valences: list[float] | None
+
+        if self.valences is None:
+            if valences_from_charges:
+                if which_charge == "Mulliken":
+                    self.valences = charge_obj.mulliken
+                elif which_charge == "Loewdin":
+                    self.valences = charge_obj.loewdin
+            else:
+                bv_analyzer = BVAnalyzer()
+                try:
+                    self.valences = bv_analyzer.get_valences(structure=self.structure)  # type:ignore[arg-type]
+                except ValueError as exc:
+                    self.valences = None
+                    if additional_condition in {1, 3, 5, 6}:
+                        raise ValueError(
+                            "Valences cannot be assigned, additional_conditions 1, 3, 5 and 6 will not work"
+                        ) from exc
 
         if np.allclose(self.valences or [], np.zeros_like(self.valences)) and additional_condition in {1, 3, 5, 6}:
             raise ValueError("All valences are equal to 0, additional_conditions 1, 3, 5 and 6 will not work")
@@ -434,9 +254,7 @@ class LobsterNeighbors(NearNeighbors):
                 are_cobis=are_cobis_id2,
             )
 
-        obj = cls.__new__(cls)
-
-        obj.__init_new__(
+        return cls(
             structure=structure,
             icoxxlist_obj=icoxxlist_obj,
             are_coops=are_coops,
@@ -444,9 +262,10 @@ class LobsterNeighbors(NearNeighbors):
             charge_obj=charge_obj,
             bonding_list_1=bonding_list_1,
             bonding_list_2=bonding_list_2,
+            id_blist_sg1=id_blist_sg1,
+            id_blist_sg2=id_blist_sg2,
             **kwargs,
         )
-        return obj
 
     @property
     def structures_allowed(self) -> Literal[True]:

--- a/tests/analysis/test_lobster_env.py
+++ b/tests/analysis/test_lobster_env.py
@@ -29,20 +29,20 @@ class TestLobsterNeighbors:
         # test additional conditions first
         # only consider cation anion bonds
 
-        self.chem_env_lobster1 = LobsterNeighbors(
+        self.chem_env_lobster1 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
             additional_condition=1,
             perc_strength_icohp=0.3,
             noise_cutoff=0.0,
         )
 
         # all bonds
-        self.chem_env_lobster0 = LobsterNeighbors(
+        self.chem_env_lobster0 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
             additional_condition=0,
         )
         # test __init_new__ using from_files
@@ -54,10 +54,10 @@ class TestLobsterNeighbors:
         )
 
         # only cation-cation, anion-anion bonds
-        self.chem_env_lobster5 = LobsterNeighbors(
+        self.chem_env_lobster5 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
             additional_condition=5,
         )
 
@@ -69,10 +69,10 @@ class TestLobsterNeighbors:
         )
 
         # only cation-cation bonds
-        self.chem_env_lobster6 = LobsterNeighbors(
+        self.chem_env_lobster6 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
             additional_condition=6,
         )
 
@@ -84,77 +84,77 @@ class TestLobsterNeighbors:
         )
 
         # 2,3,4 are not tested so far
-        self.chem_env_lobster2 = LobsterNeighbors(
+        self.chem_env_lobster2 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
             additional_condition=2,
         )
 
-        self.chem_env_lobster3 = LobsterNeighbors(
+        self.chem_env_lobster3 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
             additional_condition=3,
         )
 
-        self.chem_env_lobster4 = LobsterNeighbors(
+        self.chem_env_lobster4 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
             additional_condition=4,
         )
 
         # search for other testcase where 2,3,4 arrive at different results
-        self.chem_env_lobster0_second = LobsterNeighbors(
+        self.chem_env_lobster0_second = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=0,
             perc_strength_icohp=0.05,
         )
-        self.chem_env_lobster1_second = LobsterNeighbors(
+        self.chem_env_lobster1_second = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=1,
         )
 
-        self.chem_env_lobster2_second = LobsterNeighbors(
+        self.chem_env_lobster2_second = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=2,
         )
 
-        self.chem_env_lobster5_second = LobsterNeighbors(
+        self.chem_env_lobster5_second = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=5,
             perc_strength_icohp=0.05,
         )
 
-        self.chem_env_lobster5_second_percentage = LobsterNeighbors(
+        self.chem_env_lobster5_second_percentage = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=5,
             perc_strength_icohp=1.0,
         )
 
-        self.chem_env_lobster6_second = LobsterNeighbors(
+        self.chem_env_lobster6_second = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             additional_condition=6,
             perc_strength_icohp=0.05,
         )
         # coop / cobi
-        self.chem_env_lobster1_coop_NaCl = LobsterNeighbors(
+        self.chem_env_lobster1_coop_NaCl = LobsterNeighbors.from_files(
             are_coops=True,
-            filename_icohp=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaCl.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.NaCl.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
             additional_condition=1,
             noise_cutoff=None,
         )
@@ -167,10 +167,10 @@ class TestLobsterNeighbors:
             noise_cutoff=None,
         )
 
-        self.chem_env_lobster1_cobi_NaCl = LobsterNeighbors(
+        self.chem_env_lobster1_cobi_NaCl = LobsterNeighbors.from_files(
             are_coops=True,
-            filename_icohp=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaCl.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.NaCl.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
             additional_condition=1,
             noise_cutoff=None,
         )
@@ -183,130 +183,130 @@ class TestLobsterNeighbors:
             noise_cutoff=None,
         )
 
-        self.chem_env_lobster1_cobi_mp470 = LobsterNeighbors(
+        self.chem_env_lobster1_cobi_mp470 = LobsterNeighbors.from_files(
             are_coops=True,
-            filename_icohp=f"{TEST_DIR}/ICOBILIST.lobster.mp-470.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-470.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-470.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOBILIST.lobster.mp-470.gz",
             additional_condition=1,
         )
 
         # TODO: use charge instead of valence
-        self.chem_env_lobster1_charges = LobsterNeighbors(
+        self.chem_env_lobster1_charges = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=1,
         )
-        self.chem_env_lobster1_charges_noisecutoff = LobsterNeighbors(
+        self.chem_env_lobster1_charges_noisecutoff = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-632319.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-632319.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-632319.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-632319.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-632319.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-632319.gz",
             additional_condition=1,
             perc_strength_icohp=0.05,
             noise_cutoff=0.1,
         )
-        self.chem_env_lobster1_charges_wo_noisecutoff = LobsterNeighbors(
+        self.chem_env_lobster1_charges_wo_noisecutoff = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-632319.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-632319.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-632319.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-632319.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-632319.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-632319.gz",
             additional_condition=1,
             perc_strength_icohp=0.05,
             noise_cutoff=None,
         )
-        self.chem_env_lobster1_charges_loewdin = LobsterNeighbors(
+        self.chem_env_lobster1_charges_loewdin = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=1,
             which_charge="Loewdin",
         )
-        self.chem_env_lobster6_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster6_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=6,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster5_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster5_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=5,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster4_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster4_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=4,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster3_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster3_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=3,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster2_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster2_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=2,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster1_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster1_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=1,
             adapt_extremum_to_add_cond=True,
         )
 
-        self.chem_env_lobster0_charges_additional_condition = LobsterNeighbors(
+        self.chem_env_lobster0_charges_additional_condition = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=0,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster0_NaSi = LobsterNeighbors(
+        self.chem_env_lobster0_NaSi = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.NaSi.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaSi.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.NaSi.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.NaSi.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.NaSi.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.NaSi.gz",
             additional_condition=0,
             adapt_extremum_to_add_cond=True,
         )
-        self.chem_env_lobster_NaSi_wo_charges = LobsterNeighbors(
+        self.chem_env_lobster_NaSi_wo_charges = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.NaSi.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaSi.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.NaSi.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.NaSi.gz",
             valences_from_charges=False,
-            filename_charge=None,
+            charge_path=None,
             additional_condition=0,
             adapt_extremum_to_add_cond=True,
         )
@@ -314,78 +314,34 @@ class TestLobsterNeighbors:
         self.obj_icohp = Icohplist(filename=f"{TEST_DIR}/ICOHPLIST.lobster.NaSi.gz")
         self.obj_charge = Charge(filename=f"{TEST_DIR}/CHARGE.lobster.NaSi.gz")
         self.chem_env_w_obj = LobsterNeighbors(
-            filename_icohp=None,
             are_coops=False,
-            obj_icohp=self.obj_icohp,
-            obj_charge=self.obj_charge,
+            icoxxlist_obj=self.obj_icohp,
+            charge_obj=self.obj_charge,
             structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaSi.gz"),
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.NaSi.gz",
             additional_condition=0,
             adapt_extremum_to_add_cond=True,
         )
         # test LSE on_error
-        self.chem_env_on_error = LobsterNeighbors(
+        self.chem_env_on_error = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-1018096.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-1018096.gz"),
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-1018096.gz",
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-1018096.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-1018096.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-1018096.gz",
             additional_condition=0,
             adapt_extremum_to_add_cond=True,
             valences_from_charges=True,
         )
-
-    def test_init_new(self):
-        # additional condition 0
-        ref_lse = self.chem_env_lobster0.get_light_structure_environment(only_cation_environments=False)
-        test_lse = self.chem_env_lobster0_from_file.get_light_structure_environment(only_cation_environments=False)
-
-        assert self.chem_env_lobster0.anion_types == self.chem_env_lobster0_from_file.anion_types
-        assert ref_lse.coordination_environments == test_lse.coordination_environments
-        assert ref_lse.valences == test_lse.valences
-
-        # additional condition 5
-        ref_lse = self.chem_env_lobster5.get_light_structure_environment(only_cation_environments=False)
-        test_lse = self.chem_env_lobster5_from_file.get_light_structure_environment(only_cation_environments=False)
-
-        assert self.chem_env_lobster5.anion_types == self.chem_env_lobster5_from_file.anion_types
-        assert ref_lse.coordination_environments == test_lse.coordination_environments
-        assert ref_lse.valences == test_lse.valences
-
-        # additional condition 6
-        ref_lse = self.chem_env_lobster6.get_light_structure_environment(only_cation_environments=False)
-        test_lse = self.chem_env_lobster6_from_file.get_light_structure_environment(only_cation_environments=False)
-        assert self.chem_env_lobster6.anion_types == self.chem_env_lobster6_from_file.anion_types
-        assert ref_lse.coordination_environments == test_lse.coordination_environments
-        assert ref_lse.valences == test_lse.valences
-
-        # coop NaCl
-        ref_lse = self.chem_env_lobster1_coop_NaCl.get_light_structure_environment(only_cation_environments=False)
-        test_lse = self.chem_env_lobster1_coop_NaCl_from_file.get_light_structure_environment(
-            only_cation_environments=False
-        )
-        assert self.chem_env_lobster1_coop_NaCl.anion_types == self.chem_env_lobster1_coop_NaCl_from_file.anion_types
-        assert ref_lse.coordination_environments == test_lse.coordination_environments
-        assert ref_lse.valences == test_lse.valences
-
-        # cobi NaCl
-        ref_lse = self.chem_env_lobster1_cobi_NaCl.get_light_structure_environment(only_cation_environments=False)
-        test_lse = self.chem_env_lobster1_cobi_NaCl_from_file.get_light_structure_environment(
-            only_cation_environments=False
-        )
-        assert self.chem_env_lobster1_cobi_NaCl.anion_types == self.chem_env_lobster1_cobi_NaCl_from_file.anion_types
-        assert ref_lse.coordination_environments == test_lse.coordination_environments
-        assert ref_lse.valences == test_lse.valences
 
     def test_cation_anion_mode_without_ions(self):
         with pytest.raises(
             ValueError,
             match="Valences cannot be assigned, additional_conditions 1, 3, 5 and 6 will not work",
         ):
-            _ = LobsterNeighbors(
+            _ = LobsterNeighbors.from_files(
                 are_coops=False,
-                filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.gz",
-                structure=Structure.from_file(f"{TEST_DIR}/POSCAR.gz"),
+                icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.gz",
+                structure_path=f"{TEST_DIR}/POSCAR.gz",
                 valences_from_charges=False,
                 additional_condition=1,
             )
@@ -393,10 +349,10 @@ class TestLobsterNeighbors:
             ValueError,
             match="All valences are equal to 0, additional_conditions 1, 3, 5 and 6 will not work",
         ):
-            _ = LobsterNeighbors(
+            _ = LobsterNeighbors.from_files(
                 are_coops=False,
-                filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.gz",
-                structure=Structure.from_file(f"{TEST_DIR}/POSCAR.gz"),
+                icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.gz",
+                structure_path=f"{TEST_DIR}/POSCAR.gz",
                 valences_from_charges=False,
                 additional_condition=1,
                 valences=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -407,22 +363,22 @@ class TestLobsterNeighbors:
             ValueError,
             match=r"Unexpected additional_condition=10, must be one of \[0, 1, 2, 3, 4, 5, 6\]",
         ):
-            LobsterNeighbors(
+            LobsterNeighbors.from_files(
                 are_coops=False,
-                filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-                structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+                icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
+                structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
                 valences_from_charges=True,
-                filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+                charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
                 additional_condition=10,
             )
 
     def test_set_limits(self):
-        test = LobsterNeighbors(
+        test = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-353.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-353.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-353.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.mp-353.gz",
             additional_condition=1,
             limits=[-100000, 0],
         )
@@ -741,14 +697,14 @@ class TestLobsterNeighbors:
         assert isinstance(sg, StructureGraph)
 
     def test_extended_structure_graph(self):
-        self.chem_env_lobsterNaCl = LobsterNeighbors(
+        self.chem_env_lobsterNaCl = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.NaCl.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaCl.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.NaCl.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.NaCl.gz",
             valences_from_charges=True,
-            filename_charge=f"{TEST_DIR}/CHARGE.lobster.NaCl.gz",
-            filename_blist_sg1=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
-            filename_blist_sg2=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
+            charge_path=f"{TEST_DIR}/CHARGE.lobster.NaCl.gz",
+            blist_sg1_path=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
+            blist_sg2_path=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
             add_additional_data_sg=True,
             id_blist_sg1="icobi",
             id_blist_sg2="icoop",
@@ -769,14 +725,14 @@ class TestLobsterNeighbors:
 
     def test_raises_extended_structure_graph(self):
         with pytest.raises(ValueError, match="Algorithm can only work with ICOOPs, ICOBIs"):
-            self.chem_env_lobsterNaCl = LobsterNeighbors(
+            self.chem_env_lobsterNaCl = LobsterNeighbors.from_files(
                 are_coops=False,
-                filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.NaCl.gz",
-                structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.NaCl.gz"),
+                icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.NaCl.gz",
+                structure_path=f"{TEST_DIR}/CONTCAR.NaCl.gz",
                 valences_from_charges=True,
-                filename_charge=f"{TEST_DIR}/CHARGE.lobster.NaCl.gz",
-                filename_blist_sg1=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
-                filename_blist_sg2=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
+                charge_path=f"{TEST_DIR}/CHARGE.lobster.NaCl.gz",
+                blist_sg1_path=f"{TEST_DIR}/ICOBILIST.lobster.NaCl.gz",
+                blist_sg2_path=f"{TEST_DIR}/ICOOPLIST.lobster.NaCl.gz",
                 add_additional_data_sg=True,
                 id_blist_sg1="icopppp",
                 id_blist_sg2="icoop",
@@ -833,10 +789,10 @@ class TestLobsterNeighbors:
         assert self.chem_env_lobster1.get_info_icohps_between_neighbors(isites=[0])[2] == 12
         # use an example where this is easier to test (e.g., linear environment?)
 
-        chemenv_here = LobsterNeighbors(
+        chemenv_here = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-7000.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-7000.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-7000.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-7000.gz",
             additional_condition=1,
             perc_strength_icohp=0.05,
             noise_cutoff=0.0,
@@ -898,10 +854,10 @@ class TestLobsterNeighbors:
         assert label == "6 x O-Re (per bond)"
 
     def test_get_info_cohps_to_neighbors(self):
-        chem_env_lobster1 = LobsterNeighbors(
+        chem_env_lobster1 = LobsterNeighbors.from_files(
             are_coops=False,
-            filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-            structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
+            structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
             additional_condition=1,
         )
         cohpcar_lobster_mp_190 = f"{TEST_DIR}/COHPCAR.lobster.mp-190.gz"
@@ -1027,9 +983,9 @@ class TestLobsterNeighbors:
 
     def test_backward_compatibility_warning(self):
         with pytest.warns(UserWarning, match="You are using an older version for neighbor detection"):
-            _ = LobsterNeighbors(
-                filename_icohp=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
-                structure=Structure.from_file(f"{TEST_DIR}/CONTCAR.mp-190.gz"),
+            _ = LobsterNeighbors.from_files(
+                icoxxlist_path=f"{TEST_DIR}/ICOHPLIST.lobster.mp-190.gz",
+                structure_path=f"{TEST_DIR}/CONTCAR.mp-190.gz",
                 backward_compatibility=True,
             )
 


### PR DESCRIPTION
This pull request refactors the initialization of the `LobsterNeighbors` class to deprecate direct file-based arguments in favor of a new `from_files` class method, and updates all test cases accordingly. The existing __init__ constructor is replaced, and the tests are migrated to use the new interface, improving clarity and future-proofing the API.

## Changes
- Removed the old file-based `__init__` constructor for `LobsterNeighbors`, deprecated direct path and object arguments in favor of only object-based initialization, and moved file name args to `from_files `class method.

-  Updated tests accordingly