### PR TITLE
Add whole motif flip strategy to `MagneticStructureEnumerator`

### DIFF
--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -906,6 +906,10 @@ class MagneticStructureEnumerator:
             # the rest) trips MagOrderingTransformation._remove_dummy_species.
             for symbol in wyckoff_symbols:
                 num_motif_sites = wyckoff.count(symbol)
+                # a motif that is exactly half the magnetic sites gives an order
+                # parameter of 0.5, i.e. the global AFM constraint added above
+                if num_motif_sites * 2 == num_mag_sites:
+                    continue
                 all_constraints[f"ferri_by_motif_{symbol}_flip"] = num_motif_sites / num_mag_sites
 
         # and also try ferrimagnetic when there are multiple magnetic species

--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -907,8 +907,9 @@ class MagneticStructureEnumerator:
             for symbol in wyckoff_symbols:
                 num_motif_sites = wyckoff.count(symbol)
                 # a motif that is exactly half the magnetic sites gives an order
-                # parameter of 0.5, i.e. the global AFM constraint added above
-                if num_motif_sites * 2 == num_mag_sites:
+                # parameter of 0.5, i.e. the global AFM constraint added above --
+                # but only skip it when that constraint is actually present
+                if num_motif_sites * 2 == num_mag_sites and "antiferromagnetic" in self.strategies:
                     continue
                 all_constraints[f"ferri_by_motif_{symbol}_flip"] = num_motif_sites / num_mag_sites
 

--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -898,6 +898,16 @@ class MagneticStructureEnumerator:
 
                 all_constraints[f"ferri_by_motif_{symbol}"] = constraints
 
+            # ...and one whole motif flipped antiparallel to the rest, e.g. the Neel
+            # ground state of a spinel ferrimagnet. The constraints above cannot reach
+            # this: they make a motif internally AFM instead of flipping it as a block.
+            # Given as a global order parameter (fraction of up spins) like
+            # ferrimagnetic_by_species, since the per-motif form (1 on this motif, 0 on
+            # the rest) trips MagOrderingTransformation._remove_dummy_species.
+            for symbol in wyckoff_symbols:
+                num_motif_sites = wyckoff.count(symbol)
+                all_constraints[f"ferri_by_motif_{symbol}_flip"] = num_motif_sites / num_mag_sites
+
         # and also try ferrimagnetic when there are multiple magnetic species
         if "ferrimagnetic_by_species" in self.strategies:
             sp_list = [str(site.specie) for site in structure]

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -553,6 +553,26 @@ class TestMagneticStructureEnumeratorMotifFlip:
         assert {"afm", "ferri_by_motif_2a", "ferri_by_motif_2b"} <= set(transformations)
         assert [name for name in transformations if name.endswith("_flip")] == []
 
+    def test_half_multiplicity_flip_kept_without_antiferromagnetic_strategy(self):
+        # same structure as above, but without "antiferromagnetic" in strategies: the
+        # 0.5-order-parameter flip is no longer a duplicate of a global "afm"
+        # constraint that was never added, so it must be emitted.
+        structure = Structure.from_file(f"{TEST_DIR}/Ca3Co2O6.json")
+        enumerator = object.__new__(MagneticStructureEnumerator)
+        enumerator.logger = logging.getLogger("test")
+        enumerator.default_magmoms = None
+        enumerator.strategies = ["ferrimagnetic_by_motif"]
+        enumerator.automatic = False
+        enumerator.transformation_kwargs = {"check_ordered_symmetry": False, "timeout": 5}
+        enumerator.max_unique_sites = 8
+        enumerator.ordered_structures = []
+        enumerator.ordered_structure_origins = []
+        sanitized = enumerator._sanitize_input_structure(structure)
+        transformations = enumerator._generate_transformations(sanitized)
+
+        assert "afm" not in transformations
+        assert {"ferri_by_motif_2a_flip", "ferri_by_motif_2b_flip"} <= set(transformations)
+
 
 class TestMagneticDeformation:
     def test_magnetic_deformation(self):

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -15,6 +15,7 @@ from pymatgen.analysis.magnetism import (
     magnetic_deformation,
 )
 from pymatgen.core import Element, Lattice, Species, Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
@@ -295,6 +296,61 @@ class TestMagneticStructureEnumerator:
         )
         assert enumerator.input_origin == "afm_by_motif_2a"
 
