### PR TITLE
Diffraction pattern optimizations

### DIFF
--- a/src/pymatgen/analysis/diffraction/neutron.py
+++ b/src/pymatgen/analysis/diffraction/neutron.py
@@ -49,6 +49,12 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
     Chapter13, Cambridge University Press 2003.
     """
 
+    # Upper bound on the number of entries of the phase matrix
+    # exp(2 pi i g.r) held in memory at once when accumulating structure
+    # factors (2^22 complex128 entries = 64 MB). Bounds peak memory for
+    # large structures and wide two-theta ranges; has no effect on results.
+    PHASE_CHUNK_ENTRIES = 4_194_304
+
     def __init__(self, wavelength=1.54184, symprec: float = 0, debye_waller_factors=None):
         """Initialize the ND calculator with a given radiation.
 
@@ -144,14 +150,22 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
         theta = np.arcsin(np.clip(wavelength * g_hkls / 2, -1, 1))
         s2 = (g_hkls / 2) ** 2
 
-        dw = np.exp(-dwfactors[None, :] * s2[:, None])
+        hkls_float = hkls_int.astype(float)  # (M, 3)
+        b_occus = coeffs * occus  # (N,) scattering length x occupancy
+        has_dw = np.any(dwfactors != 0)
 
-        g_dot_r = hkls_int.astype(float) @ fcoords.T
-
-        f_hkl = np.sum(
-            coeffs[None, :] * occus[None, :] * np.exp(2j * np.pi * g_dot_r) * dw,
-            axis=1,
-        )
+        # Structure factors F(g) = sum_j b_j occu_j DW_j(g) exp(2 pi i g.r_j),
+        # accumulated in chunks of hkl rows so the (chunk, N) phase matrix
+        # never exceeds PHASE_CHUNK_ENTRIES entries.
+        n_sites = len(b_occus)
+        chunk_rows = max(1, self.PHASE_CHUNK_ENTRIES // n_sites)
+        f_hkl = np.zeros(len(g_hkls), dtype=np.complex128)
+        for start in range(0, len(g_hkls), chunk_rows):
+            rows = slice(start, start + chunk_rows)
+            phase = np.exp(2j * np.pi * (hkls_float[rows] @ fcoords.T))  # (chunk, N)
+            if has_dw:
+                phase *= np.exp(-dwfactors[None, :] * s2[rows, None])
+            f_hkl[rows] = phase @ b_occus
 
         i_hkl = (f_hkl * f_hkl.conjugate()).real
 

--- a/src/pymatgen/analysis/diffraction/neutron.py
+++ b/src/pymatgen/analysis/diffraction/neutron.py
@@ -131,20 +131,26 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
         occus = np.asarray(_occus)  # (N,)
         dwfactors = np.asarray(_dw_factors)  # (N,)
 
-        # --- Unpack reciprocal points ---
-        recip_pts_sorted = sorted(
-            recip_pts,
-            key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2]),
-        )
+        # --- Unpack reciprocal points, keep one Friedel half-space ---
+        # The neutron scattering lengths are real (bound coherent values;
+        # absorption/incoherent terms are not modeled), so Friedel's law
+        # I(g) = I(-g) holds exactly: F(-g) = F*(g). Only the half-space
+        # with (h, k, l) lexicographically positive is computed; intensities
+        # are doubled and the -g Miller indices are restored when collecting
+        # hkl families. This also excludes the (000) point and halves the sort.
+        hkls_int = np.round([pt[0] for pt in recip_pts]).astype(int)  # (M, 3)
+        g_hkls = np.array([pt[1] for pt in recip_pts])  # (M,)
 
-        hkls_raw = np.array([pt[0] for pt in recip_pts_sorted])
-        g_hkls = np.array([pt[1] for pt in recip_pts_sorted])
+        h, k, ell = hkls_int.T
+        half = (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (ell > 0))
+        hkls_int = hkls_int[half]  # (M/2, 3)
+        g_hkls = g_hkls[half]
 
