### PR TITLE
fix: strip H/O from PourbaixDiagram comp_dict (#4657)

### DIFF
--- a/src/pymatgen/analysis/pourbaix_diagram.py
+++ b/src/pymatgen/analysis/pourbaix_diagram.py
@@ -445,8 +445,10 @@ class PourbaixDiagram(MSONable):
         Args:
             entries ([PourbaixEntry] or [MultiEntry]): Entries list
                 containing Solids and Ions or a list of MultiEntries
-            comp_dict (dict[str, float]): Dictionary of compositions,
-                defaults to equal parts of each elements
+            comp_dict (dict[str, float]): Dictionary of compositions for the
+                non-H/O elements. H and O are open species in the Pourbaix
+                formalism so any H or O entries are silently stripped before
+                use. Defaults to equal parts of each non-H/O element.
             conc_dict (dict[str, float]): Dictionary of ion concentrations,
                 defaults to 1e-6 for each element
             filter_solids (bool): applying this filter to a Pourbaix
@@ -490,7 +492,18 @@ class PourbaixDiagram(MSONable):
                 conc_dict = {elt.symbol: 1e-6 for elt in self.pbx_elts}
             self._conc_dict = conc_dict
 
-            self._elt_comp = comp_dict
+            # H and O are open species in the Pourbaix formalism and are not
+            # compositional degrees of freedom. Strip them from comp_dict so it
+            # stays consistent with self.pbx_elts and get_decomposition_energy,
+            # both of which already exclude H and O via self.elements_ho.
+            ho_symbols = {elt.symbol for elt in self.elements_ho}
+            filtered_comp_dict = {k: v for k, v in comp_dict.items() if k not in ho_symbols}
+            if not filtered_comp_dict:
+                raise ValueError(
+                    "comp_dict must contain at least one non-H/O element; "
+                    "H and O are treated as open species in the Pourbaix formalism."
+                )
+            self._elt_comp = filtered_comp_dict
             self.pourbaix_elements = self.pbx_elts
 
             solid_entries = [entry for entry in entries if entry.phase_type == "Solid"]
@@ -518,7 +531,7 @@ class PourbaixDiagram(MSONable):
                 solid_entries = list(set(solid_pd.stable_entries) - set(entries_HO))
 
             self._filtered_entries = solid_entries + ion_entries
-            if len(comp_dict) > 1:
+            if len(self._elt_comp) > 1:
                 self._multi_element = True
                 self._processed_entries = self._preprocess_pourbaix_entries(self._filtered_entries, nproc=nproc)
             else:

--- a/tests/analysis/test_pourbaix_diagram.py
+++ b/tests/analysis/test_pourbaix_diagram.py
@@ -4,6 +4,7 @@ import multiprocessing
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 from monty.serialization import dumpfn, loadfn
 from pytest import approx
 
@@ -202,6 +203,24 @@ class TestPourbaixDiagram:
 
         multi_entry = PourbaixDiagram.process_multientry(entries, prod_comp=comp_dict)
         assert multi_entry is None
+
+    def test_comp_dict_with_h_or_o_is_stripped(self):
+        # Regression test: comp_dict containing H or O used to leave _elt_comp
+        # with those species, which then mismatched the non-H/O fractional
+        # composition checked inside get_decomposition_energy and raised
+        # ValueError for entries that should have been valid.
+        pbx = PourbaixDiagram(
+            self.test_data["Ag-Te"],
+            filter_solids=True,
+            comp_dict={"Ag": 0.5, "Te": 0.5, "O": 1, "H": 1},
+        )
+        assert pbx._elt_comp == {"Ag": 0.5, "Te": 0.5}
+        entry = pbx.find_stable_entry(8, 2)
+        # Must not raise.
+        pbx.get_decomposition_energy(entry, 8, 2)
+
+        with pytest.raises(ValueError, match="non-H/O element"):
+            PourbaixDiagram(self.test_data["Ag-Te"], comp_dict={"H": 1, "O": 1})
 
     def test_get_pourbaix_domains(self):
         domains = PourbaixDiagram.get_pourbaix_domains(self.test_data["Zn"])


### PR DESCRIPTION
Fixes #4657. `PourbaixDiagram.__init__` now strips H/O from a user-supplied `comp_dict` before storing it as `self._elt_comp`, matching the H/O-stripping that already happens in the entry-derived branch and inside `get_decomposition_energy`, so calling `get_decomposition_energy` on a comp_dict that contained H or O no longer raises `ValueError: Composition of stability entry does not match Pourbaix Diagram`. Added a regression test that pins this behavior on the existing `Ag-Te` fixtures. (@zccalka)
