### PR TITLE
Fix HeisenbergModel as_dict/from_dict round-trip (#4664)

### DIFF
--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -913,12 +913,17 @@ class HeisenbergModel(MSONable):
         # Interaction graph
         igraph = StructureGraph.from_dict(dct["igraph"])
 
-        # Reconstitute the exchange matrix DataFrame
-        try:
-            ex_mat = literal_eval(dct["ex_mat"])
-            ex_mat = pd.DataFrame.from_dict(ex_mat)
-        except SyntaxError:  # if ex_mat is empty
-            ex_mat = pd.DataFrame(columns=["E", "E0"])
+        # Reconstitute the exchange matrix DataFrame. as_dict() serializes
+        # ex_mat with jsanitize, which turns a DataFrame into a dict, while
+        # older serializations may store a (JSON/repr) string instead. Accept
+        # both forms and fall back to an empty matrix when ex_mat is empty.
+        ex_mat = dct["ex_mat"]
+        if isinstance(ex_mat, str):
+            try:
+                ex_mat = literal_eval(ex_mat)
+            except (SyntaxError, ValueError):  # empty or unparsable string
+                ex_mat = None
+        ex_mat = pd.DataFrame.from_dict(ex_mat) if ex_mat else pd.DataFrame(columns=["E", "E0"])
 
         return HeisenbergModel(
             formula=dct["formula"],

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pandas as pd
 from pytest import approx
 
-from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
+from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.core.structure import Structure
 from tests.testing import TEST_FILES_DIR
 
@@ -73,3 +73,23 @@ class TestHeisenbergMapper:
         for hm in self.hms:
             hmodel = hm.get_heisenberg_model()
             assert hmodel.formula == "Mn3Al"
+
+    def test_as_from_dict_round_trip(self):
+        # HeisenbergModel must survive MSON round-trips. as_dict() serializes
+        # ex_mat with jsanitize (a DataFrame becomes a dict), so from_dict()
+        # must accept a dict and not only a string.
+        # https://github.com/materialsproject/pymatgen/issues/4664
+        for hm in self.hms:
+            model = hm.get_heisenberg_model()
+
+            # First round-trip: ex_mat starts as a JSON string, becomes a DataFrame.
+            model_rt = HeisenbergModel.from_dict(model.as_dict())
+            assert isinstance(model_rt.ex_mat, pd.DataFrame)
+            assert model_rt.formula == model.formula
+
+            # Second round-trip: ex_mat is now a DataFrame, which jsanitize
+            # serializes to a dict. This raised
+            # "ValueError: malformed node or string" before the fix.
+            model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
+            assert isinstance(model_rt2.ex_mat, pd.DataFrame)
+            pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)


### PR DESCRIPTION
## Summary

Fixes #4664.

`HeisenbergModel` is not round-trippable through `as_dict()` / `from_dict()`. `as_dict()` serializes the `ex_mat` exchange matrix (a `pandas.DataFrame`) with `jsanitize`, which produces a **dict**, but `from_dict()` parsed it back with `ast.literal_eval`, which only accepts a **string** and raises `ValueError: malformed node or string` on a dict. The existing `except SyntaxError` guard does not catch `ValueError`, so deserialization fails.

This breaks any MSON-based persistence of a `HeisenbergModel` (e.g. passing one between jobflow/atomate2 jobs in the exchange workflow).

Full credit to @Luguza for the detailed root-cause analysis and minimal reproducer in the issue.

## Fix

`from_dict()` now consumes what `as_dict()` produces:

- accepts the **dict** form emitted by `jsanitize(DataFrame)`,
- tolerates the legacy **string** form for backwards compatibility,
- falls back to an empty `["E", "E0"]` matrix when `ex_mat` is empty/unparsable.

```python
ex_mat = dct["ex_mat"]
if isinstance(ex_mat, str):
    try:
        ex_mat = literal_eval(ex_mat)
    except (SyntaxError, ValueError):  # empty or unparsable string
        ex_mat = None
ex_mat = pd.DataFrame.from_dict(ex_mat) if ex_mat else pd.DataFrame(columns=["E", "E0"])
```

## Test plan

- Added `test_as_from_dict_round_trip` to `tests/analysis/magnetism/test_heisenberg.py`. It performs a double MSON round-trip on a fitted model: the first hop turns the JSON-string `ex_mat` into a `DataFrame`, and the second hop exercises the `jsanitize`'d **dict** path that previously raised `ValueError`.
- Verified the new test **fails on `main`** (`ValueError: malformed node or string`) and **passes with this change**.
- Full `tests/analysis/magnetism/test_heisenberg.py` suite passes (8 passed).
- `ruff check` and `ruff format --check` clean on the changed files.