-        nonzero = g_hkls != 0
-        hkls_raw = hkls_raw[nonzero]
-        g_hkls = g_hkls[nonzero]
-
-        hkls_int = np.round(hkls_raw).astype(int)  # (M, 3)
+        # Same ordering as the previous sorted(key=(g, -h, -k, -l)):
+        # np.lexsort is stable and takes keys in reverse priority order.
+        order = np.lexsort((-hkls_int[:, 2], -hkls_int[:, 1], -hkls_int[:, 0], g_hkls))
+        hkls_int = hkls_int[order]
+        g_hkls = g_hkls[order]
 
         # --- Vectorized diffraction calculation ---
         theta = np.arcsin(np.clip(wavelength * g_hkls / 2, -1, 1))
@@ -173,7 +179,8 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
         cost = np.cos(theta)
         lorentz = 1.0 / (sint**2 * cost)
 
-        intensities = i_hkl * lorentz
+        # Factor 2: the -g half-space contributes identically (Friedel).
+        intensities = 2 * i_hkl * lorentz
         two_thetas_arr = np.degrees(2 * theta)
 
         # --- Merge peaks within tolerance ---
@@ -184,20 +191,24 @@ class NDCalculator(AbstractDiffractionPatternCalculator):
 
         for m in range(len(g_hkls)):
             hkl = tuple(int(v) for v in hkls_int[m])
+            # Restore the -g reflection dropped by the Friedel halving so
+            # hkl families and multiplicities are reported as before.
+            neg_hkl = tuple(-v for v in hkl)
 
             if is_hex:
                 hkl = (hkl[0], hkl[1], -hkl[0] - hkl[1], hkl[2])
+                neg_hkl = (neg_hkl[0], neg_hkl[1], -neg_hkl[0] - neg_hkl[1], neg_hkl[2])
 
             key = bin_keys[m]
             d_hkl = 1.0 / g_hkls[m]
 
             if key in peaks:
                 peaks[key][0] += float(intensities[m])
-                peaks[key][1].append(hkl)
+                peaks[key][1] += (hkl, neg_hkl)
             else:
                 peaks[key] = [
                     float(intensities[m]),
-                    [hkl],
+                    [hkl, neg_hkl],
                     float(two_thetas_arr[m]),
                     float(d_hkl),
                 ]

--- a/src/pymatgen/analysis/diffraction/xrd.py
+++ b/src/pymatgen/analysis/diffraction/xrd.py
@@ -164,27 +164,31 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
         if min_r:
             recip_pts = [pt for pt in recip_pts if pt[1] >= min_r]
 
-        # --- Build per-site arrays ---
-        _zs, _coeffs, _frac_coords, _occus, _dw_factors = [], [], [], [], []
+        # --- Group sites by element ---
+        # The scattering coefficients, atomic number and Debye-Waller factor
+        # depend only on the element, so the form factor is computed once per
+        # element over all hkl instead of once per atom.
+        species_groups: dict[str, dict] = {}
         for site in structure:
             for sp, occu in site.species.items():
-                _zs.append(sp.Z)
                 try:
-                    c = ATOMIC_SCATTERING_PARAMS[sp.symbol]
+                    coeff = ATOMIC_SCATTERING_PARAMS[sp.symbol]
                 except KeyError:
                     raise ValueError(
                         f"Unable to calculate XRD pattern as there is no scattering coefficients for {sp.symbol}."
                     )
-                _coeffs.append(c)
-                _dw_factors.append(self.debye_waller_factors.get(sp.symbol, 0))
-                _frac_coords.append(site.frac_coords)
-                _occus.append(occu)
-
-        zs = np.array(_zs)  # (N,)
-        coeffs = np.array(_coeffs)  # (N, 4, 2)
-        fcoords = np.array(_frac_coords)  # (N, 3)
-        occus = np.array(_occus)  # (N,)
-        dwfactors = np.array(_dw_factors)  # (N,)
+                grp = species_groups.setdefault(
+                    sp.symbol,
+                    {
+                        "z": sp.Z,
+                        "coeff": np.asarray(coeff),  # (n_coeff, 2)
+                        "dw_factor": self.debye_waller_factors.get(sp.symbol, 0),
+                        "frac_coords": [],
+                        "occus": [],
+                    },
+                )
+                grp["frac_coords"].append(site.frac_coords)
+                grp["occus"].append(occu)
 
         # --- Unpack reciprocal points & filter g_hkl == 0 ---
         recip_pts_sorted = sorted(recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2]))