+    def test_whole_motif_flip_enumeration(self):
+        # Neel ordering of a ferrimagnet: every magnetic Wyckoff motif is internally
+        # FM, but the motifs are antiparallel to one another. Fe3O4 has 6 magnetic
+        # sites split 4 (4f) + 2 (2c), so this is 4 up / 2 down. Only the
+        # ferri_by_motif_{symbol}_flip constraint can reach it: afm is 3 up / 3 down,
+        # and ferri_by_motif_{symbol} makes one motif internally AFM rather than
+        # flipping it as a block.
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/Fe3O4.cif", primitive=True)
+        symmetrized = SpacegroupAnalyzer(structure).get_symmetrized_structure()
+        wyckoff = ["n/a"] * len(structure)
+        for indices, symbol in zip(symmetrized.equivalent_indices, symmetrized.wyckoff_symbols, strict=True):
+            for index in indices:
+                wyckoff[index] = symbol
+        neel_magmoms = [
+            (5 if wyckoff[idx] == "4f" else -5) if site.specie.symbol == "Fe" else 0
+            for idx, site in enumerate(structure)
+        ]
+        neel_structure = structure.copy(site_properties={"magmom": neel_magmoms})
+
+        enumerator = MagneticStructureEnumerator(
+            neel_structure,
+            strategies=("ferromagnetic", "antiferromagnetic", "ferrimagnetic_by_motif"),
+            automatic=False,
+        )
+        # with only two motifs the flipped and unflipped block are each other's
+        # spin inversion, so either flip constraint can be the one credited
+        assert enumerator.input_origin in {"ferri_by_motif_4f_flip", "ferri_by_motif_2c_flip"}
+
+    def test_complementary_motif_flips_are_pruned(self):
+        # Fe3O4 has two magnetic motifs, so flipping 4f (order parameter 4/6) and
+        # flipping 2c (2/6) generate the same orderings up to a global spin
+        # inversion, which matches_ordering deliberately treats as equal. The
+        # duplicate pruning in _generate_ordered_structures must therefore collapse
+        # the two flip strategies down to one surviving set.
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/Fe3O4.cif", primitive=True)
+        enumerator = MagneticStructureEnumerator(
+            structure,
+            strategies=("ferromagnetic", "antiferromagnetic", "ferrimagnetic_by_motif"),
+            automatic=False,
+            truncate_by_symmetry=False,
+        )
+        origins = enumerator.ordered_structure_origins
+
+        # both flip strategies do enumerate structures, but only one label survives
+        flip_origins = {origin for origin in origins if origin.endswith("_flip")}
+        assert flip_origins in ({"ferri_by_motif_4f_flip"}, {"ferri_by_motif_2c_flip"})
+
+        # and more generally, no two surviving orderings are duplicates
+        assert len(origins) == len(enumerator.ordered_structures)
+        for idx, struct in enumerate(enumerator.ordered_structures):
+            analyzer = CollinearMagneticStructureAnalyzer(struct, overwrite_magmom_mode="none")
+            for other_idx, other in enumerate(enumerator.ordered_structures):
+                if idx != other_idx:
+                    assert not analyzer.matches_ordering(other)
+
     def test_default_transformation_kwargs(self):
         structure = Structure.from_file(f"{TEST_DIR}/LaMnO3.json")
 
@@ -448,6 +504,54 @@ class TestMagneticStructureEnumeratorTruncation:
             for other_idx, other in enumerate(out_structures):
                 if idx != other_idx:
                     assert not analyzer.matches_ordering(other)
