### PR TITLE
Fix typo and docstring in polarization.py (#4644)

### DIFF
--- a/src/pymatgen/analysis/ferroelectricity/polarization.py
+++ b/src/pymatgen/analysis/ferroelectricity/polarization.py
@@ -99,8 +99,6 @@ def get_total_ionic_dipole(structure, zval_dict):
 
     structure: pymatgen Structure
     zval_dict: specie, zval dictionary pairs
-    center (np.array with shape [3,1]) : dipole center used by VASP
-    tiny (float) : tolerance for determining boundary of calculation.
     """
     tot_ionic = []
     for site in structure:
@@ -116,7 +114,7 @@ def get_nearest_site(
     r: float | None = None,
 ):
     """
-    Given coords and a site, find closet site to coords.
+    Given coords and a site, find closest site to coords.
 
     Args:
         coords (3x1 array): Cartesian coords of center of sphere


### PR DESCRIPTION
## Summary
Major changes:
- fix 1: Fixed a typo ("closet" → "closest") in the docstring for `get_nearest_site`
- fix 2: Removed outdated documentation for `center` and `tiny` parameters in the docstring of `get_total_ionic_dipole`, which no longer exist in the function signature

Fixes #4644

## Todos
None — this PR is complete and ready for review.

## Checklist
- [x] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have `duecredit` `@due.dcite` decorators to reference relevant papers by DOI