@@ -203,27 +207,23 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
         theta = np.arcsin(np.clip(wavelength * g_hkls / 2, -1, 1))
         s2 = (g_hkls / 2) ** 2  # (M,)
 
-        # Atomic scattering factors: (M, N)
-        #   fs[m, n] = zs[n] - 41.78214 * s2[m] * sum_k(coeffs[n,k,0] * exp(-coeffs[n,k,1]*s2[m]))
-        # coeffs: (N, 4, 2)  →  broadcast s2: (M, 1, 1)
-        s2_mnk = s2[:, None, None]  # (M, 1, 1)
-        gauss = np.sum(
-            coeffs[None, :, :, 0] * np.exp(-coeffs[None, :, :, 1] * s2_mnk),
-            axis=2,
-        )  # (M, N)
-        fs = zs[None, :] - 41.78214 * s2[:, None] * gauss  # (M, N)
+        hkls_float = hkls_int.astype(float)  # (M, 3)
 
-        # Debye-Waller per atom, per hkl: (M, N)
-        dw = np.exp(-dwfactors[None, :] * s2[:, None])
+        # Structure factors accumulated element by element: (M,)
+        #   F(g) = sum_e f_e(g) DW_e(g) sum_{j in e} occu_j exp(2 pi i g.r_j)
+        f_hkl = np.zeros(len(g_hkls), dtype=np.complex128)
+        for grp in species_groups.values():
+            coeff = grp["coeff"]  # (n_coeff, 2)
+            # Atomic scattering factor for this element: (M,)
+            #   f(s) = Z - 41.78214 * s^2 * sum_k(a_k * exp(-b_k * s^2))
+            fs = grp["z"] - 41.78214 * s2 * np.sum(coeff[:, 0] * np.exp(-coeff[:, 1] * s2[:, None]), axis=1)
+            if grp["dw_factor"]:
+                fs = fs * np.exp(-grp["dw_factor"] * s2)
 
-        # g·r for all hkl and all atoms: (M, N)
-        g_dot_r = hkls_int.astype(float) @ fcoords.T  # (M, N)
+            # Occupancy-weighted phase sum over this element's sites: (M,)
+            g_dot_r = hkls_float @ np.asarray(grp["frac_coords"]).T  # (M, m)
+            f_hkl += fs * (np.exp(2j * math.pi * g_dot_r) @ np.asarray(grp["occus"]))
 
-        # Structure factors: (M,)
-        f_hkl = np.sum(
-            fs * occus[None, :] * np.exp(2j * math.pi * g_dot_r) * dw,
-            axis=1,
-        )
         i_hkl = (f_hkl * f_hkl.conjugate()).real  # (M,)
 
         # Lorentz-polarization factor: (M,)

--- a/src/pymatgen/analysis/diffraction/xrd.py
+++ b/src/pymatgen/analysis/diffraction/xrd.py
@@ -100,6 +100,12 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
     # Tuple of available radiation keywords.
     AVAILABLE_RADIATION = tuple(WAVELENGTHS)
 