+
+
+class TestMagneticStructureEnumeratorMotifFlip:
+    # Not gated on ENUMLIB_PRESENT: _generate_transformations only builds
+    # MagOrderingTransformation instances, it never shells out to enum.x.
+    @staticmethod
+    def generate_transformations(structure):
+        """Run _generate_transformations on a manually-built enumerator, bypassing
+        __init__ (and enumlib) since only the constraints it builds are under test.
+        """
+        enumerator = object.__new__(MagneticStructureEnumerator)
+        enumerator.logger = logging.getLogger("test")
+        enumerator.default_magmoms = None
+        enumerator.strategies = ["ferromagnetic", "antiferromagnetic", "ferrimagnetic_by_motif"]
+        enumerator.automatic = False
+        enumerator.transformation_kwargs = {"check_ordered_symmetry": False, "timeout": 5}
+        enumerator.max_unique_sites = 8
+        enumerator.ordered_structures = []
+        enumerator.ordered_structure_origins = []
+        sanitized = enumerator._sanitize_input_structure(structure)
+        return enumerator._generate_transformations(sanitized)
+
+    def test_whole_motif_flip_constraints(self):
+        # Fe3O4's 6 magnetic Fe sites split over two Wyckoff motifs, 4f (4 sites)
+        # and 2c (2 sites)
+        structure = Structure.from_file(f"{TEST_FILES_DIR}/cif/Fe3O4.cif", primitive=True)
+        transformations = self.generate_transformations(structure)
+
+        # the pre-existing internally-AFM-on-one-motif orderings are unaffected...
+        assert {"ferri_by_motif_4f", "ferri_by_motif_2c"} <= set(transformations)
+        # ...and each motif also gets a whole-motif flip, expressed as a single
+        # global order parameter (the fraction of magnetic sites left pointing up)
+        # (MagOrderingTransformation stores its constraints as serialized dicts)
+        for symbol, num_motif_sites in (("4f", 4), ("2c", 2)):
+            (constraint,) = transformations[f"ferri_by_motif_{symbol}_flip"].order_parameter
+            assert constraint["order_parameter"] == approx(num_motif_sites / 6)
+            assert constraint["species_constraints"] == ["Fe"]
+            assert constraint["site_constraint_name"] is None
+
+    def test_no_flip_constraint_when_motif_is_half_the_magnetic_sites(self):
+        # Ca3Co2O6 puts its 4 magnetic Co sites on two motifs of equal multiplicity
+        # (2a and 2b), so flipping either whole motif is an order parameter of 0.5,
+        # i.e. exactly the global AFM constraint. It must not be emitted twice.
+        structure = Structure.from_file(f"{TEST_DIR}/Ca3Co2O6.json")
+        transformations = self.generate_transformations(structure)
+
+        assert {"afm", "ferri_by_motif_2a", "ferri_by_motif_2b"} <= set(transformations)
+        assert [name for name in transformations if name.endswith("_flip")] == []
 
 
 class TestMagneticDeformation:


### PR DESCRIPTION
## Summary

`MagneticStructureEnumerator` with the `ferrimagnetic_by_motif` strategy could not produce orderings where one or more whole Wyckoff motifs are flipped antiparallel to the rest, with every motif staying internally ferromagnetic. The Néel ground state of a spinel ferrimagnet like Fe3O4 (4f up, 2c down) is one of these. The existing `ferri_by_motif_{symbol}` constraints make one motif internally AFM, and `afm` forces equal up/down counts, so neither one reaches these orderings.

This PR adds them as `ferri_by_motif_{symbols}_flip` orderings, e.g. `ferri_by_motif_2c_flip` or `ferri_by_motif_b_c_flip`.

## Implementation

- **Built directly, not enumerated.** When every motif is internally FM, the magnetic cell is the crystallographic primitive cell, so picking which motifs to flip fixes the ordering. `_add_whole_motif_flips` builds these structures and appends them to `ordered_structures`, the same way the `fm` ordering is already handled. It does not call enumlib.
  - An earlier version of this PR used a global order parameter (`num_motif_sites / num_mag_sites`). That fixes only *how many* spins point up, not *which sites* carry them. On Fe3O4 it produced six orderings, and only one of them was the whole-motif flip. The Néel state survived only because it was the most symmetric, so `truncate_by_symmetry` / `max_orderings` could drop it on other structures. The direct construction replaces that approach, together with its `order parameter == 0.5` guard, which also made the half-multiplicity flip unreachable when `antiferromagnetic` was not requested.
- **All combinations, no inversion duplicates.** The PR emits every non-empty subset of motifs to flip, with the first motif always held up. Flipping a set of motifs and flipping its complement differ only by a global spin inversion, so n motifs give `2**(n-1) - 1` orderings. With `max_unique_sites=8` that is at most 127. All of them keep the full crystal symmetry, so `truncate_by_symmetry` does not remove them.
- **Reproducible origins.** `wyckoff_symbols` is now sorted by descending multiplicity, then by symbol, instead of iterating a `set`. Before this change, which of two equivalent orderings survived duplicate pruning (and so which origin label was recorded) could change with `PYTHONHASHSEED`.
- Adapted to the duplicate-pruning fix in #4702.

## Tests

- Fe3O4 Néel input is recognized as `ferri_by_motif_2c_flip`.
- Each motif stays internally FM in the flipped structure. The existing `ferri_by_motif_4f` / `ferri_by_motif_2c` transformations are unchanged.
- Motifs of equal multiplicity (Ca3Co2O6, 2a/2b) give a single flip, not one per motif.
- Three motifs give exactly the three expected subsets and spin patterns.
- For 2–6 motifs: the output has `2**(n-1) - 1` orderings, and none is the spin inversion of another.
- The flip is emitted when only `ferrimagnetic_by_motif` is requested, without `antiferromagnetic`.
- No two surviving orderings on Fe3O4 are duplicates according to `matches_ordering`.

The `TestMagneticStructureEnumeratorMotifFlip` tests skip `__init__` and do not need enumlib.