+    # Upper bound on the number of entries of the per-element phase matrix
+    # exp(2 pi i g.r) held in memory at once when accumulating structure
+    # factors (2^22 complex128 entries = 64 MB). Bounds peak memory for
+    # large structures and wide two-theta ranges; has no effect on results.
+    PHASE_CHUNK_ENTRIES = 4_194_304
+
     def __init__(self, wavelength="CuKa", symprec: float = 0, debye_waller_factors=None):
         """Initialize the XRD calculator with a given radiation.
 
@@ -220,9 +226,17 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
             if grp["dw_factor"]:
                 fs = fs * np.exp(-grp["dw_factor"] * s2)
 
-            # Occupancy-weighted phase sum over this element's sites: (M,)
-            g_dot_r = hkls_float @ np.asarray(grp["frac_coords"]).T  # (M, m)
-            f_hkl += fs * (np.exp(2j * math.pi * g_dot_r) @ np.asarray(grp["occus"]))
+            # Occupancy-weighted phase sum over this element's sites,
+            # accumulated in chunks of hkl rows so the (chunk, m) phase
+            # matrix never exceeds PHASE_CHUNK_ENTRIES entries.
+            fcoords_t = np.asarray(grp["frac_coords"]).T  # (3, m)
+            occus = np.asarray(grp["occus"])  # (m,)
+            n_sites = fcoords_t.shape[1]
+            chunk_rows = max(1, self.PHASE_CHUNK_ENTRIES // n_sites)
+            for start in range(0, len(g_hkls), chunk_rows):
+                rows = slice(start, start + chunk_rows)
+                g_dot_r = hkls_float[rows] @ fcoords_t  # (chunk, m)
+                f_hkl[rows] += fs[rows] * (np.exp(2j * math.pi * g_dot_r) @ occus)
 
         i_hkl = (f_hkl * f_hkl.conjugate()).real  # (M,)
 

--- a/src/pymatgen/analysis/diffraction/xrd.py
+++ b/src/pymatgen/analysis/diffraction/xrd.py
@@ -196,17 +196,26 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
                 grp["frac_coords"].append(site.frac_coords)
                 grp["occus"].append(occu)
 
-        # --- Unpack reciprocal points & filter g_hkl == 0 ---
-        recip_pts_sorted = sorted(recip_pts, key=lambda i: (i[1], -i[0][0], -i[0][1], -i[0][2]))
+        # --- Unpack reciprocal points, keep one Friedel half-space ---
+        # The atomic scattering factors are real (anomalous dispersion is
+        # not modeled), so Friedel's law I(g) = I(-g) holds exactly:
+        # F(-g) = F*(g). Only the half-space with (h, k, l) lexicographically
+        # positive is computed; intensities are doubled and the -g Miller
+        # indices are restored when collecting hkl families. This also
+        # excludes the (000) point and halves the sort.
+        hkls_int = np.round([pt[0] for pt in recip_pts]).astype(int)  # (M, 3)
+        g_hkls = np.array([pt[1] for pt in recip_pts])  # (M,)
 
-        hkls_raw = np.array([pt[0] for pt in recip_pts_sorted])  # (M, 3)
-        g_hkls = np.array([pt[1] for pt in recip_pts_sorted])  # (M,)
+        h, k, ell = hkls_int.T
+        half = (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (ell > 0))
+        hkls_int = hkls_int[half]  # (M/2, 3)
+        g_hkls = g_hkls[half]
 
-        nonzero = g_hkls != 0
-        hkls_raw = hkls_raw[nonzero]
-        g_hkls = g_hkls[nonzero]
-
-        hkls_int = np.round(hkls_raw).astype(int)  # (M, 3)
+        # Same ordering as the previous sorted(key=(g, -h, -k, -l)):
+        # np.lexsort is stable and takes keys in reverse priority order.
+        order = np.lexsort((-hkls_int[:, 2], -hkls_int[:, 1], -hkls_int[:, 0], g_hkls))
+        hkls_int = hkls_int[order]
+        g_hkls = g_hkls[order]
 
         # --- Fully vectorized computation over all M hkl points ---
         # shapes: (M,)
@@ -246,7 +255,8 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
         cost = np.cos(theta)
         lorentz = (1 + cos2t**2) / (sint**2 * cost)
 
-        intensities = i_hkl * lorentz  # (M,)
+        # Factor 2: the -g half-space contributes identically (Friedel).
+        intensities = 2 * i_hkl * lorentz  # (M,)
         two_thetas_arr = np.degrees(2 * theta)  # (M,)
 
         # Merge peaks within TWO_THETA_TOL by binning: round each two_theta to the
@@ -257,15 +267,19 @@ class XRDCalculator(AbstractDiffractionPatternCalculator):
         peaks: dict[int, list] = {}
         for m in range(len(g_hkls)):
             hkl = tuple(int(v) for v in hkls_int[m])  # np.int64 -> int
+            # Restore the -g reflection dropped by the Friedel halving so
+            # hkl families and multiplicities are reported as before.
+            neg_hkl = tuple(-v for v in hkl)
             if is_hex:
                 hkl = (hkl[0], hkl[1], -hkl[0] - hkl[1], hkl[2])
+                neg_hkl = (neg_hkl[0], neg_hkl[1], -neg_hkl[0] - neg_hkl[1], neg_hkl[2])
             key = bin_keys[m]
             d_hkl = 1.0 / g_hkls[m]
             if key in peaks:
                 peaks[key][0] += float(intensities[m])  # np.float64 -> float
-                peaks[key][1].append(hkl)
+                peaks[key][1] += (hkl, neg_hkl)
             else:
-                peaks[key] = [float(intensities[m]), [hkl], float(two_thetas_arr[m]), float(d_hkl)]
+                peaks[key] = [float(intensities[m]), [hkl, neg_hkl], float(two_thetas_arr[m]), float(d_hkl)]
 
         # --- Build output ---
         max_intensity = max(v[0] for v in peaks.values())

--- a/tests/analysis/diffraction/test_neutron.py
+++ b/tests/analysis/diffraction/test_neutron.py
@@ -104,6 +104,40 @@ class TestNDCalculator(MatSciTest):
         assert pattern.x[2] == approx(44.39599754)
         assert pattern.y[2] == approx(39.471514740)
 
+    def test_get_pattern_non_centrosymmetric(self):
+        """Tetragonal BaTiO3 (P4mm, non-centrosymmetric) with Ti, whose
+        neutron scattering length is negative (-3.438 fm): F(hkl) is genuinely
+        complex, so Friedel's law I(g) = I(-g) rests on F(-g) = F*(g) rather
+        than the centrosymmetric special case of real F. Reference values were
+        generated with the full-sphere (pre Friedel-halving) implementation
+        and must not change. Multiplicities count both +l and -l reflections,
+        e.g. (001) has multiplicity 2 although P4mm does not relate +l to -l.
+        """
+        struct = Structure(
+            Lattice.tetragonal(3.9945, 4.0334),
+            ["Ba", "Ti", "O", "O", "O"],
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.5, 0.4820],
+                [0.5, 0.5, 0.0160],
+                [0.5, 0.0, 0.5150],
+                [0.0, 0.5, 0.5150],
+            ],
+        )
+        calc = NDCalculator(wavelength=1.54184)
+        pattern = calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        assert len(pattern.x) == 27
+        assert pattern.x[:4] == approx([22.037944670652465, 22.255284684116262, 31.52181770727521, 31.678181395101802])
+        assert pattern.y[:4] == approx([453.13576368164007, 800.8355861573295, 1916.4711408968653, 971.0175541753043])
+        assert pattern.d_hkls[:4] == approx([4.0334, 3.9945, 2.838191301738583, 2.824538037449664])
+        assert pattern.hkls[:4] == [
+            [{"hkl": (0, 0, 1), "multiplicity": 2}],
+            [{"hkl": (1, 0, 0), "multiplicity": 4}],
+            [{"hkl": (1, 0, 1), "multiplicity": 8}],
+            [{"hkl": (1, 1, 0), "multiplicity": 4}],
+        ]
+
     def test_get_pattern_chunked_matches_unchunked(self, monkeypatch):
         """Structure factors are accumulated in memory-bounded chunks of hkl
         rows; the result must not depend on the chunk size. Force one hkl row

--- a/tests/analysis/diffraction/test_neutron.py
+++ b/tests/analysis/diffraction/test_neutron.py
@@ -104,6 +104,23 @@ class TestNDCalculator(MatSciTest):
         assert pattern.x[2] == approx(44.39599754)
         assert pattern.y[2] == approx(39.471514740)
 
+    def test_get_pattern_chunked_matches_unchunked(self, monkeypatch):
+        """Structure factors are accumulated in memory-bounded chunks of hkl
+        rows; the result must not depend on the chunk size. Force one hkl row
+        per chunk and compare against the effectively unchunked default.
+        """
+        struct = self.get_structure("LiFePO4")
+        calc = NDCalculator(wavelength=1.54184, debye_waller_factors={"Fe": 0.4})
+        ref = calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        monkeypatch.setattr(NDCalculator, "PHASE_CHUNK_ENTRIES", 1)
+        chunked = calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        assert chunked.x == approx(ref.x)
+        assert chunked.y == approx(ref.y, rel=1e-12)
+        assert chunked.d_hkls == approx(ref.d_hkls)
+        assert chunked.hkls == ref.hkls
+
     def test_get_plot(self):
         struct = self.get_structure("Graphite")
         c = NDCalculator(wavelength=1.54184, debye_waller_factors={"C": 1})

--- a/tests/analysis/diffraction/test_xrd.py
+++ b/tests/analysis/diffraction/test_xrd.py
@@ -5,6 +5,7 @@ from pytest import approx
 
 from pymatgen.analysis.diffraction.xrd import XRDCalculator
 from pymatgen.core.lattice import Lattice
+from pymatgen.core.periodic_table import Species
 from pymatgen.core.structure import Structure
 from pymatgen.util.testing import MatSciTest
 
@@ -87,6 +88,31 @@ class TestXRDCalculator(MatSciTest):
         assert xrd.x[0] == approx(40.294828554672264)
         assert xrd.y[0] == approx(2377745.2296686019)
         assert xrd.d_hkls[0] == approx(2.2382050944897789)
+
+    def test_get_pattern_disordered_species_dw(self):
+        """Disordered fcc Cu-Au with oxidation-state species, partial occupancies
+        and Debye-Waller factors: exercises the occupancy-weighted sum over
+        site.species and the symbol-keyed scattering/DW lookups. Reference
+        values were generated with the per-atom (pre grouped-by-element)
+        implementation and must not change.
+        """
+        struct = Structure(
+            Lattice.cubic(3.677),
+            [{Species("Cu2+"): 0.5, Species("Au3+"): 0.5}] * 4,
+            [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]],
+        )
+        xrd_calc = XRDCalculator(debye_waller_factors={"Cu": 0.62, "Au": 0.58})
+        xrd = xrd_calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        assert xrd.x == approx([42.58654814199049, 49.583339742779344, 72.7415377864004, 88.11241551060378])
+        assert xrd.y == approx([2823918.0596514726, 1327811.2328217993, 770012.3450414365, 910580.4261507628])
+        assert xrd.d_hkls == approx([2.1229169398102536, 1.8385, 1.3000158172114675, 1.1086572140124369])
+        assert xrd.hkls == [
+            [{"hkl": (1, 1, 1), "multiplicity": 8}],
+            [{"hkl": (2, 0, 0), "multiplicity": 6}],
+            [{"hkl": (2, 2, 0), "multiplicity": 12}],
+            [{"hkl": (3, 1, 1), "multiplicity": 24}],
+        ]
 
     def test_get_pattern_merge_regression(self):
         """

--- a/tests/analysis/diffraction/test_xrd.py
+++ b/tests/analysis/diffraction/test_xrd.py
@@ -114,6 +114,23 @@ class TestXRDCalculator(MatSciTest):
             [{"hkl": (3, 1, 1), "multiplicity": 24}],
         ]
 
+    def test_get_pattern_chunked_matches_unchunked(self, monkeypatch):
+        """Structure factors are accumulated in memory-bounded chunks of hkl
+        rows; the result must not depend on the chunk size. Force one hkl row
+        per chunk and compare against the effectively unchunked default.
+        """
+        struct = self.get_structure("LiFePO4")
+        xrd_calc = XRDCalculator()
+        ref = xrd_calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        monkeypatch.setattr(XRDCalculator, "PHASE_CHUNK_ENTRIES", 1)
+        chunked = xrd_calc.get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        assert chunked.x == approx(ref.x)
+        assert chunked.y == approx(ref.y, rel=1e-12)
+        assert chunked.d_hkls == approx(ref.d_hkls)
+        assert chunked.hkls == ref.hkls
+
     def test_get_pattern_merge_regression(self):
         """
         Regression test for peak-merging behaviour. Assertion values were generated

--- a/tests/analysis/diffraction/test_xrd.py
+++ b/tests/analysis/diffraction/test_xrd.py
@@ -114,6 +114,36 @@ class TestXRDCalculator(MatSciTest):
             [{"hkl": (3, 1, 1), "multiplicity": 24}],
         ]
 
+    def test_get_pattern_non_centrosymmetric(self):
+        """Wurtzite ZnO (P6_3mc, non-centrosymmetric): F(hkl) is genuinely
+        complex, so Friedel's law I(g) = I(-g) rests on F(-g) = F*(g) rather
+        than the centrosymmetric special case of real F. Reference values were
+        generated with the full-sphere (pre Friedel-halving) implementation
+        and must not change. Multiplicities count both +l and -l reflections.
+        """
+        struct = Structure(
+            Lattice.hexagonal(3.25, 5.207),
+            ["Zn", "Zn", "O", "O"],
+            [
+                [1 / 3, 2 / 3, 0.0],
+                [2 / 3, 1 / 3, 0.5],
+                [1 / 3, 2 / 3, 0.3817],
+                [2 / 3, 1 / 3, 0.8817],
+            ],
+        )
+        xrd = XRDCalculator().get_pattern(struct, scaled=False, two_theta_range=(0, 90))
+
+        assert len(xrd.x) == 13
+        assert xrd.x[:4] == approx([31.793191209385288, 34.4481096267274, 36.28192404106642, 47.577360078761224])
+        assert xrd.y[:4] == approx([138729.92514225902, 106194.79943567653, 270038.0917113368, 61581.215456583785])
+        assert xrd.d_hkls[:4] == approx([2.814582562299426, 2.6035, 2.4760090064581086, 1.9112241235795175])
+        assert xrd.hkls[:4] == [
+            [{"hkl": (1, 0, -1, 0), "multiplicity": 6}],
+            [{"hkl": (0, 0, 0, 2), "multiplicity": 2}],
+            [{"hkl": (1, 0, -1, 1), "multiplicity": 12}],
+            [{"hkl": (1, 0, -1, 2), "multiplicity": 12}],
+        ]
+
     def test_get_pattern_chunked_matches_unchunked(self, monkeypatch):
         """Structure factors are accumulated in memory-bounded chunks of hkl
         rows; the result must not depend on the chunk size. Force one hkl row


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: These are purely efficiency optimizations under the hood for predicting XRD and neutron diffraction patterns. The interface remains untouched. These gains allow direct prediction of diffraction patterns from MD trajectories, include Debye-Waller factors in seconds on a PC which was impossible before due to memory and compute constraints. The performance and bit-wise accuracy of the enhancements is shown in the attached plots for each optimization.

- Optimization 1 (XRD only): Per element form factors are computed once and stored for each element rather than computed for each atom

<img width="1440" height="1638" alt="02_per_element_form_factors" src="https://github.com/user-attachments/assets/f227672f-7c4c-4004-a093-062d0c7d97a2" />

- Optimization 2: Chunked structure factors per species, which massively reduces memory requirements
 
<img width="1440" height="1638" alt="03_chunked_structure_factors" src="https://github.com/user-attachments/assets/255a9d7c-e68a-4265-819c-771a3466f131" />
<img width="1440" height="1638" alt="05_neutron_chunked" src="https://github.com/user-attachments/assets/f1a73280-2a33-452f-8c63-085230db2fb8" />

- Optimization 3: Friedel halving i.e. only computing for g and not both g and -g and transforming rather than computing for the full sphere


<img width="1440" height="1638" alt="04_friedel_halving" src="https://github.com/user-attachments/assets/4e84f488-8bd6-45c1-aa85-31436025cf10" />
<img width="1440" height="1638" alt="06_neutron_friedel" src="https://github.com/user-attachments/assets/ccc5eca9-2f39-4b94-b2c4-1b8ba92863b7" />

## Todos
- pass tests

## Checklist

- [ ] Pass tests
