### PR TITLE
 [breaking] Support mixed-supercell orderings in `HeisenbergMapper `via a shared parent-cell sublattice definition

### DIFF
--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -7,9 +7,9 @@ model.
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 from ast import literal_eval
 from typing import TYPE_CHECKING
-from abc import ABC
 
 import numpy as np
 import pandas as pd
@@ -26,14 +26,177 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 if TYPE_CHECKING:
     from typing import Self
 
-__author__ = "ncfrey"
-__version__ = "0.1"
-__maintainer__ = "Nathan C. Frey"
-__email__ = "ncfrey@lbl.gov"
+# __author__ = "ncfrey"
+# __version__ = "0.1"
+# __maintainer__ = "Nathan C. Frey"
+# __email__ = "ncfrey@lbl.gov"
+# __status__ = "Development"
+# __date__ = "June 2019"
+
+__author__ = "Luca Frey"
+__version__ = "0.2"
+__maintainer__ = "Luca Frey"
+__email__ = "luca.frey@student.kit.edu"
 __status__ = "Development"
-__date__ = "June 2019"
+__date__ = "July 2026"
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TOL = 0.05  # Angstrom tolerance
+
+
+def _analyzer(structure: Structure, **kwargs) -> CollinearMagneticStructureAnalyzer:
+    """CollinearMagneticStructureAnalyzer factory with the settings used throughout this module.
+
+    ``make_primitive=False`` keeps the cell as given, ``threshold=0.0`` retains any nonzero
+    moment, and ``threshold_nonmag=100.0`` always zeroes out nonmagnetic ions, so induced
+    magnetic moments don't change the number of magnetic sites per unit cell between orderings.
+
+    Extra keyword arguments are passed through to the analyzer.
+    """
+    return CollinearMagneticStructureAnalyzer(
+        structure, **{"make_primitive": False, "threshold": 0.0, "threshold_nonmag": 100.0, **kwargs} # last value wins if there are multiple conflicting values for the same key -> defaults overridden by kwargs
+    )
+
+
+
+class MagneticOrdering(ABC):
+    """A single collinear magnetic configuration on a common parent lattice.
+
+    Base class holding one ordering's structure, its magnetic-only reduction,
+    its NN graph, and the parent-sublattice labels of its magnetic sites.
+    """
+
+    def __init__(self, structure: Structure, cutoff: float = 0, tol: float = DEFAULT_TOL):
+        self.structure = structure
+        self.analyzer = _analyzer(structure)
+        self.cutoff = cutoff
+        self.tol = tol
+        self.nn_graph = self._get_nn_graph()
+        self.magn_species: set[str] = {site.specie.symbol for site in self.magn_substructure}
+
+        self.sublattice_ids_dict: dict[tuple[int, ...], int] = {}
+        self.sublattice_labels: list[int] | None = None
+        self.sublattice_wyckoff_symbols: dict[int, str] = {}
+
+    @property
+    def magn_substructure(self) -> Structure:
+        return self._magnetic_only(self.structure)
+
+    @staticmethod
+    def _nonmagnetic(structure) -> Structure:
+        """Nonmagnetic copy of a structure (moments zeroed, all ions kept)."""
+        s0 = _analyzer(structure).get_nonmagnetic_structure(make_primitive=False)
+        if "wyckoff" in s0.site_properties:
+            s0.remove_site_property("wyckoff")
+        return s0
+
+    @staticmethod
+    def _magnetic_only(structure) -> Structure:
+        """Magnetic-only copy (nonmagnetic ions removed).
+
+        Whether a site is magnetic is decided by its *species*: only species listed in
+        CollinearMagneticStructureAnalyzer's default magmoms are treated as magnetic.
+
+        - Magnetic-species sites keep their existing magmom (any nonzero value is retained,
+          since ``threshold=0.0``). If the input has no magmom site property, the default magmoms are assigned (``replace_all_if_undefined``).
+        - Nonmagnetic-species sites always get a magmom of zero. Because ``threshold_nonmag=100.0``,
+          even induced moments on nonmagnetic ions are zeroed out, so the number of magnetic sites
+          per cell stays constant across orderings.
+
+        Finally, all sites with zero magmom are dropped (even if magnetic-species sites with magmom=0. or magmom=None) and only sites with nonzero magmom are kept.
+        """
+        # overwrite_magmom_mode: if the structure has no magmom site property, assign default magmoms to all magnetic species
+        return _analyzer(structure).get_structure_with_only_magnetic_atoms(make_primitive=False)
+
+    @staticmethod
+    def _sublattice_ids_dict(labels: list[int]) -> dict[tuple[int, ...], int]:
+        """Group site indices by sublattice id: {tuple(site indices): sublattice id}."""
+        groups: dict[int, list[int]] = {}
+        for idx, sub_id in enumerate(labels):
+            groups.setdefault(sub_id, []).append(idx)
+        return {tuple(indices): sub_id for sub_id, indices in groups.items()}
+    
+    def _get_nn_graph(self) -> StructureGraph:
+        """
+        NN StructureGraph of the magnetic-only structure.
+        
+        If self.cutoff is set, the graph includes all neighbors within that distance. 
+        Otherwise, only the nearest neighbors of each site are included.
+        """
+
+        strategy = MinimumDistanceNN(cutoff=self.cutoff, get_all_sites=True) if self.cutoff else MinimumDistanceNN()  # only NN
+        return StructureGraph.from_local_env_strategy(self.magn_substructure, strategy=strategy)
+    
+    @abstractmethod
+    def set_sublattice_ids(self) -> dict[tuple[int, ...], int]:
+        """
+        Sets the following properties for this ordering:
+            - `self.sublattice_ids_dict` = {tuple(site indices): sublattice id}
+            - `self.sublattice_wyckoff_symbols` = {sublattice id: wyckoff symbol}
+            - `self.sublattice_ids` = [sublattice id for each magnetic site in the ordering or None for nonmagnetic sites]
+
+        All nonmagnetic (`CollinearMagneticStructureAnalyzer` default_magmom=0) sites are grouped into one sublattice with label `None`.
+        
+        For `ParentOrdering`, this defines the sublattice ids by grouping symmetrically equivalent sites of ions into sublattices (nonmagnetic ions present for symmetry analysis). 
+        
+        For `RelaxedOrdering`, this is a mapping from the ordering's site indices to the sublattice ids via the finding the corresponding site in the parent for each site in the relaxed ordering.
+        
+        Finally, the sublattice ids are stored as a site property in the ordering's structure for easy access.
+        """
+
+
+class ParentOrdering(MagneticOrdering):
+    """The nonmagnetic parent cell that defines the sublattices.
+
+    Sublattices are its symmetry orbits (computed with nonmagnetic ions present),
+    restricted to the magnetic species.
+
+    """
+
+    def __init__(self, structure: Structure, cutoff: float = 0, tol: float = DEFAULT_TOL):
+        super().__init__(structure, cutoff, tol)
+        self.structure = self._nonmagnetic(structure)  # parent is always nonmagnetic
+        self.set_sublattice_ids()
+
+    def set_sublattice_ids(self):
+        symmetrized_parent = SpacegroupAnalyzer(self.structure).get_symmetrized_structure()
+        self.sublattice_ids = [None] * len(self.structure)
+        for indices, wyckoff_symbol in zip(symmetrized_parent.equivalent_indices, symmetrized_parent.wyckoff_symbols, strict=True):
+            assert all(symmetrized_parent[i].specie == symmetrized_parent[indices[0]].specie for i in indices)
+            if symmetrized_parent[indices[0]].specie.symbol not in self.magn_species:
+                continue
+            sub_id = len(self.sublattice_wyckoff_symbols)
+            self.sublattice_wyckoff_symbols[sub_id] = wyckoff_symbol # one sublattice always has one wyckoff symbol, but multiple sublattices can share the same wyckoff symbol (e.g. two species on the same wyckoff position)
+            for index in indices:
+                self.sublattice_ids[index] = sub_id
+
+        self.structure.add_site_property("sublattice_id", self.sublattice_ids)
+
+        self.sublattice_ids_dict = self._sublattice_ids_dict(self.sublattice_ids)
+
+
+class RelaxedOrdering(MagneticOrdering):
+    """One DFT-relaxed magnetic ordering with its energy and parent back-reference."""
+
+    def __init__(self, structure: Structure, energy: float, parent_ordering: ParentOrdering, cutoff: float = 0, tol: float = DEFAULT_TOL):
+        super().__init__(structure, cutoff, tol)
+        self.parent_ordering = parent_ordering
+        self.energy = energy
+        self.set_sublattice_ids()
+
+    def set_sublattice_ids(self):
+        matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
+
+        matched_parent = matcher.get_s2_like_s1(self._nonmagnetic(self.structure), self.parent_ordering.structure)
+        if matched_parent is None:
+            raise ValueError(
+                "The RelaxedOrdering is not a supercell of the ParentOrdering cell; it "
+                "cannot be mapped onto the parent sublattices."
+            )
+        self.sublattice_ids = [int(matched_parent[i].properties["sublattice_id"]) for i in range(len(self.structure))]
+
+
 
 
 class HeisenbergMapper:
@@ -52,7 +215,7 @@ class HeisenbergMapper:
         parent (Structure): Nonmagnetic parent cell that defines the sublattices.
         site_labels (list[list[int]]): site_labels[k][i] is the parent
             sublattice id of site i in ordering k.
-        wyckoff_ids (dict): Maps each sublattice id to its wyckoff symbol.
+        sublattice_wyckoff_symbols (dict): Maps each sublattice id to its wyckoff symbol.
         nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
         dists (dict): NN, NNN, and NNNN interaction distances.
         ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
@@ -60,7 +223,7 @@ class HeisenbergMapper:
             included 'E0' offset stays in eV.
     """
 
-    def __init__(self, ordered_structures, energies, parent=None, cutoff=0, tol: float = 0.02):
+    def __init__(self, ordered_structures, energies, parent, cutoff=0, tol: float = DEFAULT_TOL):
         """Exchange parameters are computed by mapping to a classical Heisenberg
         model. n+1 unique orderings are required to compute n exchange parameters.
 
@@ -74,16 +237,16 @@ class HeisenbergMapper:
             ordered_structures (list): Structure objects with magmoms.
             energies (list): Total energies of each relaxed magnetic structure.
             parent (Structure): Paramagnetic parent cell whose symmetry defines the
-                magnetic sublattices. If None, it is inferred as the primitive cell
-                of the lowest-energy ordering. Defaults to None.
+                magnetic sublattices. 
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
                 Defaults to 0 (only NN, no NNN, etc.).
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances
-                being equal.
+                being equal and structure matching.
         """
         # Save original copies of inputs
         self.ordered_structures_ = ordered_structures
         self.energies_ = energies
+        self.parent_ = parent
 
         # Sanitize inputs: standardize moments, convert energies to per magnetic
         # ion, drop duplicates and sort by energy. The screener keeps both a
@@ -103,7 +266,7 @@ class HeisenbergMapper:
         # every ordering with the parent sublattice it belongs to.
         self.parent = self._get_parent(parent, self.full_structures)
         self.parent_sgraph = self._get_graph(cutoff, self._magnetic_only(self.parent))
-        self.wyckoff_ids, self.site_labels, self.parent_site_labels = self._label_orderings(self.parent, self.full_structures)
+        self.sublattice_wyckoff_symbols, self.site_labels, self.parent_site_labels = self._label_orderings(self.parent, self.full_structures)
 
         # These attributes are set by internal methods
         self.nn_interactions = self.dists = self.ex_mat = self.ex_params = None
@@ -112,7 +275,7 @@ class HeisenbergMapper:
             raise SystemExit("We need at least 2 unique orderings.")
 
         self._get_nn_dict()
-        self._get_exchange_df()
+        self._build_exchange_matmat()
 
     @staticmethod
     def _get_graph(cutoff, structure):
@@ -129,138 +292,97 @@ class HeisenbergMapper:
         strategy = MinimumDistanceNN(cutoff=cutoff, get_all_sites=True) if cutoff else MinimumDistanceNN()  # only NN
         return StructureGraph.from_local_env_strategy(structure, strategy=strategy)
 
-    @staticmethod
-    def _nonmagnetic(structure):
-        """Nonmagnetic copy of a structure (moments zeroed, all ions kept)."""
-        s0 = CollinearMagneticStructureAnalyzer(
-            structure, make_primitive=False, threshold=0.0, threshold_nonmag=100.0
-        ).get_nonmagnetic_structure(make_primitive=False)
-        if "wyckoff" in s0.site_properties:
-            s0.remove_site_property("wyckoff")
-        return s0
 
-    @staticmethod
-    def _magnetic_only(structure):
-        """Magnetic-only copy of a structure (nonmagnetic ions removed).
+    # @classmethod
+    # def _get_parent(cls, parent, full_structures):
+    #     """Return the full primitive parent cell that defines the sublattices.
 
-        Magnetic sites are taken from CollinearMagneticStructureAnalyzer's
-        default magmoms, so this also works on a moment-less cell such as the
-        nonmagnetic parent: species that carry a default moment are kept, the
-        rest are dropped. Real moments are respected when the structure has them
-        ("replace_all_if_undefined" only falls back to defaults when no magmoms
-        are defined).
-        """
-        return CollinearMagneticStructureAnalyzer(
-            structure,
-            make_primitive=False,
-            overwrite_magmom_mode="replace_all_if_undefined",
-            threshold=0.0,
-            threshold_nonmag=100.0,
-        ).get_structure_with_only_magnetic_atoms(make_primitive=False)
+    #     The nonmagnetic ions are kept: site equivalence is read from this parent's
+    #     symmetry, and removing the nonmagnetic ions first can raise the apparent
+    #     site symmetry and merge sublattices that are actually distinct.
 
+    #     Args:
+    #         parent (Structure | None): Explicit paramagnetic parent (all ions). If
+    #             None, the primitive cell of the lowest-energy ordering is used.
+    #         full_structures (list[Structure]): Orderings with all ions retained.
 
-    @classmethod
-    def _get_parent(cls, parent, full_structures):
-        """Return the full primitive parent cell that defines the sublattices.
+    #     Returns:
+    #         Structure: Nonmagnetic primitive parent cell, nonmagnetic ions included.
+    #     """
+    #     ref = parent if parent is not None else full_structures[0]
+    #     return cls._nonmagnetic(ref).get_primitive_structure()
 
-        The nonmagnetic ions are kept: site equivalence is read from this parent's
-        symmetry, and removing the nonmagnetic ions first can raise the apparent
-        site symmetry and merge sublattices that are actually distinct.
+    # @classmethod
+    # def _label_orderings(cls, parent, full_structures):
+    #     """Label every magnetic site in every ordering with its parent sublattice.
 
-        Args:
-            parent (Structure | None): Explicit paramagnetic parent (all ions). If
-                None, the primitive cell of the lowest-energy ordering is used.
-            full_structures (list[Structure]): Orderings with all ions retained.
+    #     The magnetic sublattices are the parent's symmetry orbits, computed on the
+    #     *full* cell (nonmagnetic ions present) and then restricted to the magnetic
+    #     species. Each ordering is folded back onto the full parent so its sites
+    #     inherit the parent labels; the labels of the nonmagnetic sites are
+    #     discarded. This keeps the labels consistent across orderings that live in
+    #     different supercells, while preserving the true site symmetry.
 
-        Returns:
-            Structure: Nonmagnetic primitive parent cell, nonmagnetic ions included.
-        """
-        ref = parent if parent is not None else full_structures[0]
-        return cls._nonmagnetic(ref).get_primitive_structure()
+    #     Args:
+    #         parent (Structure): Nonmagnetic parent cell (all ions).
+    #         full_structures (list[Structure]): Orderings with all ions retained and
+    #             a 'magmom' site property on every site.
 
-    @classmethod
-    def _label_orderings(cls, parent, full_structures):
-        """Label every magnetic site in every ordering with its parent sublattice.
+    #     Returns:
+    #         tuple[dict, list[list[int]], list[int]]:
+    #             - sublattice_wyckoff_symbols maps each magnetic sublattice id to its wyckoff symbol.
+    #             - site_labels[k][i] is the sublattice id of magnetic site i in
+    #               ordering k (aligned with the magnetic-only graphs).
+    #             - parent_site_labels is the sublattice id of each site in the parent structure.
 
-        The magnetic sublattices are the parent's symmetry orbits, computed on the
-        *full* cell (nonmagnetic ions present) and then restricted to the magnetic
-        species. Each ordering is folded back onto the full parent so its sites
-        inherit the parent labels; the labels of the nonmagnetic sites are
-        discarded. This keeps the labels consistent across orderings that live in
-        different supercells, while preserving the true site symmetry.
+    #     Raises:
+    #         ValueError: If an ordering is not a supercell of the parent cell.
+    #     """
+    #     # Species that carry a moment in any ordering are the magnetic species.
+    #     mag_species = {site.specie.symbol for s in full_structures for site in s if abs(site.properties["magmom"]) > 0}
 
-        Args:
-            parent (Structure): Nonmagnetic parent cell (all ions).
-            full_structures (list[Structure]): Orderings with all ions retained and
-                a 'magmom' site property on every site.
+    #     # Sublattices = the parent's symmetry orbits restricted to magnetic
+    #     # species. Nonmagnetic sites get the sentinel -1 (never used).
+    #     symm_parent = SpacegroupAnalyzer(parent).get_symmetrized_structure()
+    #     parent_labels = [-1] * len(parent)
+    #     sublattice_wyckoff_symbols = {}
+    #     for indices, symbol in zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True):
+    #         if symm_parent[indices[0]].specie.symbol not in mag_species:
+    #             continue
+    #         sub_id = len(sublattice_wyckoff_symbols)
+    #         sublattice_wyckoff_symbols[sub_id] = symbol
+    #         for index in indices:
+    #             parent_labels[index] = sub_id
 
-        Returns:
-            tuple[dict, list[list[int]], list[int]]:
-                - wyckoff_ids maps each magnetic sublattice id to its wyckoff symbol.
-                - site_labels[k][i] is the sublattice id of magnetic site i in
-                  ordering k (aligned with the magnetic-only graphs).
-                - parent_site_labels is the sublattice id of each site in the parent structure.
+    #     # Carry the parent labels across to each ordering by folding the ordering's
+    #     # full geometry onto the tagged parent cell (the nonmagnetic ions help pin
+    #     # down a unique mapping). This also validates that every ordering is a
+    #     # genuine supercell of the parent.
+    #     tagged_parent = parent.copy()
+    #     tagged_parent.add_site_property("sublattice_id", parent_labels)
+    #     matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
 
-        Raises:
-            ValueError: If an ordering is not a supercell of the parent cell.
-        """
-        # Species that carry a moment in any ordering are the magnetic species.
-        mag_species = {site.specie.symbol for s in full_structures for site in s if abs(site.properties["magmom"]) > 0}
+    #     site_labels = []
+    #     for idx, full in enumerate(full_structures):
+    #         matched = matcher.get_s2_like_s1(cls._nonmagnetic(full), tagged_parent)
+    #         if matched is None:
+    #             raise ValueError(
+    #                 f"Ordering {idx} is not a supercell of the parent cell; it "
+    #                 "cannot be mapped onto the parent sublattices. Pass an explicit "
+    #                 "`parent` cell that all orderings share."
+    #             )
+    #         # matched[i] is the parent site that ordering site i folds onto. Keep
+    #         # only the magnetic sites, in order, so the labels align with the
+    #         # magnetic-only structure used to build the graphs.
+    #         magmoms = full.site_properties["magmom"]
+    #         site_labels.append(
+    #             [int(matched[i].properties["sublattice_id"]) for i in range(len(full)) if abs(magmoms[i]) > 0]
+    #         )
 
-        # Sublattices = the parent's symmetry orbits restricted to magnetic
-        # species. Nonmagnetic sites get the sentinel -1 (never used).
-        symm_parent = SpacegroupAnalyzer(parent).get_symmetrized_structure()
-        parent_labels = [-1] * len(parent)
-        wyckoff_ids = {}
-        for indices, symbol in zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True):
-            if symm_parent[indices[0]].specie.symbol not in mag_species:
-                continue
-            sub_id = len(wyckoff_ids)
-            wyckoff_ids[sub_id] = symbol
-            for index in indices:
-                parent_labels[index] = sub_id
+    #     parent_labels = [int(label) for label in parent_labels if label >= 0]  # drop nonmagnetic sites
 
-        # Carry the parent labels across to each ordering by folding the ordering's
-        # full geometry onto the tagged parent cell (the nonmagnetic ions help pin
-        # down a unique mapping). This also validates that every ordering is a
-        # genuine supercell of the parent.
-        tagged_parent = parent.copy()
-        tagged_parent.add_site_property("sublattice_id", parent_labels)
-        matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
+    #     return wyckoff_ids, site_labels, parent_labels
 
-        site_labels = []
-        for idx, full in enumerate(full_structures):
-            matched = matcher.get_s2_like_s1(cls._nonmagnetic(full), tagged_parent)
-            if matched is None:
-                raise ValueError(
-                    f"Ordering {idx} is not a supercell of the parent cell; it "
-                    "cannot be mapped onto the parent sublattices. Pass an explicit "
-                    "`parent` cell that all orderings share."
-                )
-            # matched[i] is the parent site that ordering site i folds onto. Keep
-            # only the magnetic sites, in order, so the labels align with the
-            # magnetic-only structure used to build the graphs.
-            magmoms = full.site_properties["magmom"]
-            site_labels.append(
-                [int(matched[i].properties["sublattice_id"]) for i in range(len(full)) if abs(magmoms[i]) > 0]
-            )
-
-        parent_labels = [int(label) for label in parent_labels if label >= 0]  # drop nonmagnetic sites
-
-        return wyckoff_ids, site_labels, parent_labels
-
-    @staticmethod
-    def _site_ids_dict(labels):
-        """Group site indices by sublattice id: {tuple(site indices): sublattice id}."""
-        groups: dict[int, list[int]] = {}
-        for idx, sub_id in enumerate(labels):
-            groups.setdefault(sub_id, []).append(idx)
-        return {tuple(indices): sub_id for sub_id, indices in groups.items()}
-
-    @property
-    def unique_site_ids(self):
-        """list[dict]: One {tuple(site indices): sublattice id} map per ordering."""
-        return [self._site_ids_dict(labels) for labels in self.site_labels]
 
     def _shell_of(self, dist):
         """Return 'nn'/'nnn'/'nnnn' for a distance, or None if it matches no shell."""
@@ -320,7 +442,7 @@ class HeisenbergMapper:
         # Keep at most n interactions for n+1 orderings
         return columns[: len(self.sgraphs) + 1]
 
-    def _get_exchange_df(self):
+    def _build_exchange_matmat(self):
         """Build the Heisenberg Hamiltonian, one row per ordering, by summing the
         signed products S_i . S_j over each graph. Sets self.ex_mat.
 
@@ -439,7 +561,7 @@ class HeisenbergMapper:
         fm_e = afm_e = fm_e_min = afm_e_min = 0
 
         for s, e in zip(self.ordered_structures, self.energies, strict=True):
-            ordering = CollinearMagneticStructureAnalyzer(s, threshold=0.0, threshold_nonmag=100.0, make_primitive=False).ordering
+            ordering = _analyzer(s).ordering
             magmoms = s.site_properties["magmom"]
 
             # Try to find matching orderings first
@@ -477,13 +599,9 @@ class HeisenbergMapper:
                     afm_e_min = e
 
         # Convert to magnetic structures with 'magmom' site property
-        fm_struct = CollinearMagneticStructureAnalyzer(
-            fm_struct, make_primitive=False, threshold=0.0, threshold_nonmag=100.0,
-        ).get_structure_with_only_magnetic_atoms(make_primitive=False)
+        fm_struct = _analyzer(fm_struct).get_structure_with_only_magnetic_atoms(make_primitive=False)
 
-        afm_struct = CollinearMagneticStructureAnalyzer(
-            afm_struct, make_primitive=False, threshold=0.0, threshold_nonmag=100.0,
-        ).get_structure_with_only_magnetic_atoms(make_primitive=False)
+        afm_struct = _analyzer(afm_struct).get_structure_with_only_magnetic_atoms(make_primitive=False)
 
         return fm_struct, afm_struct, fm_e, afm_e
 
@@ -597,7 +715,7 @@ class HeisenbergMapper:
                 j_exc = self._get_j_exc(labels[i], labels[j], c[-1])
                 # Only add bonds the fit actually parameterized. Unparameterized
                 # bonds (no matching sublattice-pair/shell in ex_params, exactly
-                # the bonds _get_exchange_df also ignores) get j_exc == 0, which
+                # the bonds _build_exchange_mat also ignores) get j_exc == 0, which
                 # StructureGraph.add_edge silently drops via its falsy-weight
                 # guard, leaving an edge with weight=None that breaks downstream
                 # per-bond consumers.
@@ -721,7 +839,7 @@ class HeisenbergScreener:
         # Keep both a full copy (all ions, needed for correct site symmetry) and
         # a magnetic-only copy (used to build the interaction graphs).
         # Make sure no induced moments are present (threshold_nonmag=100).
-        analyzers = [CollinearMagneticStructureAnalyzer(s, make_primitive=False, threshold=0.0, threshold_nonmag=100.0) for s in structures]
+        analyzers = [_analyzer(s) for s in structures]
         full_structures = [analyzer.structure for analyzer in analyzers]
         ordered_structures = [
             analyzer.get_structure_with_only_magnetic_atoms(make_primitive=False) for analyzer in analyzers

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -67,10 +67,10 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 if TYPE_CHECKING:
     from typing import Self
 
-__author__ = " Luca Frey"
+__author__ = "Luguza, ncfrey"
 __version__ = "0.2"
-__maintainer__ = "Luca Frey"
-__email__ = "luca.frey@student.kit.edu"
+__maintainer__ = "Luca Frey, Nathan C. Frey"
+__email__ = "luca.frey@student.kit.edu, ncfrey@lbl.gov"
 __status__ = "Development"
 __date__ = "July 2026"
 

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -63,6 +63,66 @@ def _analyzer(structure: Structure, **kwargs) -> CollinearMagneticStructureAnaly
     )
 
 
+class SublatticeMinimumDistanceNN(MinimumDistanceNN):
+    """Nearest-neighbor strategy taking the nearest shell of every sublattice pair.
+
+    ``MinimumDistanceNN`` is sublattice-blind: it keeps only the neighbors closer than
+    (1 + tol) times a site's *overall* nearest-neighbor distance. A sublattice pair whose
+    bond is longer than that then never enters the graph, so a structure whose sublattices
+    sit close together but are internally widely spaced yields only the inter-sublattice
+    bonds and no intra-sublattice ones.
+
+    Here the trial neighbors of a site are grouped by the sublattice they belong to and the
+    same window is applied within each group, so every sublattice pair the lattice realizes
+    within ``cutoff`` contributes its nearest shell, whatever the other pairs do.
+    """
+
+    def __init__(self, sublattice_ids: list[int], tol: float = 0.1, cutoff: float = 10) -> None:
+        """
+        Args:
+            sublattice_ids (list[int]): Sublattice id of each site, indexed against the
+                structure this strategy will be applied to.
+            tol (float): Relative tolerance on neighbor distances being in the same shell,
+                applied within a sublattice pair. Defaults to 0.1.
+            cutoff (float): Cutoff radius in Angstrom to look for trial neighbors in.
+                Defaults to 10.
+        """
+        super().__init__(tol=tol, cutoff=cutoff, get_all_sites=False)
+        self.sublattice_ids = sublattice_ids
+
+    def get_nn_info(self, structure: Structure, n: int) -> list[dict]:
+        """Nearest neighbors of site n, one shell per sublattice the neighbors belong to.
+
+        Args:
+            structure (Structure): input structure.
+            n (int): index of the site to find neighbors of.
+
+        Returns:
+            list[dict]: dicts with the neighbor site, its image, weight and site index.
+        """
+        by_sublattice: dict[int, list] = {}
+        for nn in structure.get_neighbors(structure[n], self.cutoff):
+            site_index = self._get_original_site(structure, nn)
+            by_sublattice.setdefault(self.sublattice_ids[site_index], []).append((nn, site_index))
+
+        siw = []
+        # The site's own sublattice is just another group here, so intra-sublattice bonds
+        # survive even when they are much longer than the shortest inter-sublattice one.
+        for neighbors in by_sublattice.values():
+            min_dist = min(nn.nn_distance for nn, _ in neighbors)
+            for nn, site_index in neighbors:
+                if nn.nn_distance < (1 + self.tol) * min_dist:
+                    siw.append(
+                        {
+                            "site": nn,
+                            "image": self._get_image(structure, nn),
+                            "weight": min_dist / nn.nn_distance,
+                            "site_index": site_index,
+                        }
+                    )
+        return siw
+
+
 class MagneticOrdering(ABC):
     """A single collinear magnetic configuration on a common parent lattice.
 
@@ -131,9 +191,17 @@ class MagneticOrdering(ABC):
         """NN StructureGraph of the magnetic-only structure.
 
         If self.cutoff is set, the graph includes all neighbors within that distance.
-        Otherwise, only the nearest neighbors of each site are included.
+        Otherwise each site keeps the nearest shell of every sublattice pair it takes part
+        in, so no pair drops out of the graph for being longer-ranged than another
+        (see SublatticeMinimumDistanceNN).
         """
-        strategy = MinimumDistanceNN(cutoff=self.cutoff, get_all_sites=True) if self.cutoff else MinimumDistanceNN()
+        if self.cutoff:
+            strategy = MinimumDistanceNN(cutoff=self.cutoff, get_all_sites=True)
+        else:
+            # Cached, so a graph built before the labels exist would be silently wrong.
+            if not self.sublattice_ids:
+                raise ValueError("Sublattice ids must be set before the nearest-neighbor graph is built.")
+            strategy = SublatticeMinimumDistanceNN(self.sublattice_ids)
         return StructureGraph.from_local_env_strategy(self.magnetic_structure, strategy=strategy)
 
     @abstractmethod
@@ -469,9 +537,10 @@ class HeisenbergMapper:
         nearest 0-0 and 0-1 interaction respectively, even when one of them is the longer interaction.
 
         Every distinct interaction the parent graph contains is kept, so which interactions are
-        parameterized follows entirely from how that graph is built: with cutoff=0 each
-        site keeps only its nearest neighbors (one nn-shell per sublattice pair, but every
-        pair the lattice realizes), with cutoff > 0 it keeps every interaction up to the cutoff.
+        parameterized follows entirely from how that graph is built: with cutoff=0 each site
+        keeps the nearest shell of every sublattice pair it takes part in, giving exactly one
+        'nn' interaction per pair the lattice realizes; with cutoff > 0 it keeps every
+        interaction up to the cutoff.
 
         Distances and connectivity are read from the parent ordering; see
         _initialize_orderings() for how the parent is defined and how the sublattices are

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -510,7 +510,31 @@ class HeisenbergMapper:
         return tuple(sorted((i_id, j_id)))
 
     def _interaction_label(self, i_id, j_id, dist):
-        """Return the J label of an interaction, or None if it matches no interaction.
+        """Return the J label of an interaction, or None if the pair does not interact.
+
+        The bond is assigned to the *closest* shell of its sublattice pair, so the shell
+        boundaries sit at the midpoints between consecutive parent distances and every bond
+        gets a label:
+
+                      nn               nnn               nnnn
+                ------o--------:---------o--------:--------o------->  dist
+                               :                  :
+                            midpoint           midpoint
+
+        Matching against a fixed +-tol window around each parent distance instead would leave
+        dead zones between the windows. Relaxation moves a bond off the parent distance it was
+        measured at, and one that drifts into a gap gets no label at all - dropping it silently
+        from both the fit and the interaction graph:
+
+                   [-- nn --]      x      [-- nnn --]     [-- nnnn --]
+                -------o---------------------o---------------o------->  dist
+                                   ^
+                             bond lands in the gap
+
+        _set_interactions separates consecutive shells by more than tol, so a midpoint is never
+        closer than tol/2 to either shell it divides. With cutoff=0 the assignment is exact: 
+        SublatticeMinimumDistanceNN gives each pair exactly one
+        shell, leaving nothing to choose between.
 
         Args:
             i_id (int): sublattice id of the ith site
@@ -520,13 +544,14 @@ class HeisenbergMapper:
         Returns:
             str | None: '<i>-<j>-<shell>' label, e.g. '0-1-nn'.
         """
-        for label in self.nn_interactions.get(self._order_sublattice_ids(i_id, j_id), ()):
-            if abs(dist - self.dists[label]) <= self.tol:
-                return label
-        logger.warning(
-            f"Interaction between sublattices {i_id} and {j_id} at {dist:.2f} Angstrom does not match any interaction in nn_interactions built from the parent:\n{self.nn_interactions}\n"
-        )
-        return None
+        labels = self.nn_interactions.get(self._order_sublattice_ids(i_id, j_id), ())
+        if not labels:
+            logger.warning(
+                f"Sublattices {i_id} and {j_id} interact at {dist:.2f} Angstrom but the pair does not appear in nn_interactions built from the parent:\n{self.nn_interactions}\n"
+            )
+            return None
+
+        return min(labels, key=lambda label: abs(dist - self.dists[label]))
 
     def _set_interactions(self):
         """Set self.dists and self.nn_interactions describing the distinct interactions.

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -11,10 +11,10 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from functools import cached_property
 from typing import TYPE_CHECKING
-from warnings import deprecated
 
 import numpy as np
 import pandas as pd
+from monty.dev import deprecated
 from monty.json import MSONable, jsanitize
 from monty.serialization import dumpfn
 
@@ -524,7 +524,7 @@ class HeisenbergMapper:
         columns = self._exchange_columns()
         j_columns = [c for c in columns if c not in ("E", "E0")]
 
-        if len(j_columns) < 2:  # Only <J> can be calculated
+        if len(j_columns) < 2:  # too few interactions to fit; get_exchange raises on this
             self.ex_mat = pd.DataFrame(columns=columns)
             return
 
@@ -584,8 +584,11 @@ class HeisenbergMapper:
 
         The rows of ex_mat multiply the raw magnetic moments in muB rather than normalized
         spins, so the fitted J_ij come out in meV/muB^2: it takes J_ij * m_i * m_j to get
-        the energy of a bond. This follows Frey et al., Sci. Adv. 6, eabd1076 (2020), where
-        "S is the magnitude of the average magnetic moment". Codes and papers working with
+        the energy of a bond. Leaving the moments unnormalized is deliberate: orderings
+        relax to different moment magnitudes, and it is the bond energy that should follow
+        the product m_i * m_j, while the interaction strength itself stays the same.
+        Normalizing every moment to 1 would fold that ordering-to-ordering variation into
+        the fitted J_ij as noise. Codes and papers working with
         normalized spins (VAMPIRE, UppASD, TB2J) instead report J in meV for
         E = -sum_<ij> J_ij e_i.e_j with |e| = 1; get_interaction_graph does that conversion.
 
@@ -594,17 +597,26 @@ class HeisenbergMapper:
                 the included 'E0' offset is in eV per magnetic ion (its column in ex_mat
                 is 1.0 and the fitted energies are per magnetic ion, so it comes out
                 intensive, which is what lets orderings of different size share one fit).
-            residual (float): Residual of the least-squares fit.
+            residual (float): Sum of squared residuals of the least-squares fit, in
+                (meV per magnetic ion)^2. It is a residual on the fitted energies, so
+                unlike the J_ij it keeps the per-magnetic-ion normalisation.
+
+        Raises:
+            ValueError: If the orderings constrain fewer than two exchange interactions,
+                leaving nothing for the fit to solve.
         """
         ex_mat = self.ex_mat
         E = ex_mat[["E"]]
-        j_names = [j for j in ex_mat.columns if j != "E"]
+        col_names = [c for c in ex_mat.columns if c != "E"]
 
-        # Only 1 NN interaction -> estimate <J> from E_AFM - E_FM
-        if len(j_names) < 3:
-            ex_params = {"<J>": self.estimate_exchange()}
-            self.ex_params = ex_params
-            return ex_params
+        # E0 and a single J cannot be fitted from the energies alone, so there is nothing
+        # to solve here.
+        if len(col_names) < 3:
+            raise ValueError(
+                f"Exchange matrix holds {len(col_names) - 1} interaction(s) besides E0; a least-squares "
+                "fit needs at least 2. Supply orderings whose nearest-neighbor shell holds more than "
+                "one sublattice pair, or set a cutoff so that further shells are included."
+            )
 
         # Fit E0 and the J_ij to the energies of every ordering
         H = np.array(ex_mat.loc[:, ex_mat.columns != "E"].values).astype(float)
@@ -623,6 +635,12 @@ class HeisenbergMapper:
 
         j_ij, residuals, rank, _singular = np.linalg.lstsq(H, E, rcond=None)
 
+        # lstsq only fills residuals for an overdetermined full-rank fit; for a square,
+        # underdetermined or rank-deficient one it returns an empty array, so compute the
+        # sum of squared residuals here. It sits on the energy side of the system, not the
+        # J_ij side, so it is a squared energy in (eV per magnetic ion)^2.
+        residual = float(residuals[0]) if residuals.size else float(np.sum((H @ j_ij - np.asarray(E)) ** 2))
+
         # A least-squares fit does not fail on a system it cannot determine,
         # it silently returns the minimum-norm solution. cond above cannot see this case:
         # with fewer rows than parameters it stays finite.
@@ -634,10 +652,11 @@ class HeisenbergMapper:
             )
 
         j_ij[1:] *= 1000  # J_ij in meV/muB^2 (E0 stays in eV per magnetic ion)
-        ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij.tolist(), strict=True)}
+        residual *= 1e6  # convert to (meV per magnetic ion)^2
+        ex_params = {j_name: j[0] for j_name, j in zip(col_names, j_ij.tolist(), strict=True)}
 
         self.ex_params = ex_params
-        self.residual = residuals[0]
+        self.residual = residual
         return self.ex_params, self.residual
 
     def get_low_energy_orderings(self):
@@ -698,9 +717,21 @@ class HeisenbergMapper:
 
         return fm_struct, afm_struct, fm_e, afm_e
 
-    @deprecated("<J> is in units of meV/magnetic ion.")
+    @deprecated(
+        get_exchange,
+        message=(
+            "<J> is a single average in meV/magnetic ion rather than a set of shell-resolved "
+            "J_ij, and it is only defined for a pair of FM/AFM orderings."
+        ),
+        category=DeprecationWarning,
+        deadline=(2027, 8, 1),
+    )
     def estimate_exchange(self, fm_struct=None, afm_struct=None, fm_e=None, afm_e=None):
         """Estimate <J> for a structure based on low energy FM and AFM orderings.
+
+        .. deprecated::
+            Use :meth:`get_exchange` instead, which fits shell-resolved J_ij over all
+            supplied orderings.
 
         Args:
             fm_struct (Structure): fm structure with 'magmom' site property
@@ -732,13 +763,23 @@ class HeisenbergMapper:
         return j_avg
 
     @deprecated(
-        "<J> is in units of meV/magnetic ion, double counts diagonal entries, and is only a crude estimate of the true exchange parameters."
+        message=(
+            "<J> is in units of meV/magnetic ion, the multi-sublattice branch double counts the "
+            "diagonal entries of omega, and the result is only a crude estimate of the true "
+            "critical temperature."
+        ),
+        category=DeprecationWarning,
+        deadline=(2027, 8, 1),
     )
     def get_mft_temperature(self, j_avg):
         """
         Crude mean field estimate of critical temperature based on <J> for
         one sublattice, or solving the coupled equations for a multi-sublattice
         material.
+
+        .. deprecated::
+            No direct replacement; use a Monte Carlo solver (e.g. VAMPIRE) on the
+            exchange parameters from :meth:`get_exchange` for a reliable T_c.
 
         Args:
             j_avg (float): Average exchange parameter (meV / magnetic ion)
@@ -808,10 +849,6 @@ class HeisenbergMapper:
             structure, edge_weight_name="exchange_constant", edge_weight_units="meV"
         )
 
-        javg_only = "<J>" in self.ex_params
-        if javg_only:
-            logger.warning("Only <J> is available. The interaction graph will not tell you much.")
-
         # J_ij exchange interaction matrix
         for i in range(len(nn_graph.graph.nodes)):
             for c in nn_graph.get_connected_sites(i):
@@ -820,11 +857,8 @@ class HeisenbergMapper:
                 j_exc = self._get_j_exc(sub_ids[i], sub_ids[j], c[-1])
                 # Weights are in meV, so fold this ordering's moments into the fitted
                 # meV/muB^2 parameters. Only the magnitudes enter: the relative orientation
-                # of the two sites belongs to the spin vectors, not to J_ij. The <J>
-                # fallback is already an energy (meV per magnetic ion, see
-                # estimate_exchange), so there is nothing to fold in there.
-                if not javg_only:
-                    j_exc *= abs(magmoms[i] * magmoms[j])
+                # of the two sites belongs to the spin vectors, not to J_ij.
+                j_exc *= abs(magmoms[i] * magmoms[j])
                 # Only add interactions the fit actually parameterized. Unparameterized
                 # interactions (no matching sublattice-pair/shell in ex_params, exactly
                 # the interactions _build_exchange_mat also ignores) get j_exc == 0, which
@@ -856,10 +890,6 @@ class HeisenbergMapper:
         """
         label = self._interaction_label(i_id, j_id, round(dist, DISTANCE_ROUND_DECIMALS))
 
-        # Check if only averaged NN <J> values are available
-        if "<J>" in self.ex_params:
-            return self.ex_params["<J>"] if label and label.endswith("-nn") else 0
-
         return self.ex_params.get(label, 0)
 
     def get_heisenberg_model(self):
@@ -868,6 +898,7 @@ class HeisenbergMapper:
         Returns:
             HeisenbergModel: MSONable object.
         """
+        ex_params, residual = self.get_exchange()
         return HeisenbergModel(
             formula=str(self.ordered_structures_[0].reduced_formula),
             structures=self.structures,
@@ -881,8 +912,8 @@ class HeisenbergMapper:
             nn_interactions=self.nn_interactions,
             dists=self.dists,
             ex_mat=self.ex_mat,
-            ex_params=self.get_exchange(),
-            javg=self.estimate_exchange(),
+            ex_params=ex_params,
+            residual=residual,
             igraph=self.get_interaction_graph(),
         )
 
@@ -985,7 +1016,7 @@ class HeisenbergModel(MSONable):
         dists=None,
         ex_mat=None,
         ex_params=None,
-        javg=None,
+        residual=None,
         igraph=None,
     ):
         """
@@ -1008,7 +1039,8 @@ class HeisenbergModel(MSONable):
             ex_params (dict): Exchange parameter values. The J_ij are in meV/muB^2 (they
                 multiply the raw moments, see HeisenbergMapper.get_exchange); the included
                 'E0' offset is in eV per magnetic ion.
-            javg (float): <J> exchange param (meV / magnetic ion).
+            residual (float): Sum of squared residuals of the fit that produced ex_params,
+                in (meV per magnetic ion)^2.
             igraph (StructureGraph): Exchange interaction graph, edge weights in meV.
         """
         self.formula = formula
@@ -1024,7 +1056,7 @@ class HeisenbergModel(MSONable):
         self.dists = dists
         self.ex_mat = ex_mat
         self.ex_params = ex_params
-        self.javg = javg
+        self.residual = residual
         self.igraph = igraph
 
     def as_dict(self):
@@ -1043,7 +1075,7 @@ class HeisenbergModel(MSONable):
             "sublattice_ids": self.sublattice_ids,
             "dists": self.dists,
             "ex_params": self.ex_params,
-            "javg": self.javg,
+            "residual": self.residual,
             "igraph": self.igraph.as_dict(),
             # Sanitize int keys / DataFrame
             "ex_mat": jsanitize(self.ex_mat.to_dict()),
@@ -1080,6 +1112,6 @@ class HeisenbergModel(MSONable):
             dists=dct["dists"],
             ex_mat=ex_mat,
             ex_params=dct["ex_params"],
-            javg=dct["javg"],
+            residual=dct["residual"],
             igraph=igraph,
         )

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -2,11 +2,50 @@
 This module implements a simple algorithm for extracting nearest neighbor
 exchange parameters by mapping low energy magnetic orderings to a Heisenberg
 model.
+
+Migrating from HeisenbergMapper 0.1
+-----------------------------------
+Sublattices used to be derived from the orderings themselves, which restricted
+all orderings to a single common supercell. They are now defined once on a
+paramagnetic *parent cell* and every ordering is mapped onto it, so orderings in
+different supercells can be fitted together. This changed the public surface:
+
+* ``HeisenbergMapper(ordered_structures, energies, cutoff, tol)`` gained a
+  ``parent`` argument in third position, so positional ``cutoff``/``tol`` move
+  along: ``HeisenbergMapper(ordered_structures, energies, parent, cutoff, tol)``.
+  Supply the paramagnetic parent cell whenever you have it; leaving it as None
+  infers it from the lowest-energy ordering and warns.
+* ``sgraphs`` is gone. Each ordering is now a :class:`RelaxedOrdering` in
+  ``mapper.orderings``, carrying its own ``structure``, ``magnetic_structure``,
+  ``energy`` and ``nn_graph``; ``mapper.nn_graphs`` gives the list of graphs.
+  Note these are built on the magnetic-only structure, not the full one.
+* ``unique_site_ids`` and ``wyckoff_ids`` are gone. Sublattices are now the
+  symmetry orbits of the parent: ``mapper.sublattice_ids`` labels the magnetic
+  sites of each ordering and ``mapper.sublattice_wyckoff_symbols`` maps a
+  sublattice id to its Wyckoff symbol.
+* ``ordered_structures`` (the screened, energy-sorted list) is now
+  ``mapper.structures``; ``mapper.energies`` keeps its name but now holds energy
+  *per magnetic ion* rather than total energy. The unmodified constructor
+  inputs are still ``ordered_structures_``/``energies_``.
+* ``get_exchange`` now returns ``(ex_params, residual)`` rather than
+  ``ex_params`` alone, and is a least-squares fit over all orderings instead of
+  an exactly-determined solve - so supplying more orderings than parameters is
+  now useful, and the ``{"<J>": ...}`` fallback for under-determined systems is
+  gone. ``residual`` is the RMS fit residual in meV per magnetic ion and is also
+  stored on ``mapper.residual`` and on :class:`HeisenbergModel`.
+* ``estimate_exchange`` and ``get_mft_temperature`` are deprecated. Use
+  ``get_exchange`` for shell-resolved ``J_ij``, and a Monte Carlo solver (e.g.
+  VAMPIRE, via :class:`HeisenbergModel`) rather than the mean field estimate for
+  a critical temperature.
+* ``HeisenbergScreener(ordered_structures, energies)`` now takes the list of
+  :class:`RelaxedOrdering` objects and exposes ``screened_orderings`` in place
+  of ``screened_structures``/``screened_energies``.
 """
 
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from ast import literal_eval
 from functools import cached_property
@@ -28,14 +67,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 if TYPE_CHECKING:
     from typing import Self
 
-# __author__ = "ncfrey"
-# __version__ = "0.1"
-# __maintainer__ = "Nathan C. Frey"
-# __email__ = "ncfrey@lbl.gov"
-# __status__ = "Development"
-# __date__ = "June 2019"
-
-__author__ = "Luca Frey"
+__author__ = " Luca Frey"
 __version__ = "0.2"
 __maintainer__ = "Luca Frey"
 __email__ = "luca.frey@student.kit.edu"
@@ -372,7 +404,8 @@ class HeisenbergMapper:
         ***IMPORTANT NOTE***
 
         If the parent is not supplied, it is inferred as the primitive cell of the lowest-energy ordering.
-        Not supplying a parent cell is only safe if the lowest-energy ordering still preserves the symmetry of the paramagnetic parent.
+        Not supplying a parent cell is only safe if the lowest-energy ordering still
+        preserves the symmetry of the paramagnetic parent.
         In most cases, relaxation will lower the symmetry and the parent cell must be supplied explicitly.
 
         Args:
@@ -418,9 +451,12 @@ class HeisenbergMapper:
 
         This function does:
          - Build a set of magnetic species pooled over all orderings.
-         - Build a RelaxedOrdering for each ordering, with its magnetic-only structure and NN graph. Since the parent is not yet known, the sublattice ids are not set yet.
-         - Drop duplicate/degenerate orderings and sort by energy per magnetic ion using HeisenbergScreener.
-         - Build the ParentOrdering from the lowest-energy ordering (or the explicit parent if supplied), and set its sublattice ids.
+         - Build a RelaxedOrdering for each ordering, with its magnetic-only structure and
+           NN graph. Since the parent is not yet known, the sublattice ids are not set yet.
+         - Drop duplicate/degenerate orderings and sort by energy per magnetic ion using
+           HeisenbergScreener.
+         - Build the ParentOrdering from the lowest-energy ordering (or the explicit parent
+           if supplied), and set its sublattice ids.
 
         Args:
             ordered_structures (list): Structure objects with magmoms.
@@ -429,10 +465,12 @@ class HeisenbergMapper:
                 it from the lowest-energy ordering.
 
         Raises:
-            SystemExit: If fewer than 2 unique orderings remain after screening.
+            ValueError: If fewer than 2 unique orderings remain after screening.
         """
-        # Pool the magnetic species over all orderings, to make sure a species that relaxes to zero moment in one ordering still counts as magnetic there.
-        # Since the magmom of this species is zero, it contributes a zero term to the Heisenberg Hamiltonian, but it stays on the lattice and keeps the site count and graph topology consistent with the other orderings.
+        # Pool the magnetic species over all orderings, to make sure a species that relaxes to
+        # zero moment in one ordering still counts as magnetic there. Since the magmom of this
+        # species is zero, it contributes a zero term to the Heisenberg Hamiltonian, but it stays
+        # on the lattice and keeps the site count and graph topology consistent with the others.
         magn_species = set().union(*(MagneticOrdering._magnetic_species(struct) for struct in ordered_structures))
 
         orderings = [
@@ -444,11 +482,22 @@ class HeisenbergMapper:
         self.orderings = HeisenbergScreener(orderings, screen=False).screened_orderings
 
         if len(self.orderings) < 2:
-            raise SystemExit("HeisenbergMapper needs at least 2 unique orderings.")
+            raise ValueError("HeisenbergMapper needs at least 2 unique orderings.")
 
         # The nonmagnetic ions are kept in the parent: site equivalence is read from its
         # symmetry, and removing them first can raise the apparent site symmetry and merge
         # sublattices that are actually distinct.
+        if parent is None:
+            warnings.warn(
+                "No `parent` cell supplied; the magnetic sublattices are inferred from the "
+                "primitive cell of the lowest-energy ordering. This is only correct if that "
+                "ordering still has the symmetry of the paramagnetic parent - relaxation "
+                "usually lowers it, which silently splits or merges sublattices. Pass an "
+                "explicit `parent` unless you have checked that it does not.",
+                UserWarning,
+                # _initialize_orderings <- __init__ <- caller
+                stacklevel=3,
+            )
         reference = parent if parent is not None else self.orderings[0].structure
         self.parent = ParentOrdering(
             MagneticOrdering._nonmagnetic(reference).get_primitive_structure(),
@@ -506,7 +555,10 @@ class HeisenbergMapper:
 
     @staticmethod
     def _order_sublattice_ids(i_id, j_id):
-        """Returns the sublattice_ids in the order (i, j) with i <= j. This is the key used to look up the interactions of a sublattice pair."""
+        """Returns the sublattice_ids in the order (i, j) with i <= j.
+
+        This is the key used to look up the interactions of a sublattice pair.
+        """
         return tuple(sorted((i_id, j_id)))
 
     def _interaction_label(self, i_id, j_id, dist):
@@ -532,7 +584,7 @@ class HeisenbergMapper:
                              bond lands in the gap
 
         _set_interactions separates consecutive shells by more than tol, so a midpoint is never
-        closer than tol/2 to either shell it divides. With cutoff=0 the assignment is exact: 
+        closer than tol/2 to either shell it divides. With cutoff=0 the assignment is exact:
         SublatticeMinimumDistanceNN gives each pair exactly one
         shell, leaving nothing to choose between.
 
@@ -547,7 +599,8 @@ class HeisenbergMapper:
         labels = self.nn_interactions.get(self._order_sublattice_ids(i_id, j_id), ())
         if not labels:
             logger.warning(
-                f"Sublattices {i_id} and {j_id} interact at {dist:.2f} Angstrom but the pair does not appear in nn_interactions built from the parent:\n{self.nn_interactions}\n"
+                f"Sublattices {i_id} and {j_id} interact at {dist:.2f} Angstrom but the pair "
+                f"does not appear in nn_interactions built from the parent:\n{self.nn_interactions}\n"
             )
             return None
 

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from ast import literal_eval
 from typing import TYPE_CHECKING
+from abc import ABC
 
 import numpy as np
 import pandas as pd
@@ -96,12 +97,13 @@ class HeisenbergMapper:
         self.tol = tol
 
         # Graph representation of each (magnetic-only) ordering
-        self.sgraphs = self._get_graphs(cutoff, self.ordered_structures)
+        self.sgraphs = [self._get_graph(cutoff, s) for s in self.ordered_structures]
 
         # The parent cell defines the sublattices; label every magnetic site in
         # every ordering with the parent sublattice it belongs to.
         self.parent = self._get_parent(parent, self.full_structures)
-        self.wyckoff_ids, self.site_labels = self._label_orderings(self.parent, self.full_structures)
+        self.parent_sgraph = self._get_graph(cutoff, self._magnetic_only(self.parent))
+        self.wyckoff_ids, self.site_labels, self.parent_site_labels = self._label_orderings(self.parent, self.full_structures)
 
         # These attributes are set by internal methods
         self.nn_interactions = self.dists = self.ex_mat = self.ex_params = None
@@ -113,19 +115,19 @@ class HeisenbergMapper:
         self._get_exchange_df()
 
     @staticmethod
-    def _get_graphs(cutoff, ordered_structures):
-        """Generate graph representations of magnetic structures with nearest
+    def _get_graph(cutoff, structure):
+        """Generate graph representations of a magnetic structure with nearest
         neighbor bonds. Right now this only works for MinimumDistanceNN.
 
         Args:
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
-            ordered_structures (list): Structure objects.
+            structure (Structure): A single magnetic structure.
 
         Returns:
-            list[StructureGraph]: One graph per ordering.
+            StructureGraph: The graph representation of the structure.
         """
         strategy = MinimumDistanceNN(cutoff=cutoff, get_all_sites=True) if cutoff else MinimumDistanceNN()  # only NN
-        return [StructureGraph.from_local_env_strategy(s, strategy=strategy) for s in ordered_structures]
+        return StructureGraph.from_local_env_strategy(structure, strategy=strategy)
 
     @staticmethod
     def _nonmagnetic(structure):
@@ -137,9 +139,29 @@ class HeisenbergMapper:
             s0.remove_site_property("wyckoff")
         return s0
 
+    @staticmethod
+    def _magnetic_only(structure):
+        """Magnetic-only copy of a structure (nonmagnetic ions removed).
+
+        Magnetic sites are taken from CollinearMagneticStructureAnalyzer's
+        default magmoms, so this also works on a moment-less cell such as the
+        nonmagnetic parent: species that carry a default moment are kept, the
+        rest are dropped. Real moments are respected when the structure has them
+        ("replace_all_if_undefined" only falls back to defaults when no magmoms
+        are defined).
+        """
+        return CollinearMagneticStructureAnalyzer(
+            structure,
+            make_primitive=False,
+            overwrite_magmom_mode="replace_all_if_undefined",
+            threshold=0.0,
+            threshold_nonmag=100.0,
+        ).get_structure_with_only_magnetic_atoms(make_primitive=False)
+
+
     @classmethod
     def _get_parent(cls, parent, full_structures):
-        """Return the nonmagnetic primitive parent cell that defines the sublattices.
+        """Return the full primitive parent cell that defines the sublattices.
 
         The nonmagnetic ions are kept: site equivalence is read from this parent's
         symmetry, and removing the nonmagnetic ions first can raise the apparent
@@ -173,10 +195,11 @@ class HeisenbergMapper:
                 a 'magmom' site property on every site.
 
         Returns:
-            tuple[dict, list[list[int]]]:
+            tuple[dict, list[list[int]], list[int]]:
                 - wyckoff_ids maps each magnetic sublattice id to its wyckoff symbol.
                 - site_labels[k][i] is the sublattice id of magnetic site i in
                   ordering k (aligned with the magnetic-only graphs).
+                - parent_site_labels is the sublattice id of each site in the parent structure.
 
         Raises:
             ValueError: If an ordering is not a supercell of the parent cell.
@@ -222,7 +245,9 @@ class HeisenbergMapper:
                 [int(matched[i].properties["sublattice_id"]) for i in range(len(full)) if abs(magmoms[i]) > 0]
             )
 
-        return wyckoff_ids, site_labels
+        parent_labels = [int(label) for label in parent_labels if label >= 0]  # drop nonmagnetic sites
+
+        return wyckoff_ids, site_labels, parent_labels
 
     @staticmethod
     def _site_ids_dict(labels):
@@ -248,12 +273,12 @@ class HeisenbergMapper:
         """Set self.dists and self.nn_interactions describing the unique NN, NNN and
         NNNN interactions between sublattices.
 
-        Distances and connectivity are read from the lowest-energy ordering, whose
-        per-site sublattice labels are already consistent with every other ordering.
+        Distances and connectivity are read from the parent ordering. See _get_parent() for how the parent is defined and how the sublattices are labelled. The connectivity is
+    read from the parent StructureGraph, which is built from the magnetic-only parent structure (nonmagnetic ions are ignored for the graph, but they are kept in the parent structure to preserve the true site symmetry).
         """
         tol = self.tol
-        sgraph = self.sgraphs[0]
-        labels = self.site_labels[0]
+        sgraph = self.parent_sgraph
+        labels = self.parent_site_labels
 
         # One representative site index per sublattice
         reps = {}

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -597,9 +597,13 @@ class HeisenbergMapper:
                 the included 'E0' offset is in eV per magnetic ion (its column in ex_mat
                 is 1.0 and the fitted energies are per magnetic ion, so it comes out
                 intensive, which is what lets orderings of different size share one fit).
-            residual (float): Sum of squared residuals of the least-squares fit, in
-                (meV per magnetic ion)^2. It is a residual on the fitted energies, so
-                unlike the J_ij it keeps the per-magnetic-ion normalisation.
+            residual (float): Root-mean-square residual of the least-squares fit, in meV
+                per magnetic ion. It is a residual on the fitted energies, so unlike the
+                J_ij it keeps the per-magnetic-ion normalisation, and averaging over the
+                orderings instead of summing makes it independent of how many orderings
+                went into the fit. Both normalisations together make it an intensive
+                measure of how well the Heisenberg model describes the energies, i.e.
+                one that is comparable between materials.
 
         Raises:
             ValueError: If the orderings constrain fewer than two exchange interactions,
@@ -639,7 +643,14 @@ class HeisenbergMapper:
         # underdetermined or rank-deficient one it returns an empty array, so compute the
         # sum of squared residuals here. It sits on the energy side of the system, not the
         # J_ij side, so it is a squared energy in (eV per magnetic ion)^2.
-        residual = float(residuals[0]) if residuals.size else float(np.sum((H @ j_ij - np.asarray(E)) ** 2))
+        ssr = float(residuals[0]) if residuals.size else float(np.sum((H @ j_ij - np.asarray(E)) ** 2))
+
+        # Take the root mean square over the orderings rather than the raw sum: the sum
+        # grows with the number of orderings, while the RMS stays a typical per-ordering
+        # energy error and can be compared between materials fitted from different numbers
+        # of orderings. Divided by the row count, not by the degrees of freedom, so that a
+        # square system (as many orderings as parameters) does not divide by zero.
+        residual = float(np.sqrt(ssr / H.shape[0]))
 
         # A least-squares fit does not fail on a system it cannot determine,
         # it silently returns the minimum-norm solution. cond above cannot see this case:
@@ -652,7 +663,7 @@ class HeisenbergMapper:
             )
 
         j_ij[1:] *= 1000  # J_ij in meV/muB^2 (E0 stays in eV per magnetic ion)
-        residual *= 1e6  # convert to (meV per magnetic ion)^2
+        residual *= 1000  # convert to meV per magnetic ion
         ex_params = {j_name: j[0] for j_name, j in zip(col_names, j_ij.tolist(), strict=True)}
 
         self.ex_params = ex_params
@@ -1039,8 +1050,9 @@ class HeisenbergModel(MSONable):
             ex_params (dict): Exchange parameter values. The J_ij are in meV/muB^2 (they
                 multiply the raw moments, see HeisenbergMapper.get_exchange); the included
                 'E0' offset is in eV per magnetic ion.
-            residual (float): Sum of squared residuals of the fit that produced ex_params,
-                in (meV per magnetic ion)^2.
+            residual (float): Root-mean-square residual of the fit that produced ex_params,
+                in meV per magnetic ion. Intensive in both the cell size and the number of
+                orderings, so it is comparable between materials.
             igraph (StructureGraph): Exchange interaction graph, edge weights in meV.
         """
         self.formula = formula

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -130,7 +130,7 @@ class HeisenbergMapper:
     def _nonmagnetic(structure):
         """Nonmagnetic copy of a structure (moments zeroed, all ions kept)."""
         s0 = CollinearMagneticStructureAnalyzer(
-            structure, make_primitive=False, threshold=0.0
+            structure, make_primitive=False, threshold=0.0, threshold_nonmag=100.0
         ).get_nonmagnetic_structure(make_primitive=False)
         if "wyckoff" in s0.site_properties:
             s0.remove_site_property("wyckoff")
@@ -399,7 +399,7 @@ class HeisenbergMapper:
         fm_e = afm_e = fm_e_min = afm_e_min = 0
 
         for s, e in zip(self.ordered_structures, self.energies, strict=True):
-            ordering = CollinearMagneticStructureAnalyzer(s, threshold=0, make_primitive=False).ordering
+            ordering = CollinearMagneticStructureAnalyzer(s, threshold=0.0, threshold_nonmag=100.0, make_primitive=False).ordering
             magmoms = s.site_properties["magmom"]
 
             # Try to find matching orderings first
@@ -438,11 +438,11 @@ class HeisenbergMapper:
 
         # Convert to magnetic structures with 'magmom' site property
         fm_struct = CollinearMagneticStructureAnalyzer(
-            fm_struct, make_primitive=False, threshold=0.0
+            fm_struct, make_primitive=False, threshold=0.0, threshold_nonmag=100.0,
         ).get_structure_with_only_magnetic_atoms(make_primitive=False)
 
         afm_struct = CollinearMagneticStructureAnalyzer(
-            afm_struct, make_primitive=False, threshold=0.0
+            afm_struct, make_primitive=False, threshold=0.0, threshold_nonmag=100.0,
         ).get_structure_with_only_magnetic_atoms(make_primitive=False)
 
         return fm_struct, afm_struct, fm_e, afm_e
@@ -672,7 +672,8 @@ class HeisenbergScreener:
         # Standardize moments (zero threshold so small moments are preserved).
         # Keep both a full copy (all ions, needed for correct site symmetry) and
         # a magnetic-only copy (used to build the interaction graphs).
-        analyzers = [CollinearMagneticStructureAnalyzer(s, make_primitive=False, threshold=0.0) for s in structures]
+        # Make sure no induced moments are present (threshold_nonmag=100).
+        analyzers = [CollinearMagneticStructureAnalyzer(s, make_primitive=False, threshold=0.0, threshold_nonmag=100.0) for s in structures]
         full_structures = [analyzer.structure for analyzer in analyzers]
         ordered_structures = [
             analyzer.get_structure_with_only_magnetic_atoms(make_primitive=False) for analyzer in analyzers

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -19,6 +19,7 @@ from monty.serialization import dumpfn
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import MinimumDistanceNN
 from pymatgen.analysis.magnetism import CollinearMagneticStructureAnalyzer, Ordering
+from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
@@ -41,7 +42,8 @@ class HeisenbergMapper:
     Attributes:
         strategy (object): Class from pymatgen.analysis.local_env for constructing graphs.
         sgraphs (list): StructureGraph objects.
-        unique_site_ids (dict): Maps each site to its unique numerical identifier.
+        unique_site_ids (list[dict]): One unique_site_ids dict per ordering, with
+            identifiers shared across orderings via a common parent cell.
         wyckoff_ids (dict): Maps unique numerical identifier to wyckoff position.
         nn_interactions (dict): {i: j} pairs of NN interactions between unique sites.
         dists (dict): NN, NNN, and NNNN interaction distances
@@ -87,8 +89,9 @@ class HeisenbergMapper:
         # Get graph representations
         self.sgraphs = self._get_graphs(cutoff, ordered_structures)
 
-        # Get unique site ids and wyckoff symbols
-        self.unique_site_ids, self.wyckoff_ids = self._get_unique_sites(ordered_structures[0])
+        # Get unique site ids (one map per ordering, anchored to a common
+        # parent cell) and wyckoff symbols
+        self.unique_site_ids, self.wyckoff_ids = self._get_unique_sites(ordered_structures)
 
         # These attributes are set by internal methods
         self.nn_interactions = self.dists = self.ex_mat = self.ex_params = None
@@ -120,43 +123,117 @@ class HeisenbergMapper:
         return [StructureGraph.from_local_env_strategy(s, strategy=strategy) for s in ordered_structures]
 
     @staticmethod
-    def _get_unique_sites(structure):
-        """Get dict that maps site indices to unique identifiers.
+    def _get_unique_sites(
+        structures: list[Structure],
+        parent: Structure | None = None,
+        pre_relaxation: list[Structure] | None = None,
+    ):
+        """Map sites to unique identifiers that are consistent across orderings.
+
+        Site identifiers are anchored to a common *parent cell* so that the same
+        crystallographic orbit receives the same id in every ordering,
+        independent of supercell size. This keeps the J_ij interaction labels
+        consistent across orderings that live in different supercells.
+
+        The parent cell is, in order of preference:
+
+        1. ``parent`` if provided (the paramagnetic cell fed to the enumeration);
+        2. otherwise the first input structure's primitive cell.
+
+        Symmetry is analysed on a nonmagnetic copy (magnetic moments zeroed) that retains
+        whatever ions are present, so e.g. an anion sublattice still constrains
+        the orbits.
+
+        When ``pre_relaxation`` is supplied, its undistorted
+        geometries are used for the symmetry analysis and site matching
+        (relaxation can artificially lower the detected symmetry); the resulting
+        ids still apply to ``structures`` because relaxation preserves site
+        ordering.
 
         Args:
-            structure (Structure): ground state Structure object.
+            structures (list[Structure]): Magnetic orderings to label.
+            parent (Structure): Paramagnetic parent cell. If None, the first
+                input structure's primitive cell is used as the parent.
+            pre_relaxation (list[Structure]): Enumerated orderings before
+                relaxation, aligned index-for-index with ``structures``.
 
         Returns:
-            tuple[dict, dict]: unique_site_ids maps tuples of equivalent site indices to a
-                unique int identifier.
-                wyckoff_ids maps tuples of equivalent site indices to their wyckoff symbols
+            tuple[list[dict], dict]:
+                - list of unique_site_ids dicts, one per input structure; each
+                  maps a tuple of equivalent site indices to a global int id
+                  that is shared across all structures.
+                - wyckoff_ids maps each global int id to its wyckoff symbol.
+
+        Raises:
+            ValueError: If a structure is not a supercell of the parent cell.
         """
-        # Get a nonmagnetic representation of the supercell geometry
-        s0 = CollinearMagneticStructureAnalyzer(
-            structure, make_primitive=False, threshold=0.0
-        ).get_nonmagnetic_structure(make_primitive=False)
 
-        # Get unique sites and wyckoff positions
-        if "wyckoff" in s0.site_properties:
-            s0.remove_site_property("wyckoff")
+        def nonmagnetic(struct):
+            """Zero the moments but keep every ion, for symmetry analysis."""
+            s0 = CollinearMagneticStructureAnalyzer(
+                struct, make_primitive=False, threshold=0.0
+            ).get_nonmagnetic_structure(make_primitive=False)
+            if "wyckoff" in s0.site_properties:
+                s0.remove_site_property("wyckoff")
+            return s0
 
-        symm_s0 = SpacegroupAnalyzer(s0).get_symmetrized_structure()
-        wyckoff = ["n/a"] * len(symm_s0)
-        equivalent_indices = symm_s0.equivalent_indices
-        wyckoff_symbols = symm_s0.wyckoff_symbols
+        geometries = pre_relaxation if pre_relaxation is not None else structures
 
-        # Construct dictionaries that map sites to numerical and wyckoff
-        # identifiers
-        unique_site_ids = {}
-        wyckoff_ids = {}
+        if parent is not None:
+            parent_struct = nonmagnetic(parent)
+        else:
+            parent_struct = nonmagnetic(geometries[0].get_primitive_structure())
 
-        for idx, (indices, symbol) in enumerate(zip(equivalent_indices, wyckoff_symbols, strict=True)):
-            unique_site_ids[tuple(indices)] = idx
-            wyckoff_ids[idx] = symbol
+        # The parent's symmetry orbits define the global site identifiers.
+        symm_parent = SpacegroupAnalyzer(parent_struct).get_symmetrized_structure()
+        parent_orbit = {}  # parent site index -> global id
+        wyckoff_ids = {}  # global id -> wyckoff symbol
+        for goid, (indices, symbol) in enumerate(
+            zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True)
+        ):
+            wyckoff_ids[goid] = symbol
             for index in indices:
-                wyckoff[index] = symbol
+                parent_orbit[index] = goid
+
+        # Tag each parent site with its orbit id so the StructureMatcher can
+        # carry the labels across when it folds each ordering back onto the
+        # parent.
+        parent_struct.add_site_property("orbit_id", [parent_orbit[idx] for idx in range(len(parent_struct))])
+        matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
+
+        unique_site_ids = []
+        for s_idx, geom in enumerate(geometries):
+            s0 = nonmagnetic(geom)
+
+            # get_s2_like_s1 returns the parent supercell reordered so that its
+            # i-th site coincides with the i-th ordering site, or None if the
+            # ordering is not a (super)cell of the parent.
+            matched_parent = matcher.get_s2_like_s1(s0, parent_struct)
+            if matched_parent is None:
+                raise ValueError(
+                    f"Structure {s_idx} is not a supercell of the parent cell; its "
+                    "orderings cannot be mapped onto a common set of sites."
+                )
+
+            # matched_parent[i] is the parent site that ordering site i maps
+            # onto, so its orbit id is the global id of ordering site i. Collect
+            # all ordering sites that share each orbit id.
+            sites_by_orbit = {}
+            for site_idx, parent_site in enumerate(matched_parent.sites):
+                orbit_id = parent_site.properties["orbit_id"]
+                sites_by_orbit.setdefault(orbit_id, []).append(site_idx)
+
+            unique_site_ids.append({tuple(sorted(idxs)): goid for goid, idxs in sites_by_orbit.items()})
 
         return unique_site_ids, wyckoff_ids
+
+    @staticmethod
+    def _global_orbit_id(site_ids: dict, site_idx: int) -> int | None:
+        """Global id of the orbit containing site_idx, or None."""
+        for indices, goid in site_ids.items():
+            if site_idx in indices:
+                return goid
+        return None
 
     def _get_nn_dict(self):
         """Set self.nn_interactions and self.dists instance variables describing unique
@@ -164,7 +241,8 @@ class HeisenbergMapper:
         """
         tol = self.tol  # tolerance on NN distances
         sgraph = self.sgraphs[0]
-        unique_site_ids = self.unique_site_ids
+        # Distances/labels are derived from the first ordering, so use its map.
+        unique_site_ids = self.unique_site_ids[0]
 
         nn_dict = {}
         nnn_dict = {}
@@ -175,7 +253,7 @@ class HeisenbergMapper:
         # Loop over unique sites and get neighbor distances up to NNNN
         for k in unique_site_ids:
             i = k[0]
-            i_key = unique_site_ids[k]
+            i_goid = unique_site_ids[k]
             connected_sites = sgraph.get_connected_sites(i)
             dists = [round(cs[-1], 2) for cs in connected_sites]  # i<->j distances
             dists = sorted(set(dists))  # NN, NNN, NNNN, etc.
@@ -202,7 +280,7 @@ class HeisenbergMapper:
         # Get dictionary keys for interactions
         for k in unique_site_ids:
             i = k[0]
-            i_key = unique_site_ids[k]
+            i_goid = unique_site_ids[k]
             connected_sites = sgraph.get_connected_sites(i)
 
             # Loop over sites and determine unique NN, NNN, etc. interactions
@@ -210,16 +288,13 @@ class HeisenbergMapper:
                 dist = round(cs[-1], 2)  # i_j distance
 
                 j = cs[2]  # j index
-                j_key = None
-                for key, value in unique_site_ids.items():
-                    if j in key:
-                        j_key = value
+                j_goid = self._global_orbit_id(unique_site_ids, j)
                 if abs(dist - dists["nn"]) <= tol:
-                    nn_dict[i_key] = j_key
+                    nn_dict[i_goid] = j_goid
                 elif abs(dist - dists["nnn"]) <= tol:
-                    nnn_dict[i_key] = j_key
+                    nnn_dict[i_goid] = j_goid
                 elif abs(dist - dists["nnnn"]) <= tol:
-                    nnnn_dict[i_key] = j_key
+                    nnnn_dict[i_goid] = j_goid
 
         nn_interactions = {"nn": nn_dict, "nnn": nnn_dict, "nnnn": nnnn_dict}
 
@@ -274,18 +349,22 @@ class HeisenbergMapper:
             # Loop over all sites in each graph and compute |S_i . S_j|
             # for n+1 unique graphs to compute n exchange params
             order = ""
-            for _graph in sgraphs:
+            for graph_idx, _graph in enumerate(sgraphs):
                 sgraph = sgraphs_copy.pop(0)
+                # Each ordering lives in its own supercell, so resolve site
+                # indices against that ordering's map; the global ids it returns
+                # are shared across orderings (and with nn_interactions).
+                site_ids = unique_site_ids[graph_idx]
+                # Invert {sites: goid} -> {site: goid} once so the per-connection
+                # lookups below are O(1) instead of scanning every orbit.
+                goid_by_site = {site: goid for sites, goid in site_ids.items() for site in sites}
                 ex_row = pd.DataFrame(np.zeros((1, n_nn_j + 1)), index=[sgraph_index], columns=columns)
 
                 for idx, _node in enumerate(sgraph.graph.nodes):
                     # s_i_sign = np.sign(sgraph.structure.site_properties['magmom'][i])
                     s_i = sgraph.structure.site_properties["magmom"][idx]
 
-                    i_index = None
-                    for k, v in unique_site_ids.items():
-                        if idx in k:
-                            i_index = v
+                    i_goid = goid_by_site.get(idx)
 
                     # Get all connections for ith site and compute |S_i . S_j|
                     connections = sgraph.get_connected_sites(idx)
@@ -299,10 +378,7 @@ class HeisenbergMapper:
                         # s_j_sign = np.sign(sgraph.structure.site_properties['magmom'][j_site])
                         s_j = sgraph.structure.site_properties["magmom"][j_site]
 
-                        j_index = None
-                        for k, v in unique_site_ids.items():
-                            if j_site in k:
-                                j_index = v
+                        j_goid = goid_by_site.get(j_site)
 
                         # Determine order of connection
                         if abs(dist - dists["nn"]) <= tol:
@@ -312,13 +388,23 @@ class HeisenbergMapper:
                         elif abs(dist - dists["nnnn"]) <= tol:
                             order = "-nnnn"
 
-                        j_ij = f"{i_index}-{j_index}{order}"
-                        j_ji = f"{j_index}-{i_index}{order}"
+                        j_ij = f"{i_goid}-{j_goid}{order}"
+                        j_ji = f"{j_goid}-{i_goid}{order}"
 
                         if j_ij in ex_mat.columns:
                             ex_row.loc[sgraph_index, j_ij] -= s_i * s_j
                         elif j_ji in ex_mat.columns:
                             ex_row.loc[sgraph_index, j_ji] -= s_i * s_j
+
+                # The interaction sums above are extensive (summed over the whole
+                # supercell), but the energies are per magnetic ion (see
+                # HeisenbergScreener._do_cleanup).
+                # Normalising each row by its site count puts every ordering on
+                # the same per-ion normalisation, so orderings living in
+                # different-sized supercells can share a single fit.
+                # This also means that the E0 contribution is per magnetic ion,
+                # which the nonmagnetic energy contribution should be.
+                ex_row[j_columns] /= len(sgraph.structure)
 
                 # Ignore the row if it is a duplicate to avoid singular matrix
                 # Create a temporary DataFrame with the new row
@@ -500,7 +586,9 @@ class HeisenbergMapper:
         Returns:
             float: Critical temperature mft_t (K)
         """
-        n_sub_lattices = len(self.unique_site_ids)
+        # Number of magnetic sublattices = number of distinct global site ids
+        # (one per parent orbit), not the number of orderings.
+        n_sub_lattices = len(self.wyckoff_ids)
         k_boltzmann = 0.0861733  # meV/K
 
         # Only 1 magnetic sublattice
@@ -533,18 +621,22 @@ class HeisenbergMapper:
 
         return mft_t
 
-    def get_interaction_graph(self, filename=None):
+    def get_interaction_graph(self, filename=None, ordering_index=0):
         """Get a StructureGraph with edges and weights that correspond to exchange
         interactions and J_ij values, respectively.
 
         Args:
             filename (str): if not None, save interaction graph to filename.
+            ordering_index (int): Which ordering (and its supercell) to build the
+                interaction graph for. Site indices and the J_ij lookup use this
+                ordering's map. Defaults to 0 (the lowest-energy ordering).
 
         Returns:
             StructureGraph: Exchange interaction graph.
         """
-        structure = self.ordered_structures[0]
-        sgraph = self.sgraphs[0]
+        structure = self.ordered_structures[ordering_index]
+        sgraph = self.sgraphs[ordering_index]
+        site_ids = self.unique_site_ids[ordering_index]
 
         igraph = StructureGraph.from_empty_graph(
             structure, edge_weight_name="exchange_constant", edge_weight_units="meV"
@@ -565,7 +657,7 @@ class HeisenbergMapper:
                 j = c[2]  # index of neighbor
                 dist = c[-1]  # i <-> j distance
 
-                j_exc = self._get_j_exc(idx, j, dist)
+                j_exc = self._get_j_exc(idx, j, dist, site_ids)
 
                 igraph.add_edge(idx, j, to_jimage=jimage, weight=j_exc, warn_duplicates=False)
 
@@ -578,7 +670,7 @@ class HeisenbergMapper:
 
         return igraph
 
-    def _get_j_exc(self, i, j, dist):
+    def _get_j_exc(self, i, j, dist, site_ids):
         """
         Convenience method for looking up exchange parameter between two sites.
 
@@ -587,17 +679,18 @@ class HeisenbergMapper:
             j (int): index of jth site
             dist (float): distance (Angstrom) between sites
                 (10E-2 precision)
+            site_ids (dict): The unique_site_ids map (``self.unique_site_ids[k]``)
+                for the ordering that i and j index into, so their site indices
+                resolve to the correct global orbit ids.
 
         Returns:
             float: Exchange parameter J_exc in meV
         """
-        # Get unique site identifiers
-        i_index = j_index = 0
-        for k, v in self.unique_site_ids.items():
-            if i in k:
-                i_index = v
-            if j in k:
-                j_index = v
+        # Resolve site indices to global orbit ids using the caller-supplied map
+        # for the ordering i and j belong to. A missing site yields None, which
+        # simply won't match any J_ij key below (rather than aliasing to orbit 0).
+        i_index = self._global_orbit_id(site_ids, i)
+        j_index = self._global_orbit_id(site_ids, j)
 
         # Determine order of interaction
         order = ""
@@ -833,8 +926,9 @@ class HeisenbergModel(MSONable):
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances being equal.
             sgraphs (list): StructureGraph objects.
-            unique_site_ids (dict): Maps each site to its unique numerical
-                identifier.
+            unique_site_ids (list[dict]): One map per ordering; each maps a tuple
+                of equivalent site indices to a global orbit identifier shared across
+                orderings.
             wyckoff_ids (dict): Maps unique numerical identifier to wyckoff
                 position.
             nn_interactions (dict): {i: j} pairs of NN interactions
@@ -944,48 +1038,3 @@ class HeisenbergModel(MSONable):
             javg=dct["javg"],
             igraph=igraph,
         )
-
-    def _get_j_exc(self, i, j, dist):
-        """
-        Convenience method for looking up exchange parameter between two sites.
-
-        Args:
-            i (int): index of ith site
-            j (int): index of jth site
-            dist (float): distance (Angstrom) between sites +- tol
-
-        Returns:
-            float: Exchange parameter J_exc in meV
-        """
-        # Get unique site identifiers
-        i_index = j_index = 0
-        for k in self.unique_site_ids:
-            if i in k:
-                i_index = self.unique_site_ids[k]
-            if j in k:
-                j_index = self.unique_site_ids[k]
-
-        # Determine order of interaction
-        order = ""
-        if abs(dist - self.dists["nn"]) <= self.tol:
-            order = "-nn"
-        elif abs(dist - self.dists["nnn"]) <= self.tol:
-            order = "-nnn"
-        elif abs(dist - self.dists["nnnn"]) <= self.tol:
-            order = "-nnnn"
-
-        j_ij = f"{i_index}-{j_index}{order}"
-        j_ji = f"{j_index}-{i_index}{order}"
-
-        if j_ij in self.ex_params:
-            j_exc = self.ex_params[j_ij]
-        elif j_ji in self.ex_params:
-            j_exc = self.ex_params[j_ji]
-        else:
-            j_exc = 0
-
-        # Check if only averaged NN <J> values are available
-        if "<J>" in self.ex_params and order == "-nn":
-            j_exc = self.ex_params["<J>"]
-
-        return j_exc

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from ast import literal_eval
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -43,7 +44,7 @@ __date__ = "July 2026"
 logger = logging.getLogger(__name__)
 
 DEFAULT_TOL = 0.05  # Angstrom tolerance
-
+DISTANCE_ROUND_DECIMALS = 2  # Round distances to this many decimals when matching interactions
 
 def _analyzer(structure: Structure, **kwargs) -> CollinearMagneticStructureAnalyzer:
     """CollinearMagneticStructureAnalyzer factory with the settings used throughout this module.
@@ -54,10 +55,10 @@ def _analyzer(structure: Structure, **kwargs) -> CollinearMagneticStructureAnaly
 
     Extra keyword arguments are passed through to the analyzer.
     """
+    # Last value wins on conflicting keys, so the defaults above are overridden by kwargs.
     return CollinearMagneticStructureAnalyzer(
-        structure, **{"make_primitive": False, "threshold": 0.0, "threshold_nonmag": 100.0, **kwargs} # last value wins if there are multiple conflicting values for the same key -> defaults overridden by kwargs
+        structure, **{"make_primitive": False, "threshold": 0.0, "threshold_nonmag": 100.0, **kwargs}
     )
-
 
 
 class MagneticOrdering(ABC):
@@ -67,21 +68,37 @@ class MagneticOrdering(ABC):
     its NN graph, and the parent-sublattice labels of its magnetic sites.
     """
 
-    def __init__(self, structure: Structure, cutoff: float = 0, tol: float = DEFAULT_TOL):
-        self.structure = structure
+    def __init__(
+        self,
+        structure: Structure,
+        magn_species: set[str],
+        cutoff: float = 0,
+        tol: float = DEFAULT_TOL,
+    ):
         self.analyzer = _analyzer(structure)
+        # The analyzer works on a copy, so the caller's structure is never mutated. On
+        # this copy every site carries a float 'magmom' site property, whether the input
+        # supplied moments as site properties or as species spins, and induced moments on
+        # nonmagnetic ions have been zeroed out. Moment magnitudes are left untouched.
+        self.structure = self.analyzer.structure
+        self.magn_species = magn_species
         self.cutoff = cutoff
         self.tol = tol
-        self.nn_graph = self._get_nn_graph()
-        self.magn_species: set[str] = {site.specie.symbol for site in self.magn_substructure}
 
-        self.sublattice_ids_dict: dict[tuple[int, ...], int] = {}
-        self.sublattice_labels: list[int] | None = None
+        self.sublattice_ids: list[int] = []
         self.sublattice_wyckoff_symbols: dict[int, str] = {}
 
-    @property
-    def magn_substructure(self) -> Structure:
-        return self._magnetic_only(self.structure)
+    @cached_property
+    def magnetic_structure(self) -> Structure:
+        """Magnetic-only cell. nn_graph and sublattice_ids are both indexed against this.
+
+        Membership is decided by *species*, not by moment, using the magnetic species
+        pooled over every ordering (see ``HeisenbergMapper._initialize_orderings``). A
+        magnetic ion whose moment happens to relax to zero therefore stays on the lattice
+        and contributes a zero term, rather than dropping out and changing this ordering's
+        site count, graph topology and per-ion energy relative to its siblings.
+        """
+        return Structure.from_sites([site for site in self.structure if site.specie.symbol in self.magn_species])
 
     @staticmethod
     def _nonmagnetic(structure) -> Structure:
@@ -92,57 +109,50 @@ class MagneticOrdering(ABC):
         return s0
 
     @staticmethod
-    def _magnetic_only(structure) -> Structure:
-        """Magnetic-only copy (nonmagnetic ions removed).
+    def _magnetic_species(structure) -> set[str]:
+        """Symbols of the species carrying a moment in this structure.
 
-        Whether a site is magnetic is decided by its *species*: only species listed in
-        CollinearMagneticStructureAnalyzer's default magmoms are treated as magnetic.
+        Used to pool the magnetic species across all orderings; the pooled set then
+        defines the magnetic sublattice for every ordering and for the parent.
 
-        - Magnetic-species sites keep their existing magmom (any nonzero value is retained,
-          since ``threshold=0.0``). If the input has no magmom site property, the default magmoms are assigned (``replace_all_if_undefined``).
-        - Nonmagnetic-species sites always get a magmom of zero. Because ``threshold_nonmag=100.0``,
-          even induced moments on nonmagnetic ions are zeroed out, so the number of magnetic sites
-          per cell stays constant across orderings.
-
-        Finally, all sites with zero magmom are dropped (even if magnetic-species sites with magmom=0. or magmom=None) and only sites with nonzero magmom are kept.
+        A site counts as magnetic if it ends up with a nonzero moment after ``_analyzer``
+        has processed it, i.e. it is of a species listed in the analyzer's default magmoms
+        *and* was given a nonzero moment (``threshold=0.0`` retains any nonzero value).
+        Induced moments on nonmagnetic ions are zeroed out first (``threshold_nonmag=100.0``)
+        and so never contribute a spurious species here.
         """
-        # overwrite_magmom_mode: if the structure has no magmom site property, assign default magmoms to all magnetic species
-        return _analyzer(structure).get_structure_with_only_magnetic_atoms(make_primitive=False)
+        magnetic = _analyzer(structure).get_structure_with_only_magnetic_atoms(make_primitive=False)
+        return {site.specie.symbol for site in magnetic}
 
-    @staticmethod
-    def _sublattice_ids_dict(labels: list[int]) -> dict[tuple[int, ...], int]:
-        """Group site indices by sublattice id: {tuple(site indices): sublattice id}."""
-        groups: dict[int, list[int]] = {}
-        for idx, sub_id in enumerate(labels):
-            groups.setdefault(sub_id, []).append(idx)
-        return {tuple(indices): sub_id for sub_id, indices in groups.items()}
-    
-    def _get_nn_graph(self) -> StructureGraph:
-        """
-        NN StructureGraph of the magnetic-only structure.
-        
-        If self.cutoff is set, the graph includes all neighbors within that distance. 
+    @cached_property
+    def nn_graph(self) -> StructureGraph:
+        """NN StructureGraph of the magnetic-only structure.
+
+        If self.cutoff is set, the graph includes all neighbors within that distance.
         Otherwise, only the nearest neighbors of each site are included.
         """
+        strategy = MinimumDistanceNN(cutoff=self.cutoff, get_all_sites=True) if self.cutoff else MinimumDistanceNN()
+        return StructureGraph.from_local_env_strategy(self.magnetic_structure, strategy=strategy)
 
-        strategy = MinimumDistanceNN(cutoff=self.cutoff, get_all_sites=True) if self.cutoff else MinimumDistanceNN()  # only NN
-        return StructureGraph.from_local_env_strategy(self.magn_substructure, strategy=strategy)
-    
     @abstractmethod
-    def set_sublattice_ids(self) -> dict[tuple[int, ...], int]:
+    def set_sublattice_ids(self) -> None:
         """
-        Sets the following properties for this ordering:
-            - `self.sublattice_ids_dict` = {tuple(site indices): sublattice id}
+        Sets the following attributes for this ordering:
+            - `self.sublattice_ids` = [sublattice id for each *magnetic* site], aligned with
+              `self.magnetic_structure` and hence with `self.nn_graph`. Nonmagnetic sites are
+              not represented at all, so these are always plain ints - never None.
             - `self.sublattice_wyckoff_symbols` = {sublattice id: wyckoff symbol}
-            - `self.sublattice_ids` = [sublattice id for each magnetic site in the ordering or None for nonmagnetic sites]
 
-        All nonmagnetic (`CollinearMagneticStructureAnalyzer` default_magmom=0) sites are grouped into one sublattice with label `None`.
-        
-        For `ParentOrdering`, this defines the sublattice ids by grouping symmetrically equivalent sites of ions into sublattices (nonmagnetic ions present for symmetry analysis). 
-        
-        For `RelaxedOrdering`, this is a mapping from the ordering's site indices to the sublattice ids via the finding the corresponding site in the parent for each site in the relaxed ordering.
-        
-        Finally, the sublattice ids are stored as a site property in the ordering's structure for easy access.
+        For `ParentOrdering`, this defines the sublattice ids by grouping symmetrically
+        equivalent sites into sublattices (nonmagnetic ions present for symmetry analysis)
+        and keeping only the orbits of the magnetic species.
+
+        For `RelaxedOrdering`, this maps the ordering's sites onto the parent's to find
+        which sublattice each one belongs to.
+
+        `ParentOrdering` additionally stores the *full-cell* ids (None on nonmagnetic sites)
+        as a `sublattice_id` site property, which is what carries the labels across to each
+        `RelaxedOrdering` during structure matching.
         """
 
 
@@ -150,53 +160,108 @@ class ParentOrdering(MagneticOrdering):
     """The nonmagnetic parent cell that defines the sublattices.
 
     Sublattices are its symmetry orbits (computed with nonmagnetic ions present),
-    restricted to the magnetic species.
-
+    restricted to the magnetic species. Because the parent carries no moments it cannot
+    tell which of its species are magnetic; that is pooled from the orderings and passed
+    in as ``magn_species``.
     """
 
-    def __init__(self, structure: Structure, cutoff: float = 0, tol: float = DEFAULT_TOL):
-        super().__init__(structure, cutoff, tol)
-        self.structure = self._nonmagnetic(structure)  # parent is always nonmagnetic
+    def __init__(
+        self,
+        structure: Structure,
+        magn_species: set[str],
+        cutoff: float = 0,
+        tol: float = DEFAULT_TOL,
+    ):
+        # Strip the moments *before* super().__init__, so the structure this ordering keeps
+        # is the one its substructure and graph get derived from.
+        super().__init__(self._nonmagnetic(structure), magn_species, cutoff, tol)
         self.set_sublattice_ids()
 
     def set_sublattice_ids(self):
         symmetrized_parent = SpacegroupAnalyzer(self.structure).get_symmetrized_structure()
-        self.sublattice_ids = [None] * len(self.structure)
-        for indices, wyckoff_symbol in zip(symmetrized_parent.equivalent_indices, symmetrized_parent.wyckoff_symbols, strict=True):
-            assert all(symmetrized_parent[i].specie == symmetrized_parent[indices[0]].specie for i in indices)
+
+        # Full-cell ids, None on the nonmagnetic sites. These exist to be stamped as a site
+        # property, which is how the labels reach each RelaxedOrdering via structure matching.
+        full_ids: list[int | None] = [None] * len(self.structure)
+        for indices, wyckoff_symbol in zip(
+            symmetrized_parent.equivalent_indices, symmetrized_parent.wyckoff_symbols, strict=True
+        ):
             if symmetrized_parent[indices[0]].specie.symbol not in self.magn_species:
                 continue
             sub_id = len(self.sublattice_wyckoff_symbols)
-            self.sublattice_wyckoff_symbols[sub_id] = wyckoff_symbol # one sublattice always has one wyckoff symbol, but multiple sublattices can share the same wyckoff symbol (e.g. two species on the same wyckoff position)
+            # A sublattice always has one wyckoff symbol, but several sublattices can share
+            # one (e.g. two species sitting on the same wyckoff position).
+            self.sublattice_wyckoff_symbols[sub_id] = wyckoff_symbol
             for index in indices:
-                self.sublattice_ids[index] = sub_id
+                full_ids[index] = sub_id
 
-        self.structure.add_site_property("sublattice_id", self.sublattice_ids)
+        self.structure.add_site_property("sublattice_id", full_ids)
 
-        self.sublattice_ids_dict = self._sublattice_ids_dict(self.sublattice_ids)
+        # Drop the nonmagnetic sites to line the ids up with magnetic_structure. Both select
+        # on species, so the surviving ids are exactly the non-None ones, in order.
+        self.sublattice_ids = [sub_id for sub_id in full_ids if sub_id is not None]
 
 
 class RelaxedOrdering(MagneticOrdering):
-    """One DFT-relaxed magnetic ordering with its energy and parent back-reference."""
+    """One DFT-relaxed magnetic ordering with its energy and parent back-reference.
 
-    def __init__(self, structure: Structure, energy: float, parent_ordering: ParentOrdering, cutoff: float = 0, tol: float = DEFAULT_TOL):
-        super().__init__(structure, cutoff, tol)
+    The parent is optional at construction: the orderings have to exist, and be screened
+    and sorted, before a parent can be inferred from them, so ``HeisenbergMapper`` attaches
+    it afterwards via ``set_parent``.
+    """
+
+    def __init__(
+        self,
+        structure: Structure,
+        energy: float,
+        magn_species: set[str],
+        parent_ordering: ParentOrdering | None = None,
+        cutoff: float = 0,
+        tol: float = DEFAULT_TOL,
+    ):
+        super().__init__(structure, magn_species, cutoff, tol)
+        self.energy = energy  # total energy, as supplied by the caller
         self.parent_ordering = parent_ordering
-        self.energy = energy
+        if parent_ordering is not None:
+            self.set_sublattice_ids()
+
+    @property
+    def energy_per_magnetic_ion(self) -> float:
+        """Total energy divided by the number of magnetic ions (eV).
+
+        This is what makes orderings living in different-sized supercells comparable.
+        """
+        return self.energy / len(self.magnetic_structure)
+
+    def set_parent(self, parent_ordering: ParentOrdering) -> None:
+        """Attach the parent that defines the sublattices, and label this ordering."""
+        self.parent_ordering = parent_ordering
         self.set_sublattice_ids()
 
     def set_sublattice_ids(self):
         matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
 
+        # Fold this ordering's full geometry onto the tagged parent cell (the nonmagnetic
+        # ions help pin down a unique mapping). get_s2_like_s1 returns the parent's sites,
+        # carrying their 'sublattice_id', in this ordering's site order - so matched_parent[i]
+        # is the parent site that site i of this ordering sits on.
         matched_parent = matcher.get_s2_like_s1(self._nonmagnetic(self.structure), self.parent_ordering.structure)
         if matched_parent is None:
             raise ValueError(
-                "The RelaxedOrdering is not a supercell of the ParentOrdering cell; it "
-                "cannot be mapped onto the parent sublattices."
+                "This ordering is not a supercell of the parent cell; it cannot be mapped "
+                "onto the parent sublattices. Pass an explicit `parent` cell that all "
+                "orderings share."
             )
-        self.sublattice_ids = [int(matched_parent[i].properties["sublattice_id"]) for i in range(len(self.structure))]
 
-
+        # Keep only the magnetic sites, in order, so the ids line up with magnetic_structure
+        # and the graph built from it. A parent site is labelled iff its species is magnetic,
+        # which is the same test magnetic_structure applies.
+        self.sublattice_ids = [
+            int(site.properties["sublattice_id"])
+            for site in matched_parent
+            if site.properties["sublattice_id"] is not None
+        ]
+        self.sublattice_wyckoff_symbols = self.parent_ordering.sublattice_wyckoff_symbols
 
 
 class HeisenbergMapper:
@@ -211,244 +276,245 @@ class HeisenbergMapper:
     parameters.
 
     Attributes:
-        sgraphs (list): StructureGraph objects, one per ordering.
-        parent (Structure): Nonmagnetic parent cell that defines the sublattices.
-        site_labels (list[list[int]]): site_labels[k][i] is the parent
-            sublattice id of site i in ordering k.
-        sublattice_wyckoff_symbols (dict): Maps each sublattice id to its wyckoff symbol.
-        nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
-        dists (dict): NN, NNN, and NNNN interaction distances.
+        orderings (list[RelaxedOrdering]): The screened orderings, sorted by energy per
+            magnetic ion. Each owns its magnetic-only structure, its NN graph and its
+            parent-sublattice labels.
+        parent (ParentOrdering): Nonmagnetic parent cell that defines the sublattices.
+        nn_interactions (dict): {(i, j): [J label, ...]} - the distinct interactions of
+            each sublattice pair, ordered from the nearest shell outwards.
+        dists (dict): {J label: interaction distance in Angstrom}.
         ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
         ex_params (dict): Exchange parameter values. The J_ij are in meV; the
             included 'E0' offset stays in eV.
     """
 
-    def __init__(self, ordered_structures, energies, parent, cutoff=0, tol: float = DEFAULT_TOL):
+    def __init__(self, ordered_structures, energies, parent=None, cutoff=0, tol: float = DEFAULT_TOL):
         """Exchange parameters are computed by mapping to a classical Heisenberg
         model. n+1 unique orderings are required to compute n exchange parameters.
 
-        First run a MagneticOrderingsWF to obtain low energy collinear magnetic
+        First run a MagneticOrderings Flow to obtain low energy collinear magnetic
         orderings and find the magnetic ground state, enumerate magnetic
         states with the ground state as the input structure and do static
         calculations for these orderings. The orderings may live in different
         supercells - they only need to be commensurate with a common parent cell.
 
+        ***IMPORTANT NOTE***
+
+        If the parent is not supplied, it is inferred as the primitive cell of the lowest-energy ordering. 
+        Not supplying a parent cell is only safe if the lowest-energy ordering still preserves the symmetry of the paramagnetic parent. 
+        In most cases, relaxation will lower the symmetry and the parent cell must be supplied explicitly.
+        
         Args:
             ordered_structures (list): Structure objects with magmoms.
             energies (list): Total energies of each relaxed magnetic structure.
             parent (Structure): Paramagnetic parent cell whose symmetry defines the
-                magnetic sublattices. 
-            cutoff (float): Cutoff in Angstrom for nearest neighbor search.
-                Defaults to 0 (only NN, no NNN, etc.).
+                magnetic sublattices. If None, it is inferred as the primitive cell of
+                the lowest-energy ordering. Defaults to None.
+            cutoff (float): Cutoff in Angstrom for nearest neighbor search. Defaults to 0,
+                which keeps only each site's nearest neighbors, i.e. one shell per
+                sublattice pair; with a cutoff, every interaction up to it is kept.
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances
-                being equal and structure matching.
+                being equal.
         """
         # Save original copies of inputs
         self.ordered_structures_ = ordered_structures
         self.energies_ = energies
         self.parent_ = parent
 
-        # Sanitize inputs: standardize moments, convert energies to per magnetic
-        # ion, drop duplicates and sort by energy. The screener keeps both a
-        # magnetic-only copy (for the graphs) and a full copy (all ions, needed
-        # to determine site symmetry) of every ordering.
-        hs = HeisenbergScreener(ordered_structures, energies, screen=False)
-        self.ordered_structures = hs.screened_structures
-        self.full_structures = hs.screened_full_structures
-        self.energies = hs.screened_energies
         self.cutoff = cutoff
         self.tol = tol
 
-        # Graph representation of each (magnetic-only) ordering
-        self.sgraphs = [self._get_graph(cutoff, s) for s in self.ordered_structures]
+        # These attributes are set by internal methods, listed here for clarity.
+        self.orderings = self.parent = None  # set by _initialize_orderings
+        self.nn_interactions = self.dists = None  # set by _set_interactions
+        self.ex_mat = self.ex_params = None  # set by _build_exchange_mat and get_exchange
 
-        # The parent cell defines the sublattices; label every magnetic site in
-        # every ordering with the parent sublattice it belongs to.
-        self.parent = self._get_parent(parent, self.full_structures)
-        self.parent_sgraph = self._get_graph(cutoff, self._magnetic_only(self.parent))
-        self.sublattice_wyckoff_symbols, self.site_labels, self.parent_site_labels = self._label_orderings(self.parent, self.full_structures)
+        self._initialize_orderings(ordered_structures, energies, parent)
+        self._set_interactions()
+        self._build_exchange_mat()
 
-        # These attributes are set by internal methods
-        self.nn_interactions = self.dists = self.ex_mat = self.ex_params = None
+    def _initialize_orderings(self, ordered_structures, energies, parent):
+        """Build the RelaxedOrdering objects and the ParentOrdering that labels them.
 
-        if len(self.sgraphs) < 2:
-            raise SystemExit("We need at least 2 unique orderings.")
+        Sets self.orderings and self.parent.
 
-        self._get_nn_dict()
-        self._build_exchange_matmat()
+        The magnetic species are pooled over *all* orderings and then used to define the
+        magnetic sublattice of every ordering and of the parent. Pooling matters: if an ion
+        happens to relax to a zero moment in one ordering, it must stay on the magnetic
+        lattice there (contributing a zero term) rather than vanishing and leaving that
+        ordering with a different site count, graph topology and per-ion energy than its
+        siblings.
 
-    @staticmethod
-    def _get_graph(cutoff, structure):
-        """Generate graph representations of a magnetic structure with nearest
-        neighbor bonds. Right now this only works for MinimumDistanceNN.
+        This function does:
+         - Build a set of magnetic species pooled over all orderings.
+         - Build a RelaxedOrdering for each ordering, with its magnetic-only structure and NN graph. Since the parent is not yet known, the sublattice ids are not set yet.
+         - Drop duplicate/degenerate orderings and sort by energy per magnetic ion using HeisenbergScreener.
+         - Build the ParentOrdering from the lowest-energy ordering (or the explicit parent if supplied), and set its sublattice ids.
 
         Args:
-            cutoff (float): Cutoff in Angstrom for nearest neighbor search.
-            structure (Structure): A single magnetic structure.
+            ordered_structures (list): Structure objects with magmoms.
+            energies (list): Total energies of each relaxed magnetic structure.
+            parent (Structure | None): Explicit paramagnetic parent cell, or None to infer
+                it from the lowest-energy ordering.
+
+        Raises:
+            SystemExit: If fewer than 2 unique orderings remain after screening.
+        """
+        # Pool the magnetic species over all orderings, to make sure a species that relaxes to zero moment in one ordering still counts as magnetic there.
+        # Since the magmom of this species is zero, it contributes a zero term to the Heisenberg Hamiltonian, but it stays on the lattice and keeps the site count and graph topology consistent with the other orderings.
+        magn_species = set().union(*(MagneticOrdering._magnetic_species(struct) for struct in ordered_structures))
+
+        orderings = [
+            RelaxedOrdering(struct, energy, magn_species, cutoff=self.cutoff, tol=self.tol)
+            for struct, energy in zip(ordered_structures, energies, strict=True)
+        ]
+
+        # Drop duplicate/degenerate orderings and sort by energy per magnetic ion.
+        self.orderings = HeisenbergScreener(orderings, screen=False).screened_orderings
+
+        if len(self.orderings) < 2:
+            raise SystemExit("HeisenbergMapper needs at least 2 unique orderings.")
+
+        # The nonmagnetic ions are kept in the parent: site equivalence is read from its
+        # symmetry, and removing them first can raise the apparent site symmetry and merge
+        # sublattices that are actually distinct.
+        reference = parent if parent is not None else self.orderings[0].structure
+        self.parent = ParentOrdering(
+            MagneticOrdering._nonmagnetic(reference).get_primitive_structure(),
+            magn_species,
+            cutoff=self.cutoff,
+            tol=self.tol,
+        )
+
+        # The parent cell defines the sublattices; label every magnetic site in every
+        # ordering with the parent sublattice it belongs to.
+        for ordering in self.orderings:
+            ordering.set_parent(self.parent)
+
+    @property
+    def structures(self):
+        """list[Structure]: Each ordering with all ions retained."""
+        return [ordering.structure for ordering in self.orderings]
+
+    @property
+    def magnetic_structures(self):
+        """list[Structure]: Magnetic-only structure of each ordering."""
+        return [ordering.magnetic_structure for ordering in self.orderings]
+
+    @property
+    def energies(self):
+        """list[float]: Energy per magnetic ion (eV) of each ordering."""
+        return [ordering.energy_per_magnetic_ion for ordering in self.orderings]
+
+    @property
+    def nn_graphs(self):
+        """list[StructureGraph]: NN graph of each ordering's magnetic-only structure."""
+        return [ordering.nn_graph for ordering in self.orderings]
+
+    @property
+    def sublattice_ids(self):
+        """list[list[int]]: sublattice_ids[k][i] is the sublattice id of magnetic site i
+        in ordering k, aligned with that ordering's graph.
+        """
+        return [ordering.sublattice_ids for ordering in self.orderings]
+
+    @property
+    def parent_nn_graph(self):
+        """StructureGraph: NN graph of the magnetic-only parent structure."""
+        return self.parent.nn_graph
+
+    @property
+    def parent_sublattice_ids(self):
+        """list[int]: Sublattice id of each magnetic site in the parent."""
+        return self.parent.sublattice_ids
+
+    @property
+    def sublattice_wyckoff_symbols(self):
+        """dict[int, str]: Maps each sublattice id to its wyckoff symbol."""
+        return self.parent.sublattice_wyckoff_symbols
+
+    @staticmethod
+    def _order_sublattice_ids(i_id, j_id):
+        """Returns the sublattice_ids in the order (i, j) with i <= j. This is the key used to look up the interactions of a sublattice pair."""
+        return tuple(sorted((i_id, j_id)))
+
+    def _interaction_label(self, i_id, j_id, dist):
+        """Return the J label of an interaction, or None if it matches no interaction.
+
+        Args:
+            i_id (int): sublattice id of the ith site
+            j_id (int): sublattice id of the jth site
+            dist (float): distance (Angstrom) between the sites
 
         Returns:
-            StructureGraph: The graph representation of the structure.
+            str | None: '<i>-<j>-<shell>' label, e.g. '0-1-nn'.
         """
-        strategy = MinimumDistanceNN(cutoff=cutoff, get_all_sites=True) if cutoff else MinimumDistanceNN()  # only NN
-        return StructureGraph.from_local_env_strategy(structure, strategy=strategy)
-
-
-    # @classmethod
-    # def _get_parent(cls, parent, full_structures):
-    #     """Return the full primitive parent cell that defines the sublattices.
-
-    #     The nonmagnetic ions are kept: site equivalence is read from this parent's
-    #     symmetry, and removing the nonmagnetic ions first can raise the apparent
-    #     site symmetry and merge sublattices that are actually distinct.
-
-    #     Args:
-    #         parent (Structure | None): Explicit paramagnetic parent (all ions). If
-    #             None, the primitive cell of the lowest-energy ordering is used.
-    #         full_structures (list[Structure]): Orderings with all ions retained.
-
-    #     Returns:
-    #         Structure: Nonmagnetic primitive parent cell, nonmagnetic ions included.
-    #     """
-    #     ref = parent if parent is not None else full_structures[0]
-    #     return cls._nonmagnetic(ref).get_primitive_structure()
-
-    # @classmethod
-    # def _label_orderings(cls, parent, full_structures):
-    #     """Label every magnetic site in every ordering with its parent sublattice.
-
-    #     The magnetic sublattices are the parent's symmetry orbits, computed on the
-    #     *full* cell (nonmagnetic ions present) and then restricted to the magnetic
-    #     species. Each ordering is folded back onto the full parent so its sites
-    #     inherit the parent labels; the labels of the nonmagnetic sites are
-    #     discarded. This keeps the labels consistent across orderings that live in
-    #     different supercells, while preserving the true site symmetry.
-
-    #     Args:
-    #         parent (Structure): Nonmagnetic parent cell (all ions).
-    #         full_structures (list[Structure]): Orderings with all ions retained and
-    #             a 'magmom' site property on every site.
-
-    #     Returns:
-    #         tuple[dict, list[list[int]], list[int]]:
-    #             - sublattice_wyckoff_symbols maps each magnetic sublattice id to its wyckoff symbol.
-    #             - site_labels[k][i] is the sublattice id of magnetic site i in
-    #               ordering k (aligned with the magnetic-only graphs).
-    #             - parent_site_labels is the sublattice id of each site in the parent structure.
-
-    #     Raises:
-    #         ValueError: If an ordering is not a supercell of the parent cell.
-    #     """
-    #     # Species that carry a moment in any ordering are the magnetic species.
-    #     mag_species = {site.specie.symbol for s in full_structures for site in s if abs(site.properties["magmom"]) > 0}
-
-    #     # Sublattices = the parent's symmetry orbits restricted to magnetic
-    #     # species. Nonmagnetic sites get the sentinel -1 (never used).
-    #     symm_parent = SpacegroupAnalyzer(parent).get_symmetrized_structure()
-    #     parent_labels = [-1] * len(parent)
-    #     sublattice_wyckoff_symbols = {}
-    #     for indices, symbol in zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True):
-    #         if symm_parent[indices[0]].specie.symbol not in mag_species:
-    #             continue
-    #         sub_id = len(sublattice_wyckoff_symbols)
-    #         sublattice_wyckoff_symbols[sub_id] = symbol
-    #         for index in indices:
-    #             parent_labels[index] = sub_id
-
-    #     # Carry the parent labels across to each ordering by folding the ordering's
-    #     # full geometry onto the tagged parent cell (the nonmagnetic ions help pin
-    #     # down a unique mapping). This also validates that every ordering is a
-    #     # genuine supercell of the parent.
-    #     tagged_parent = parent.copy()
-    #     tagged_parent.add_site_property("sublattice_id", parent_labels)
-    #     matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
-
-    #     site_labels = []
-    #     for idx, full in enumerate(full_structures):
-    #         matched = matcher.get_s2_like_s1(cls._nonmagnetic(full), tagged_parent)
-    #         if matched is None:
-    #             raise ValueError(
-    #                 f"Ordering {idx} is not a supercell of the parent cell; it "
-    #                 "cannot be mapped onto the parent sublattices. Pass an explicit "
-    #                 "`parent` cell that all orderings share."
-    #             )
-    #         # matched[i] is the parent site that ordering site i folds onto. Keep
-    #         # only the magnetic sites, in order, so the labels align with the
-    #         # magnetic-only structure used to build the graphs.
-    #         magmoms = full.site_properties["magmom"]
-    #         site_labels.append(
-    #             [int(matched[i].properties["sublattice_id"]) for i in range(len(full)) if abs(magmoms[i]) > 0]
-    #         )
-
-    #     parent_labels = [int(label) for label in parent_labels if label >= 0]  # drop nonmagnetic sites
-
-    #     return wyckoff_ids, site_labels, parent_labels
-
-
-    def _shell_of(self, dist):
-        """Return 'nn'/'nnn'/'nnnn' for a distance, or None if it matches no shell."""
-        for shell in ("nn", "nnn", "nnnn"):
-            if self.dists[shell] and abs(dist - self.dists[shell]) <= self.tol:
-                return shell
+        for label in self.nn_interactions.get(self._order_sublattice_ids(i_id, j_id), ()):
+            if abs(dist - self.dists[label]) <= self.tol:
+                return label
+        logger.warning(f"Interaction between sublattices {i_id} and {j_id} at {dist:.2f} Angstrom does not match any interaction in nn_interactions built from the parent:\n{self.nn_interactions}\n")
         return None
 
-    def _get_nn_dict(self):
-        """Set self.dists and self.nn_interactions describing the unique NN, NNN and
-        NNNN interactions between sublattices.
+    def _set_interactions(self):
+        """Set self.dists and self.nn_interactions describing the distinct interactions.
 
-        Distances and connectivity are read from the parent ordering. See _get_parent() for how the parent is defined and how the sublattices are labelled. The connectivity is
-    read from the parent StructureGraph, which is built from the magnetic-only parent structure (nonmagnetic ions are ignored for the graph, but they are kept in the parent structure to preserve the true site symmetry).
+        An interaction is a (sublattice pair, neighbor shell) combination, labelled
+        '<i>-<j>-<shell>' with i <= j and shell one of 'nn', 'nnn', 'nnnn', ... Shells are
+        counted *within* a sublattice pair, not globally: '0-0-nn' and '0-1-nn' are the
+        nearest 0-0 and 0-1 interaction respectively, even when one of them is the longer interaction.
+
+        Every distinct interaction the parent graph contains is kept, so which interactions are
+        parameterized follows entirely from how that graph is built: with cutoff=0 each
+        site keeps only its nearest neighbors (one nn-shell per sublattice pair, but every
+        pair the lattice realizes), with cutoff > 0 it keeps every interaction up to the cutoff.
+
+        Distances and connectivity are read from the parent ordering; see
+        _initialize_orderings() for how the parent is defined and how the sublattices are
+        labelled. The connectivity comes from the parent's StructureGraph, which is built
+        from the magnetic-only parent structure - the nonmagnetic ions are ignored for the
+        graph, but kept in the parent structure to preserve the true site symmetry.
         """
-        tol = self.tol
-        sgraph = self.parent_sgraph
-        labels = self.parent_site_labels
+        nn_graph = self.parent.nn_graph
+        sub_ids = self.parent.sublattice_ids
 
-        # One representative site index per sublattice
-        reps = {}
-        for idx, sub_id in enumerate(labels):
-            reps.setdefault(sub_id, idx)
+        # Distinct interaction distances of each sublattice pair. Every site is visited, since
+        # with cutoff=0 the two ends of an interaction need not both count it as a nearest neighbor.
+        pair_dists: dict[tuple[int, int], set[float]] = {}
+        for i in range(len(nn_graph)):
+            for cs in nn_graph.get_connected_sites(i):
+                pair = self._order_sublattice_ids(sub_ids[i], sub_ids[cs[2]])
+                pair_dists.setdefault(pair, set()).add(round(cs[-1], DISTANCE_ROUND_DECIMALS))
 
-        # Collect neighbor distances (up to NNNN) across the sublattices
-        all_dists = []
-        for i in reps.values():
-            dists = sorted({round(cs[-1], 2) for cs in sgraph.get_connected_sites(i)})
-            all_dists += dists[:3]
-
-        # Collapse distances that are equal within tol, keep up to NNNN, pad with 0
-        all_dists = sorted(set(all_dists))
-        rm_list = [idx for idx, d in enumerate(all_dists[:-1], start=1) if abs(d - all_dists[idx]) < tol]
-        all_dists = [d for idx, d in enumerate(all_dists) if idx not in rm_list]
-        all_dists = [*all_dists, 0, 0, 0][:3]
-        self.dists = dict(zip(("nn", "nnn", "nnnn"), all_dists, strict=True))
-
-        # Determine which sublattice pairs interact at each shell
-        nn_interactions = {"nn": {}, "nnn": {}, "nnnn": {}}
-        for i_id, i in reps.items():
-            for cs in sgraph.get_connected_sites(i):
-                shell = self._shell_of(round(cs[-1], 2))
-                if shell is not None:
-                    nn_interactions[shell][i_id] = labels[cs[2]]
-
-        self.nn_interactions = nn_interactions
+        self.dists = {}
+        self.nn_interactions = {}
+        for pair, dists in sorted(pair_dists.items()):
+            labels = []
+            for dist in sorted(dists):
+                # Distances equal within tol are the same shell; the smallest one names it.
+                if labels and dist - self.dists[labels[-1]] <= self.tol:
+                    continue
+                label = f"{pair[0]}-{pair[1]}-{'n' * (len(labels) + 2)}"
+                self.dists[label] = dist
+                labels.append(label)
+            self.nn_interactions[pair] = labels
 
     def _exchange_columns(self):
-        """Column labels for the exchange matrix: 'E', 'E0' then one per J_ij."""
-        columns = ["E", "E0"]
-        for shell, pairs in self.nn_interactions.items():
-            for i_id, j_id in pairs.items():
-                col = f"{i_id}-{j_id}-{shell}"
-                rev = f"{j_id}-{i_id}-{shell}"
-                if col not in columns and rev not in columns:
-                    columns.append(col)
-        # Keep at most n interactions for n+1 orderings
-        return columns[: len(self.sgraphs) + 1]
+        """Column labels for the exchange matrix: 'E', 'E0' then one per J_ij.
 
-    def _build_exchange_matmat(self):
+        The J columns are ordered by increasing interaction length, so when the system has more
+        interactions than the orderings can constrain, the longest-ranged ones are dropped.
+        """
+        j_columns = sorted(self.dists, key=self.dists.get)
+        # Keep at most n interactions for n+1 orderings
+        return ["E", "E0", *j_columns][: len(self.orderings) + 1]
+
+    def _build_exchange_mat(self):
         """Build the Heisenberg Hamiltonian, one row per ordering, by summing the
         signed products S_i . S_j over each graph. Sets self.ex_mat.
 
         Each row is normalised per magnetic ion so that orderings living in
         different-sized supercells share a single linear system (the energies are
-        already per magnetic ion, see HeisenbergScreener._do_cleanup).
+        per magnetic ion too, see RelaxedOrdering.energy_per_magnetic_ion).
         """
         columns = self._exchange_columns()
         j_columns = [c for c in columns if c not in ("E", "E0")]
@@ -459,29 +525,29 @@ class HeisenbergMapper:
 
         rows = []
         seen = set()  # de-duplicate identical interaction rows to avoid singularity
-        for k, sgraph in enumerate(self.sgraphs):
-            labels = self.site_labels[k]
-            magmoms = sgraph.structure.site_properties["magmom"]
-            n_sites = len(sgraph.structure)
+        for ordering in self.orderings:
+            nn_graph = ordering.nn_graph
+            sub_ids = ordering.sublattice_ids
+            magmoms = nn_graph.structure.site_properties["magmom"]
+            n_sites = len(nn_graph.structure)
 
             row = dict.fromkeys(columns, 0.0)
-            for i in range(len(sgraph.graph.nodes)):
+            for i in range(len(nn_graph.graph.nodes)):
                 s_i = magmoms[i]
-                i_id = labels[i]
-                for cs in sgraph.get_connected_sites(i):
-                    shell = self._shell_of(round(cs[-1], 2))
-                    if shell is None:
-                        continue
-                    j_id = labels[cs[2]]
-                    col = f"{i_id}-{j_id}-{shell}"
-                    rev = f"{j_id}-{i_id}-{shell}"
+                for cs in nn_graph.get_connected_sites(i):
+                    col = self._interaction_label(sub_ids[i], sub_ids[cs[2]], round(cs[-1], DISTANCE_ROUND_DECIMALS))
+                    # Two ways an interaction has no column in row:
+                    # 1. col is None, meaning this
+                    # ordering's geometry has drifted off the parent lattice (a real
+                    # problem, warned about in _interaction_label), or
+                    # 2. col is just not in row, but is a genuine
+                    # interaction that _exchange_columns truncated away because the
+                    # orderings cannot constrain that many parameters (by design).
                     if col in row:
                         row[col] -= s_i * magmoms[cs[2]]
-                    elif rev in row:
-                        row[rev] -= s_i * magmoms[cs[2]]
 
             # Extensive sums -> per magnetic ion, with the 1/2 Heisenberg factor.
-            # Each bond is visited from both ends, so 2 * n_sites also removes the
+            # Each interaction is visited from both ends, so 2 * n_sites also removes the
             # double counting.
             for c in j_columns:
                 row[c] /= 2 * n_sites
@@ -491,13 +557,13 @@ class HeisenbergMapper:
                 continue
             seen.add(key)
             row["E0"] = 1.0  # nonmagnetic contribution (per ion)
-            row["E"] = self.energies[k]
+            row["E"] = ordering.energy_per_magnetic_ion
             rows.append(row)
 
         ex_mat = pd.DataFrame(rows, columns=columns)
 
         # Drop interaction columns that never appear (all zero) to keep H invertible
-        j_columns = [c for c in j_columns if (ex_mat[c] != 0).any()]
+        j_columns = [c for c in j_columns if not (ex_mat[c] == 0).all()]
         ex_mat = ex_mat[["E", "E0", *j_columns]]
 
         # Square system: one row per parameter (E0 + the J_ij)
@@ -560,7 +626,9 @@ class HeisenbergMapper:
         mag_max = 0.001
         fm_e = afm_e = fm_e_min = afm_e_min = 0
 
-        for s, e in zip(self.ordered_structures, self.energies, strict=True):
+        for magnetic_ordering in self.orderings:
+            s = magnetic_ordering.magnetic_structure
+            e = magnetic_ordering.energy_per_magnetic_ion
             ordering = _analyzer(s).ordering
             magmoms = s.site_properties["magmom"]
 
@@ -579,7 +647,9 @@ class HeisenbergMapper:
 
         # Brute force search for closest thing to FM and AFM
         if not fm_struct or not afm_struct:
-            for s, e in zip(self.ordered_structures, self.energies, strict=True):
+            for magnetic_ordering in self.orderings:
+                s = magnetic_ordering.magnetic_structure
+                e = magnetic_ordering.energy_per_magnetic_ion
                 magmoms = s.site_properties["magmom"]
 
                 if abs(sum(magmoms)) > mag_max:  # FM ground state
@@ -597,11 +667,6 @@ class HeisenbergMapper:
                     afm_struct = s
                     afm_e = e
                     afm_e_min = e
-
-        # Convert to magnetic structures with 'magmom' site property
-        fm_struct = _analyzer(fm_struct).get_structure_with_only_magnetic_atoms(make_primitive=False)
-
-        afm_struct = _analyzer(afm_struct).get_structure_with_only_magnetic_atoms(make_primitive=False)
 
         return fm_struct, afm_struct, fm_e, afm_e
 
@@ -650,7 +715,7 @@ class HeisenbergMapper:
             float: Critical temperature mft_t (K)
         """
         # Number of magnetic sublattices = number of parent orbits
-        n_sub_lattices = len(self.wyckoff_ids)
+        n_sub_lattices = len(self.sublattice_wyckoff_symbols)
         k_boltzmann = 0.0861733  # meV/K
 
         # Only 1 magnetic sublattice
@@ -696,9 +761,10 @@ class HeisenbergMapper:
         if self.ex_params is None:
             self.get_exchange()
 
-        structure = self.ordered_structures[ordering_index]
-        sgraph = self.sgraphs[ordering_index]
-        labels = self.site_labels[ordering_index]
+        ordering = self.orderings[ordering_index]
+        structure = ordering.magnetic_structure
+        nn_graph = ordering.nn_graph
+        sub_ids = ordering.sublattice_ids
 
         igraph = StructureGraph.from_empty_graph(
             structure, edge_weight_name="exchange_constant", edge_weight_units="meV"
@@ -708,17 +774,17 @@ class HeisenbergMapper:
             logger.warning("Only <J> is available. The interaction graph will not tell you much.")
 
         # J_ij exchange interaction matrix
-        for i in range(len(sgraph.graph.nodes)):
-            for c in sgraph.get_connected_sites(i):
+        for i in range(len(nn_graph.graph.nodes)):
+            for c in nn_graph.get_connected_sites(i):
                 jimage = c[1]  # relative integer coordinates of atom j
                 j = c[2]  # index of neighbor
-                j_exc = self._get_j_exc(labels[i], labels[j], c[-1])
-                # Only add bonds the fit actually parameterized. Unparameterized
-                # bonds (no matching sublattice-pair/shell in ex_params, exactly
-                # the bonds _build_exchange_mat also ignores) get j_exc == 0, which
+                j_exc = self._get_j_exc(sub_ids[i], sub_ids[j], c[-1])
+                # Only add interactions the fit actually parameterized. Unparameterized
+                # interactions (no matching sublattice-pair/shell in ex_params, exactly
+                # the interactions _build_exchange_mat also ignores) get j_exc == 0, which
                 # StructureGraph.add_edge silently drops via its falsy-weight
                 # guard, leaving an edge with weight=None that breaks downstream
-                # per-bond consumers.
+                # per-interaction consumers.
                 if not j_exc:
                     continue
                 igraph.add_edge(i, j, to_jimage=jimage, weight=j_exc, warn_duplicates=False)
@@ -741,23 +807,13 @@ class HeisenbergMapper:
         Returns:
             float: Exchange parameter J_exc in meV (0 if no matching interaction).
         """
-        shell = self._shell_of(round(dist, 2))
-        order = f"-{shell}" if shell else ""
-        j_ij = f"{i_id}-{j_id}{order}"
-        j_ji = f"{j_id}-{i_id}{order}"
-
-        if j_ij in self.ex_params:
-            j_exc = self.ex_params[j_ij]
-        elif j_ji in self.ex_params:
-            j_exc = self.ex_params[j_ji]
-        else:
-            j_exc = 0
+        label = self._interaction_label(i_id, j_id, round(dist, DISTANCE_ROUND_DECIMALS))
 
         # Check if only averaged NN <J> values are available
-        if "<J>" in self.ex_params and order == "-nn":
-            j_exc = self.ex_params["<J>"]
+        if "<J>" in self.ex_params:
+            return self.ex_params["<J>"] if label and label.endswith("-nn") else 0
 
-        return j_exc
+        return self.ex_params.get(label, 0)
 
     def get_heisenberg_model(self):
         """Save results of mapping to a HeisenbergModel object.
@@ -767,13 +823,14 @@ class HeisenbergMapper:
         """
         return HeisenbergModel(
             formula=str(self.ordered_structures_[0].reduced_formula),
-            structures=self.ordered_structures,
+            structures=self.structures,
+            magnetic_structures=self.magnetic_structures,
             energies=self.energies,
             cutoff=self.cutoff,
             tol=self.tol,
-            sgraphs=self.sgraphs,
-            site_labels=self.site_labels,
-            wyckoff_ids=self.wyckoff_ids,
+            nn_graphs=self.nn_graphs,
+            sublattice_ids=self.sublattice_ids,
+            sublattice_wyckoff_symbols=self.sublattice_wyckoff_symbols,
             nn_interactions=self.nn_interactions,
             dists=self.dists,
             ex_mat=self.ex_mat,
@@ -786,136 +843,78 @@ class HeisenbergMapper:
 class HeisenbergScreener:
     """Clean and screen magnetic orderings."""
 
-    def __init__(self, structures, energies, screen=False):
-        """Pre-processes magnetic orderings and energies for HeisenbergMapper.
+    def __init__(self, orderings:list[RelaxedOrdering], screen=False):
+        """Pre-processes magnetic orderings for HeisenbergMapper.
         It prioritizes low-energy orderings with large and localized magnetic moments.
 
         Args:
-            structures (list): Structure objects with magnetic moments.
-            energies (list): Total energies of magnetic orderings.
+            orderings (list[RelaxedOrdering]): The orderings to screen. Each one already
+                owns its magnetic-only substructure and its per-magnetic-ion energy.
             screen (bool): Try to screen out high energy and low-spin configurations.
 
         Attributes:
-            screened_structures (list): Sorted magnetic-only structures.
-            screened_full_structures (list): The same orderings with nonmagnetic
-                ions retained, aligned index-for-index with screened_structures.
-            screened_energies (list): Sorted energies.
+            screened_orderings (list[RelaxedOrdering]): Deduplicated orderings, sorted by
+                energy per magnetic ion.
         """
-        # Cleanup
-        full_structures, structures, energies = self._do_cleanup(structures, energies)
+        orderings = self._do_cleanup(orderings)
 
-        n_structures = len(structures)
+        # If there are more than 2 orderings, we want to perform a
+        # screening to prioritize well-behaved ones
+        if screen and len(orderings) > 2:
+            orderings = self._do_screen(orderings)
 
-        # If there are more than 2 structures, we want to perform a
-        # screening to prioritize well-behaved orderings
-        if screen and n_structures > 2:
-            full_structures, structures, energies = self._do_screen(full_structures, structures, energies)
-
-        self.screened_structures = structures
-        self.screened_full_structures = full_structures
-        self.screened_energies = energies
+        self.screened_orderings = orderings
 
     @staticmethod
-    def _do_cleanup(structures, energies):
-        """Sanitize input structures and energies.
+    def _do_cleanup(orderings:list[RelaxedOrdering]):
+        """Drop duplicate/degenerate orderings and sort by energy per magnetic ion.
 
-        Takes magnetic structures and performs the following operations
-        - Standardizes magmoms (every site gets a ['magmom'] site prop)
-        - Builds a magnetic-only copy of each ordering, keeping a full copy too
-        - Converts total energies -> energy / magnetic ion
-        - Checks for duplicate/degenerate orderings
-        - Sorts by energy
+        Sometimes different initial configs relax to the same state; those show up as
+        orderings with (near-)identical energies per magnetic ion.
 
         Args:
-            structures (list): Structure objects with magmoms.
-            energies (list): Corresponding energies.
+            orderings (list[RelaxedOrdering]): The orderings to clean up.
 
         Returns:
-            full_structures (list): Sanitized orderings with all ions retained.
-            ordered_structures (list): The same orderings with only magnetic ions.
-            ordered_energies (list): Sorted energies (per magnetic ion).
+            list[RelaxedOrdering]: Deduplicated, sorted by energy per magnetic ion.
         """
-        # Standardize moments (zero threshold so small moments are preserved).
-        # Keep both a full copy (all ions, needed for correct site symmetry) and
-        # a magnetic-only copy (used to build the interaction graphs).
-        # Make sure no induced moments are present (threshold_nonmag=100).
-        analyzers = [_analyzer(s) for s in structures]
-        full_structures = [analyzer.structure for analyzer in analyzers]
-        ordered_structures = [
-            analyzer.get_structure_with_only_magnetic_atoms(make_primitive=False) for analyzer in analyzers
-        ]
-
-        # Convert to energies / magnetic ion
-        energies = [e / len(s) for (e, s) in zip(energies, ordered_structures, strict=True)]
-
-        # Check for duplicate / degenerate states (sometimes different initial
-        # configs relax to the same state)
-        remove_list = []
         e_tol = 6  # 10^-6 eV/atom tol on energies
+        energies = [round(ordering.energy_per_magnetic_ion, e_tol) for ordering in orderings]
 
+        remove_list = []
         for idx, energy in enumerate(energies):
-            energy = round(energy, e_tol)
             if idx not in remove_list:
                 for i_check, e_check in enumerate(energies):
-                    e_check = round(e_check, e_tol)
                     if idx != i_check and i_check not in remove_list and energy == e_check:
                         remove_list.append(i_check)
 
-        # Drop duplicates, then sort by energy, keeping the three lists aligned.
         keep = [idx for idx in range(len(energies)) if idx not in remove_list]
         keep.sort(key=lambda idx: energies[idx])
 
-        full_structures = [full_structures[idx] for idx in keep]
-        ordered_structures = [ordered_structures[idx] for idx in keep]
-        ordered_energies = [energies[idx] for idx in keep]
-
-        return full_structures, ordered_structures, ordered_energies
+        return [orderings[idx] for idx in keep]
 
     @staticmethod
-    def _do_screen(full_structures, structures, energies):
+    def _do_screen(orderings:list[RelaxedOrdering]):
         """Screen and sort magnetic orderings based on some criteria.
 
-        Prioritize low energy orderings and large, localized magmoms. do_clean should be run first to sanitize inputs.
+        Prioritize low energy orderings and large, localized magmoms. _do_cleanup should be
+        run first to deduplicate and sort the orderings by energy.
 
         Args:
-            full_structures (list): Orderings with all ions retained.
-            structures (list): The same orderings with only magnetic ions.
-            energies (list): Energies.
+            orderings (list[RelaxedOrdering]): Cleaned up orderings, sorted by energy.
 
         Returns:
-            screened_full_structures (list): Sorted full structures.
-            screened_structures (list): Sorted magnetic-only structures.
-            screened_energies (list): Sorted energies.
+            list[RelaxedOrdering]: The ground and first excited state, followed by the
+                remaining orderings sorted by how few small moments they carry.
         """
-        magmoms = [struct.site_properties["magmom"] for struct in structures]
-        n_below_1ub = [sum(abs(m) < 1 for m in ms) for ms in magmoms]
 
-        df_mag = pd.DataFrame(
-            {
-                "full": full_structures,
-                "structure": structures,
-                "energy": energies,
-                "magmoms": magmoms,
-                "n_below_1ub": n_below_1ub,
-            }
-        )
+        def n_below_1ub(ordering):
+            magmoms = ordering.magnetic_structure.site_properties["magmom"]
+            return sum(abs(magmom) < 1 for magmom in magmoms)
 
-        # keep the ground and first excited state fixed to capture the
-        # low-energy spectrum
-        df_high_energy = df_mag.iloc[2:]
-
-        # Prioritize structures with fewer magmoms < 1 uB
-        df_high_energy = df_high_energy.sort_values(by="n_below_1ub")
-
-        index = [0, 1, *df_high_energy.index]
-
-        # sort
-        df_mag = df_mag.reindex(index)
-        return (
-            list(df_mag["full"].values),
-            list(df_mag["structure"].values),
-            list(df_mag["energy"].values),
-        )
+        # Keep the ground and first excited state fixed to capture the low-energy spectrum,
+        # and prioritize the rest by having fewer magmoms < 1 uB.
+        return [*orderings[:2], *sorted(orderings[2:], key=n_below_1ub)]
 
 
 class HeisenbergModel(MSONable):
@@ -928,12 +927,13 @@ class HeisenbergModel(MSONable):
         self,
         formula=None,
         structures=None,
+        magnetic_structures=None,
         energies=None,
         cutoff=None,
         tol=None,
-        sgraphs=None,
-        site_labels=None,
-        wyckoff_ids=None,
+        nn_graphs=None,
+        sublattice_ids=None,
+        sublattice_wyckoff_symbols=None,
         nn_interactions=None,
         dists=None,
         ex_mat=None,
@@ -944,16 +944,19 @@ class HeisenbergModel(MSONable):
         """
         Args:
             formula (str): Reduced formula of compound.
-            structures (list): Structure objects with magmoms.
+            structures (list): Each ordering with all ions retained, with magmoms.
+            magnetic_structures (list): Magnetic-only cell of each ordering. nn_graphs and
+                sublattice_ids are indexed against these, not against structures.
             energies (list): Energies of each relaxed magnetic structure.
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances being equal.
-            sgraphs (list): StructureGraph objects.
-            site_labels (list[list[int]]): site_labels[k][i] is the sublattice id of
+            nn_graphs (list): StructureGraph objects.
+            sublattice_ids (list[list[int]]): sublattice_ids[k][i] is the sublattice id of
                 site i in ordering k.
-            wyckoff_ids (dict): Maps each sublattice id to its wyckoff position.
-            nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
-            dists (dict): NN, NNN, and NNNN interaction distances.
+            sublattice_wyckoff_symbols (dict): Maps each sublattice id to its wyckoff symbol.
+            nn_interactions (dict): {(i, j): [J label, ...]} - the distinct interactions
+                of each sublattice pair, ordered from the nearest shell outwards.
+            dists (dict): {J label: interaction distance in Angstrom}.
             ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
             ex_params (dict): Exchange parameter values. The J_ij are in meV; the
                 included 'E0' offset stays in eV.
@@ -962,23 +965,19 @@ class HeisenbergModel(MSONable):
         """
         self.formula = formula
         self.structures = structures
+        self.magnetic_structures = magnetic_structures
         self.energies = energies
         self.cutoff = cutoff
         self.tol = tol
-        self.sgraphs = sgraphs
-        self.site_labels = site_labels
-        self.wyckoff_ids = wyckoff_ids
+        self.nn_graphs = nn_graphs
+        self.sublattice_ids = sublattice_ids
+        self.sublattice_wyckoff_symbols = sublattice_wyckoff_symbols
         self.nn_interactions = nn_interactions
         self.dists = dists
         self.ex_mat = ex_mat
         self.ex_params = ex_params
         self.javg = javg
         self.igraph = igraph
-
-    @property
-    def unique_site_ids(self):
-        """list[dict]: One {tuple(site indices): sublattice id} map per ordering."""
-        return [HeisenbergMapper._site_ids_dict(labels) for labels in self.site_labels]
 
     def as_dict(self):
         """Because some dicts have int keys, some sanitization is required for JSON compatibility."""
@@ -988,11 +987,12 @@ class HeisenbergModel(MSONable):
             "@version": __version__,
             "formula": self.formula,
             "structures": [struct.as_dict() for struct in self.structures],
+            "magnetic_structures": [struct.as_dict() for struct in self.magnetic_structures],
             "energies": self.energies,
             "cutoff": self.cutoff,
             "tol": self.tol,
-            "sgraphs": [sgraph.as_dict() for sgraph in self.sgraphs],
-            "site_labels": self.site_labels,
+            "nn_graphs": [nn_graph.as_dict() for nn_graph in self.nn_graphs],
+            "sublattice_ids": self.sublattice_ids,
             "dists": self.dists,
             "ex_params": self.ex_params,
             "javg": self.javg,
@@ -1000,20 +1000,19 @@ class HeisenbergModel(MSONable):
             # Sanitize int keys / DataFrame
             "ex_mat": jsanitize(self.ex_mat.to_dict()),
             "nn_interactions": jsanitize(self.nn_interactions),
-            "wyckoff_ids": jsanitize(self.wyckoff_ids),
+            "sublattice_wyckoff_symbols": jsanitize(self.sublattice_wyckoff_symbols),
         }
 
     @classmethod
     def from_dict(cls, dct: dict) -> Self:
         """Create a HeisenbergModel from a dict."""
-        # Reconstitute the int-keyed dicts that jsanitize stringified
-        nn_interactions = {
-            shell: {literal_eval(i): j for i, j in pairs.items()} for shell, pairs in dct["nn_interactions"].items()
-        }
-        wyckoff_ids = {literal_eval(k): v for k, v in dct["wyckoff_ids"].items()}
+        # Reconstitute the tuple/int-keyed dicts that jsanitize stringified
+        nn_interactions = {literal_eval(pair): labels for pair, labels in dct["nn_interactions"].items()}
+        sublattice_wyckoff_symbols = {literal_eval(k): v for k, v in dct["sublattice_wyckoff_symbols"].items()}
 
         structures = [Structure.from_dict(v) for v in dct["structures"]]
-        sgraphs = [StructureGraph.from_dict(v) for v in dct["sgraphs"]]
+        magnetic_structures = [Structure.from_dict(v) for v in dct["magnetic_structures"]]
+        nn_graphs = [StructureGraph.from_dict(v) for v in dct["nn_graphs"]]
         igraph = StructureGraph.from_dict(dct["igraph"])
 
         # Reconstitute the exchange matrix DataFrame
@@ -1022,12 +1021,13 @@ class HeisenbergModel(MSONable):
         return cls(
             formula=dct["formula"],
             structures=structures,
+            magnetic_structures=magnetic_structures,
             energies=dct["energies"],
             cutoff=dct["cutoff"],
             tol=dct["tol"],
-            sgraphs=sgraphs,
-            site_labels=dct["site_labels"],
-            wyckoff_ids=wyckoff_ids,
+            nn_graphs=nn_graphs,
+            sublattice_ids=dct["sublattice_ids"],
+            sublattice_wyckoff_symbols=sublattice_wyckoff_symbols,
             nn_interactions=nn_interactions,
             dists=dct["dists"],
             ex_mat=ex_mat,

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -1254,8 +1254,17 @@ class HeisenbergModel(MSONable):
         nn_graphs = [StructureGraph.from_dict(v) for v in dct["nn_graphs"]]
         igraph = StructureGraph.from_dict(dct["igraph"])
 
-        # Reconstitute the exchange matrix DataFrame
-        ex_mat = pd.DataFrame.from_dict(dct["ex_mat"]) if dct["ex_mat"] else pd.DataFrame(columns=["E", "E0"])
+        # Reconstitute the exchange matrix DataFrame. as_dict() calls .to_dict() on it,
+        # but serializations written before that did (and by #4664, which jsanitized the
+        # DataFrame directly) may store a (JSON/repr) string instead. Accept both forms
+        # and fall back to an empty matrix when ex_mat is empty.
+        ex_mat = dct["ex_mat"]
+        if isinstance(ex_mat, str):
+            try:
+                ex_mat = literal_eval(ex_mat)
+            except (SyntaxError, ValueError):  # empty or unparsable string
+                ex_mat = None
+        ex_mat = pd.DataFrame.from_dict(ex_mat) if ex_mat else pd.DataFrame(columns=["E", "E0"])
 
         return cls(
             formula=dct["formula"],

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -982,7 +982,7 @@ class HeisenbergModel(MSONable):
     def from_dict(cls, dct: dict) -> Self:
         """Create a HeisenbergModel from a dict."""
         # Reconstitute the site ids
-        unique_site_ids = {}
+        unique_site_ids = []
         wyckoff_ids = {}
         nn_interactions = {}
 
@@ -993,12 +993,14 @@ class HeisenbergModel(MSONable):
                 nn_dict[key] = v1
             nn_interactions[k] = nn_dict
 
-        for k, v in dct["unique_site_ids"].items():
-            key = literal_eval(k)
-            if isinstance(key, int):
-                unique_site_ids[key,] = v
-            elif isinstance(key, tuple):
-                unique_site_ids[key] = v
+        # unique_site_ids is one map per ordering (a list of dicts); rebuild the
+        # tuple keys that jsanitize stringified for each ordering's map.
+        for site_map in dct["unique_site_ids"]:
+            rebuilt = {}
+            for k, v in site_map.items():
+                key = literal_eval(k)
+                rebuilt[(key,) if isinstance(key, int) else tuple(key)] = v
+            unique_site_ids.append(rebuilt)
 
         for k, v in dct["wyckoff_ids"].items():
             wyckoff_ids[literal_eval(k)] = v

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -40,6 +40,9 @@ different supercells can be fitted together. This changed the public surface:
 * ``HeisenbergScreener(ordered_structures, energies)`` now takes the list of
   :class:`RelaxedOrdering` objects and exposes ``screened_orderings`` in place
   of ``screened_structures``/``screened_energies``.
+* The default ``tol`` changed from 0.02 to 0.05 Angstrom. This changes which
+  nearest-neighbor distances are merged into the same shell; pass ``tol=0.02``
+  explicitly to keep the old behavior.
 """
 
 from __future__ import annotations
@@ -412,14 +415,23 @@ class HeisenbergMapper:
             ordered_structures (list): Structure objects with magmoms.
             energies (list): Total energies of each relaxed magnetic structure.
             parent (Structure): Paramagnetic parent cell whose symmetry defines the
-                magnetic sublattices. If None, it is inferred as the primitive cell of
-                the lowest-energy ordering. Defaults to None.
+                magnetic sublattices. Reduced to its primitive cell either way, so a
+                deliberately-supplied supercell parent is analyzed on its primitive
+                cell too, not as given. If None, it is inferred as the primitive cell
+                of the lowest-energy ordering. Defaults to None.
             cutoff (float): Cutoff in Angstrom for nearest neighbor search. Defaults to 0,
                 which keeps only each site's nearest neighbors, i.e. one shell per
                 sublattice pair; with a cutoff, every interaction up to it is kept.
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances
                 being equal.
         """
+        if parent is not None and not isinstance(parent, Structure):
+            raise TypeError(
+                f"parent must be a Structure or None, got {type(parent).__name__}. "
+                "Note the constructor signature changed: parent now comes third, "
+                "before cutoff/tol - see the module docstring's migration guide."
+            )
+
         # Save original copies of inputs
         self.ordered_structures_ = ordered_structures
         self.energies_ = energies
@@ -431,7 +443,7 @@ class HeisenbergMapper:
         # These attributes are set by internal methods, listed here for clarity.
         self.orderings = self.parent = None  # set by _initialize_orderings
         self.nn_interactions = self.dists = None  # set by _set_interactions
-        self.ex_mat = self.ex_params = None  # set by _build_exchange_mat and get_exchange
+        self.ex_mat = self.ex_params = self.residual = None  # set by _build_exchange_mat and get_exchange
 
         self._initialize_orderings(ordered_structures, energies, parent)
         self._set_interactions()
@@ -1245,6 +1257,16 @@ class HeisenbergModel(MSONable):
     @classmethod
     def from_dict(cls, dct: dict) -> Self:
         """Create a HeisenbergModel from a dict."""
+        if "sublattice_ids" not in dct or "magnetic_structures" not in dct:
+            raise ValueError(
+                f"This dict was serialized with HeisenbergModel {dct.get('@version', '<0.2')}, which "
+                "predates the parent-cell sublattice refactor (see this module's migration guide) and "
+                "cannot be loaded by this version - it is missing `sublattice_ids`/`magnetic_structures` "
+                "(pre-0.2 dicts have `unique_site_ids`/`wyckoff_ids`/`sgraphs` instead, which don't map "
+                "onto the new parent-cell sublattices). Recompute the HeisenbergModel from the original "
+                "orderings with the current HeisenbergMapper."
+            )
+
         # Reconstitute the tuple/int-keyed dicts that jsanitize stringified
         nn_interactions = {literal_eval(pair): labels for pair, labels in dct["nn_interactions"].items()}
         sublattice_wyckoff_symbols = {literal_eval(k): v for k, v in dct["sublattice_wyckoff_symbols"].items()}

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -6,7 +6,6 @@ model.
 
 from __future__ import annotations
 
-import copy
 import logging
 from ast import literal_eval
 from typing import TYPE_CHECKING
@@ -39,36 +38,44 @@ logger = logging.getLogger(__name__)
 class HeisenbergMapper:
     """Compute exchange parameters from low energy magnetic orderings.
 
+    Sublattices are defined once, on a paramagnetic *parent cell* (its symmetry
+    orbits / Wyckoff positions). Every magnetic ordering is treated as a spin
+    sample drawn on that parent lattice, so each magnetic site is labelled with
+    the parent sublattice it belongs to. Because the labels live in the parent
+    cell - not in any one ordering's supercell - orderings that occupy
+    different-sized supercells share a single, consistent set of exchange
+    parameters.
+
     Attributes:
-        strategy (object): Class from pymatgen.analysis.local_env for constructing graphs.
-        sgraphs (list): StructureGraph objects.
-        unique_site_ids (list[dict]): One unique_site_ids dict per ordering, with
-            identifiers shared across orderings via a common parent cell.
-        wyckoff_ids (dict): Maps unique numerical identifier to wyckoff position.
-        nn_interactions (dict): {i: j} pairs of NN interactions between unique sites.
-        dists (dict): NN, NNN, and NNNN interaction distances
-        ex_mat (DataFrame): Invertible Heisenberg Hamiltonian for each graph.
-        ex_params (dict): Exchange parameter values (meV/atom)
+        sgraphs (list): StructureGraph objects, one per ordering.
+        parent (Structure): Nonmagnetic parent cell that defines the sublattices.
+        site_labels (list[list[int]]): site_labels[k][i] is the parent
+            sublattice id of site i in ordering k.
+        wyckoff_ids (dict): Maps each sublattice id to its wyckoff symbol.
+        nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
+        dists (dict): NN, NNN, and NNNN interaction distances.
+        ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
+        ex_params (dict): Exchange parameter values (meV).
     """
 
-    def __init__(self, ordered_structures, energies, cutoff=0, tol: float = 0.02):
+    def __init__(self, ordered_structures, energies, parent=None, cutoff=0, tol: float = 0.02):
         """Exchange parameters are computed by mapping to a classical Heisenberg
-        model. Strategy is the scheme for generating neighbors. Currently only
-        MinimumDistanceNN is implemented.
-        n+1 unique orderings are required to compute n exchange
-        parameters.
+        model. n+1 unique orderings are required to compute n exchange parameters.
 
         First run a MagneticOrderingsWF to obtain low energy collinear magnetic
-        orderings and find the magnetic ground state. Then enumerate magnetic
-        states with the ground state as the input structure, find the subset
-        of supercells that map to the ground state, and do static calculations
-        for these orderings.
+        orderings and find the magnetic ground state, enumerate magnetic
+        states with the ground state as the input structure and do static
+        calculations for these orderings. The orderings may live in different
+        supercells - they only need to be commensurate with a common parent cell.
 
         Args:
             ordered_structures (list): Structure objects with magmoms.
             energies (list): Total energies of each relaxed magnetic structure.
+            parent (Structure): Paramagnetic parent cell whose symmetry defines the
+                magnetic sublattices. If None, it is inferred as the primitive cell
+                of the lowest-energy ordering. Defaults to None.
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
-                Defaults to 0 (only NN, no NNN, etc.)
+                Defaults to 0 (only NN, no NNN, etc.).
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances
                 being equal.
         """
@@ -76,31 +83,31 @@ class HeisenbergMapper:
         self.ordered_structures_ = ordered_structures
         self.energies_ = energies
 
-        # Sanitize inputs and optionally order them by energy / magnetic moments
+        # Sanitize inputs: standardize moments, convert energies to per magnetic
+        # ion, drop duplicates and sort by energy. The screener keeps both a
+        # magnetic-only copy (for the graphs) and a full copy (all ions, needed
+        # to determine site symmetry) of every ordering.
         hs = HeisenbergScreener(ordered_structures, energies, screen=False)
-        ordered_structures = hs.screened_structures
-        energies = hs.screened_energies
-
-        self.ordered_structures = ordered_structures
-        self.energies = energies
+        self.ordered_structures = hs.screened_structures
+        self.full_structures = hs.screened_full_structures
+        self.energies = hs.screened_energies
         self.cutoff = cutoff
         self.tol = tol
 
-        # Get graph representations
-        self.sgraphs = self._get_graphs(cutoff, ordered_structures)
+        # Graph representation of each (magnetic-only) ordering
+        self.sgraphs = self._get_graphs(cutoff, self.ordered_structures)
 
-        # Get unique site ids (one map per ordering, anchored to a common
-        # parent cell) and wyckoff symbols
-        self.unique_site_ids, self.wyckoff_ids = self._get_unique_sites(ordered_structures)
+        # The parent cell defines the sublattices; label every magnetic site in
+        # every ordering with the parent sublattice it belongs to.
+        self.parent = self._get_parent(parent, self.full_structures)
+        self.wyckoff_ids, self.site_labels = self._label_orderings(self.parent, self.full_structures)
 
         # These attributes are set by internal methods
         self.nn_interactions = self.dists = self.ex_mat = self.ex_params = None
 
-        # Check how many commensurate graphs we found
         if len(self.sgraphs) < 2:
             raise SystemExit("We need at least 2 unique orderings.")
 
-        # Set attributes
         self._get_nn_dict()
         self._get_exchange_df()
 
@@ -114,327 +121,240 @@ class HeisenbergMapper:
             ordered_structures (list): Structure objects.
 
         Returns:
-            sgraphs (list): StructureGraph objects.
+            list[StructureGraph]: One graph per ordering.
         """
-        # Strategy for finding neighbors
         strategy = MinimumDistanceNN(cutoff=cutoff, get_all_sites=True) if cutoff else MinimumDistanceNN()  # only NN
-
-        # Generate structure graphs
         return [StructureGraph.from_local_env_strategy(s, strategy=strategy) for s in ordered_structures]
 
     @staticmethod
-    def _get_unique_sites(
-        structures: list[Structure],
-        parent: Structure | None = None,
-        pre_relaxation: list[Structure] | None = None,
-    ):
-        """Map sites to unique identifiers that are consistent across orderings.
+    def _nonmagnetic(structure):
+        """Nonmagnetic copy of a structure (moments zeroed, all ions kept)."""
+        s0 = CollinearMagneticStructureAnalyzer(
+            structure, make_primitive=False, threshold=0.0
+        ).get_nonmagnetic_structure(make_primitive=False)
+        if "wyckoff" in s0.site_properties:
+            s0.remove_site_property("wyckoff")
+        return s0
 
-        Site identifiers are anchored to a common *parent cell* so that the same
-        crystallographic orbit receives the same id in every ordering,
-        independent of supercell size. This keeps the J_ij interaction labels
-        consistent across orderings that live in different supercells.
+    @classmethod
+    def _get_parent(cls, parent, full_structures):
+        """Return the nonmagnetic primitive parent cell that defines the sublattices.
 
-        The parent cell is, in order of preference:
-
-        1. ``parent`` if provided (the paramagnetic cell fed to the enumeration);
-        2. otherwise the first input structure's primitive cell.
-
-        Symmetry is analysed on a nonmagnetic copy (magnetic moments zeroed) that retains
-        whatever ions are present, so e.g. an anion sublattice still constrains
-        the orbits.
-
-        When ``pre_relaxation`` is supplied, its undistorted
-        geometries are used for the symmetry analysis and site matching
-        (relaxation can artificially lower the detected symmetry); the resulting
-        ids still apply to ``structures`` because relaxation preserves site
-        ordering.
+        The nonmagnetic ions are kept: site equivalence is read from this parent's
+        symmetry, and removing the nonmagnetic ions first can raise the apparent
+        site symmetry and merge sublattices that are actually distinct.
 
         Args:
-            structures (list[Structure]): Magnetic orderings to label.
-            parent (Structure): Paramagnetic parent cell. If None, the first
-                input structure's primitive cell is used as the parent.
-            pre_relaxation (list[Structure]): Enumerated orderings before
-                relaxation, aligned index-for-index with ``structures``.
+            parent (Structure | None): Explicit paramagnetic parent (all ions). If
+                None, the primitive cell of the lowest-energy ordering is used.
+            full_structures (list[Structure]): Orderings with all ions retained.
 
         Returns:
-            tuple[list[dict], dict]:
-                - list of unique_site_ids dicts, one per input structure; each
-                  maps a tuple of equivalent site indices to a global int id
-                  that is shared across all structures.
-                - wyckoff_ids maps each global int id to its wyckoff symbol.
+            Structure: Nonmagnetic primitive parent cell, nonmagnetic ions included.
+        """
+        ref = parent if parent is not None else full_structures[0]
+        return cls._nonmagnetic(ref).get_primitive_structure()
+
+    @classmethod
+    def _label_orderings(cls, parent, full_structures):
+        """Label every magnetic site in every ordering with its parent sublattice.
+
+        The magnetic sublattices are the parent's symmetry orbits, computed on the
+        *full* cell (nonmagnetic ions present) and then restricted to the magnetic
+        species. Each ordering is folded back onto the full parent so its sites
+        inherit the parent labels; the labels of the nonmagnetic sites are
+        discarded. This keeps the labels consistent across orderings that live in
+        different supercells, while preserving the true site symmetry.
+
+        Args:
+            parent (Structure): Nonmagnetic parent cell (all ions).
+            full_structures (list[Structure]): Orderings with all ions retained and
+                a 'magmom' site property on every site.
+
+        Returns:
+            tuple[dict, list[list[int]]]:
+                - wyckoff_ids maps each magnetic sublattice id to its wyckoff symbol.
+                - site_labels[k][i] is the sublattice id of magnetic site i in
+                  ordering k (aligned with the magnetic-only graphs).
 
         Raises:
-            ValueError: If a structure is not a supercell of the parent cell.
+            ValueError: If an ordering is not a supercell of the parent cell.
         """
+        # Species that carry a moment in any ordering are the magnetic species.
+        mag_species = {site.specie.symbol for s in full_structures for site in s if abs(site.properties["magmom"]) > 0}
 
-        def nonmagnetic(struct):
-            """Zero the moments but keep every ion, for symmetry analysis."""
-            s0 = CollinearMagneticStructureAnalyzer(
-                struct, make_primitive=False, threshold=0.0
-            ).get_nonmagnetic_structure(make_primitive=False)
-            if "wyckoff" in s0.site_properties:
-                s0.remove_site_property("wyckoff")
-            return s0
-
-        geometries = pre_relaxation if pre_relaxation is not None else structures
-
-        if parent is not None:
-            parent_struct = nonmagnetic(parent)
-        else:
-            parent_struct = nonmagnetic(geometries[0].get_primitive_structure())
-
-        # The parent's symmetry orbits define the global site identifiers.
-        symm_parent = SpacegroupAnalyzer(parent_struct).get_symmetrized_structure()
-        parent_orbit = {}  # parent site index -> global id
-        wyckoff_ids = {}  # global id -> wyckoff symbol
-        for goid, (indices, symbol) in enumerate(
-            zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True)
-        ):
-            wyckoff_ids[goid] = symbol
+        # Sublattices = the parent's symmetry orbits restricted to magnetic
+        # species. Nonmagnetic sites get the sentinel -1 (never used).
+        symm_parent = SpacegroupAnalyzer(parent).get_symmetrized_structure()
+        parent_labels = [-1] * len(parent)
+        wyckoff_ids = {}
+        for indices, symbol in zip(symm_parent.equivalent_indices, symm_parent.wyckoff_symbols, strict=True):
+            if symm_parent[indices[0]].specie.symbol not in mag_species:
+                continue
+            sub_id = len(wyckoff_ids)
+            wyckoff_ids[sub_id] = symbol
             for index in indices:
-                parent_orbit[index] = goid
+                parent_labels[index] = sub_id
 
-        # Tag each parent site with its orbit id so the StructureMatcher can
-        # carry the labels across when it folds each ordering back onto the
-        # parent.
-        parent_struct.add_site_property("orbit_id", [parent_orbit[idx] for idx in range(len(parent_struct))])
+        # Carry the parent labels across to each ordering by folding the ordering's
+        # full geometry onto the tagged parent cell (the nonmagnetic ions help pin
+        # down a unique mapping). This also validates that every ordering is a
+        # genuine supercell of the parent.
+        tagged_parent = parent.copy()
+        tagged_parent.add_site_property("sublattice_id", parent_labels)
         matcher = StructureMatcher(primitive_cell=False, attempt_supercell=True)
 
-        unique_site_ids = []
-        for s_idx, geom in enumerate(geometries):
-            s0 = nonmagnetic(geom)
-
-            # get_s2_like_s1 returns the parent supercell reordered so that its
-            # i-th site coincides with the i-th ordering site, or None if the
-            # ordering is not a (super)cell of the parent.
-            matched_parent = matcher.get_s2_like_s1(s0, parent_struct)
-            if matched_parent is None:
+        site_labels = []
+        for idx, full in enumerate(full_structures):
+            matched = matcher.get_s2_like_s1(cls._nonmagnetic(full), tagged_parent)
+            if matched is None:
                 raise ValueError(
-                    f"Structure {s_idx} is not a supercell of the parent cell; its "
-                    "orderings cannot be mapped onto a common set of sites."
+                    f"Ordering {idx} is not a supercell of the parent cell; it "
+                    "cannot be mapped onto the parent sublattices. Pass an explicit "
+                    "`parent` cell that all orderings share."
                 )
+            # matched[i] is the parent site that ordering site i folds onto. Keep
+            # only the magnetic sites, in order, so the labels align with the
+            # magnetic-only structure used to build the graphs.
+            magmoms = full.site_properties["magmom"]
+            site_labels.append(
+                [int(matched[i].properties["sublattice_id"]) for i in range(len(full)) if abs(magmoms[i]) > 0]
+            )
 
-            # matched_parent[i] is the parent site that ordering site i maps
-            # onto, so its orbit id is the global id of ordering site i. Collect
-            # all ordering sites that share each orbit id.
-            sites_by_orbit = {}
-            for site_idx, parent_site in enumerate(matched_parent.sites):
-                orbit_id = parent_site.properties["orbit_id"]
-                sites_by_orbit.setdefault(orbit_id, []).append(site_idx)
-
-            unique_site_ids.append({tuple(sorted(idxs)): goid for goid, idxs in sites_by_orbit.items()})
-
-        return unique_site_ids, wyckoff_ids
+        return wyckoff_ids, site_labels
 
     @staticmethod
-    def _global_orbit_id(site_ids: dict, site_idx: int) -> int | None:
-        """Global id of the orbit containing site_idx, or None."""
-        for indices, goid in site_ids.items():
-            if site_idx in indices:
-                return goid
+    def _site_ids_dict(labels):
+        """Group site indices by sublattice id: {tuple(site indices): sublattice id}."""
+        groups: dict[int, list[int]] = {}
+        for idx, sub_id in enumerate(labels):
+            groups.setdefault(sub_id, []).append(idx)
+        return {tuple(indices): sub_id for sub_id, indices in groups.items()}
+
+    @property
+    def unique_site_ids(self):
+        """list[dict]: One {tuple(site indices): sublattice id} map per ordering."""
+        return [self._site_ids_dict(labels) for labels in self.site_labels]
+
+    def _shell_of(self, dist):
+        """Return 'nn'/'nnn'/'nnnn' for a distance, or None if it matches no shell."""
+        for shell in ("nn", "nnn", "nnnn"):
+            if self.dists[shell] and abs(dist - self.dists[shell]) <= self.tol:
+                return shell
         return None
 
     def _get_nn_dict(self):
-        """Set self.nn_interactions and self.dists instance variables describing unique
-        nearest neighbor interactions.
+        """Set self.dists and self.nn_interactions describing the unique NN, NNN and
+        NNNN interactions between sublattices.
+
+        Distances and connectivity are read from the lowest-energy ordering, whose
+        per-site sublattice labels are already consistent with every other ordering.
         """
-        tol = self.tol  # tolerance on NN distances
+        tol = self.tol
         sgraph = self.sgraphs[0]
-        # Distances/labels are derived from the first ordering, so use its map.
-        unique_site_ids = self.unique_site_ids[0]
+        labels = self.site_labels[0]
 
-        nn_dict = {}
-        nnn_dict = {}
-        nnnn_dict = {}
+        # One representative site index per sublattice
+        reps = {}
+        for idx, sub_id in enumerate(labels):
+            reps.setdefault(sub_id, idx)
 
+        # Collect neighbor distances (up to NNNN) across the sublattices
         all_dists = []
+        for i in reps.values():
+            dists = sorted({round(cs[-1], 2) for cs in sgraph.get_connected_sites(i)})
+            all_dists += dists[:3]
 
-        # Loop over unique sites and get neighbor distances up to NNNN
-        for k in unique_site_ids:
-            i = k[0]
-            i_goid = unique_site_ids[k]
-            connected_sites = sgraph.get_connected_sites(i)
-            dists = [round(cs[-1], 2) for cs in connected_sites]  # i<->j distances
-            dists = sorted(set(dists))  # NN, NNN, NNNN, etc.
-
-            dists = dists[:3]  # keep up to NNNN
-            all_dists += dists
-
-        # Keep only up to NNNN and call dists equal if they are within tol
+        # Collapse distances that are equal within tol, keep up to NNNN, pad with 0
         all_dists = sorted(set(all_dists))
-        rm_list = []
-        for idx, d in enumerate(all_dists[:-1], start=1):
-            if abs(d - all_dists[idx]) < tol:
-                rm_list.append(idx)
-
+        rm_list = [idx for idx, d in enumerate(all_dists[:-1], start=1) if abs(d - all_dists[idx]) < tol]
         all_dists = [d for idx, d in enumerate(all_dists) if idx not in rm_list]
+        all_dists = [*all_dists, 0, 0, 0][:3]
+        self.dists = dict(zip(("nn", "nnn", "nnnn"), all_dists, strict=True))
 
-        if len(all_dists) < 3:  # pad with zeros
-            all_dists += [0] * (3 - len(all_dists))
+        # Determine which sublattice pairs interact at each shell
+        nn_interactions = {"nn": {}, "nnn": {}, "nnnn": {}}
+        for i_id, i in reps.items():
+            for cs in sgraph.get_connected_sites(i):
+                shell = self._shell_of(round(cs[-1], 2))
+                if shell is not None:
+                    nn_interactions[shell][i_id] = labels[cs[2]]
 
-        all_dists = all_dists[:3]
-        labels = ("nn", "nnn", "nnnn")
-        dists = dict(zip(labels, all_dists, strict=True))
-
-        # Get dictionary keys for interactions
-        for k in unique_site_ids:
-            i = k[0]
-            i_goid = unique_site_ids[k]
-            connected_sites = sgraph.get_connected_sites(i)
-
-            # Loop over sites and determine unique NN, NNN, etc. interactions
-            for cs in connected_sites:
-                dist = round(cs[-1], 2)  # i_j distance
-
-                j = cs[2]  # j index
-                j_goid = self._global_orbit_id(unique_site_ids, j)
-                if abs(dist - dists["nn"]) <= tol:
-                    nn_dict[i_goid] = j_goid
-                elif abs(dist - dists["nnn"]) <= tol:
-                    nnn_dict[i_goid] = j_goid
-                elif abs(dist - dists["nnnn"]) <= tol:
-                    nnnn_dict[i_goid] = j_goid
-
-        nn_interactions = {"nn": nn_dict, "nnn": nnn_dict, "nnnn": nnnn_dict}
-
-        self.dists = dists
         self.nn_interactions = nn_interactions
 
-    def _get_exchange_df(self):
-        """
-        Loop over all sites in a graph and count the number and types of
-        nearest neighbor interactions, computing +-|S_i . S_j| to construct
-        a Heisenberg Hamiltonian for each graph. Sets self.ex_mat instance variable.
-
-        TODO Deal with large variance in |S| across configs
-        """
-        sgraphs = self.sgraphs
-        tol = self.tol
-        unique_site_ids = self.unique_site_ids
-        nn_interactions = self.nn_interactions
-        dists = self.dists
-
-        # Get |site magmoms| from FM ordering so that S_i and S_j are consistent?
-        # Large S variations is throwing a loop
-        # fm_struct = self.get_low_energy_orderings()[0]
-
-        # Total energy and nonmagnetic energy contribution
+    def _exchange_columns(self):
+        """Column labels for the exchange matrix: 'E', 'E0' then one per J_ij."""
         columns = ["E", "E0"]
+        for shell, pairs in self.nn_interactions.items():
+            for i_id, j_id in pairs.items():
+                col = f"{i_id}-{j_id}-{shell}"
+                rev = f"{j_id}-{i_id}-{shell}"
+                if col not in columns and rev not in columns:
+                    columns.append(col)
+        # Keep at most n interactions for n+1 orderings
+        return columns[: len(self.sgraphs) + 1]
 
-        # Get labels of unique NN interactions
-        for k0, v0 in nn_interactions.items():
-            for idx, j in v0.items():  # i and j indices
-                c = f"{idx}-{j}-{k0}"
-                c_rev = f"{j}-{idx}-{k0}"
-                if c not in columns and c_rev not in columns:
-                    columns.append(c)
+    def _get_exchange_df(self):
+        """Build the Heisenberg Hamiltonian, one row per ordering, by counting
+        +-|S_i . S_j| over each graph. Sets self.ex_mat.
 
-        n_sgraphs = len(sgraphs)
+        Each row is normalised per magnetic ion so that orderings living in
+        different-sized supercells share a single linear system (the energies are
+        already per magnetic ion, see HeisenbergScreener._do_cleanup).
+        """
+        columns = self._exchange_columns()
+        j_columns = [c for c in columns if c not in ("E", "E0")]
 
-        # Keep n interactions (not counting 'E') for n+1 structure graphs
-        columns = columns[: n_sgraphs + 1]
+        if len(j_columns) < 2:  # Only <J> can be calculated
+            self.ex_mat = pd.DataFrame(columns=columns)
+            return
 
-        n_nn_j = len(columns) - 1  # ignore total energy
-        j_columns = [name for name in columns if name not in ["E", "E0"]]
-        ex_mat_empty = pd.DataFrame(columns=columns)
-        ex_mat = ex_mat_empty.copy()
+        rows = []
+        seen = set()  # de-duplicate identical interaction rows to avoid singularity
+        for k, sgraph in enumerate(self.sgraphs):
+            labels = self.site_labels[k]
+            magmoms = sgraph.structure.site_properties["magmom"]
+            n_sites = len(sgraph.structure)
 
-        if len(j_columns) < 2:
-            self.ex_mat = ex_mat  # Only <J> can be calculated here
-        else:
-            sgraphs_copy = copy.deepcopy(sgraphs)
-            sgraph_index = 0
+            row = dict.fromkeys(columns, 0.0)
+            for i in range(len(sgraph.graph.nodes)):
+                s_i = magmoms[i]
+                i_id = labels[i]
+                for cs in sgraph.get_connected_sites(i):
+                    shell = self._shell_of(round(cs[-1], 2))
+                    if shell is None:
+                        continue
+                    j_id = labels[cs[2]]
+                    col = f"{i_id}-{j_id}-{shell}"
+                    rev = f"{j_id}-{i_id}-{shell}"
+                    if col in row:
+                        row[col] -= s_i * magmoms[cs[2]]
+                    elif rev in row:
+                        row[rev] -= s_i * magmoms[cs[2]]
 
-            # Loop over all sites in each graph and compute |S_i . S_j|
-            # for n+1 unique graphs to compute n exchange params
-            order = ""
-            for graph_idx, _graph in enumerate(sgraphs):
-                sgraph = sgraphs_copy.pop(0)
-                # Each ordering lives in its own supercell, so resolve site
-                # indices against that ordering's map; the global ids it returns
-                # are shared across orderings (and with nn_interactions).
-                site_ids = unique_site_ids[graph_idx]
-                # Invert {sites: goid} -> {site: goid} once so the per-connection
-                # lookups below are O(1) instead of scanning every orbit.
-                goid_by_site = {site: goid for sites, goid in site_ids.items() for site in sites}
-                ex_row = pd.DataFrame(np.zeros((1, n_nn_j + 1)), index=[sgraph_index], columns=columns)
+            # Extensive sums -> per magnetic ion, with the 1/2 Heisenberg factor.
+            # Each bond is visited from both ends, so 2 * n_sites also removes the
+            # double counting.
+            for c in j_columns:
+                row[c] /= 2 * n_sites
 
-                for idx, _node in enumerate(sgraph.graph.nodes):
-                    # s_i_sign = np.sign(sgraph.structure.site_properties['magmom'][i])
-                    s_i = sgraph.structure.site_properties["magmom"][idx]
+            key = tuple(round(row[c], 10) for c in j_columns)
+            if key in seen:
+                continue
+            seen.add(key)
+            row["E0"] = 1.0  # nonmagnetic contribution (per ion)
+            row["E"] = self.energies[k]
+            rows.append(row)
 
-                    i_goid = goid_by_site.get(idx)
+        ex_mat = pd.DataFrame(rows, columns=columns)
 
-                    # Get all connections for ith site and compute |S_i . S_j|
-                    connections = sgraph.get_connected_sites(idx)
-                    # dists = [round(cs[-1], 2) for cs in connections]  # i<->j distances
-                    # dists = sorted(list(set(dists)))  # NN, NNN, NNNN, etc.
+        # Drop interaction columns that never appear (all zero) to keep H invertible
+        j_columns = [c for c in j_columns if (ex_mat[c] != 0).any()]
+        ex_mat = ex_mat[["E", "E0", *j_columns]]
 
-                    for connection in connections:
-                        j_site = connection[2]
-                        dist = round(connection[-1], 2)  # i_j distance
-
-                        # s_j_sign = np.sign(sgraph.structure.site_properties['magmom'][j_site])
-                        s_j = sgraph.structure.site_properties["magmom"][j_site]
-
-                        j_goid = goid_by_site.get(j_site)
-
-                        # Determine order of connection
-                        if abs(dist - dists["nn"]) <= tol:
-                            order = "-nn"
-                        elif abs(dist - dists["nnn"]) <= tol:
-                            order = "-nnn"
-                        elif abs(dist - dists["nnnn"]) <= tol:
-                            order = "-nnnn"
-
-                        j_ij = f"{i_goid}-{j_goid}{order}"
-                        j_ji = f"{j_goid}-{i_goid}{order}"
-
-                        if j_ij in ex_mat.columns:
-                            ex_row.loc[sgraph_index, j_ij] -= s_i * s_j
-                        elif j_ji in ex_mat.columns:
-                            ex_row.loc[sgraph_index, j_ji] -= s_i * s_j
-
-                # The interaction sums above are extensive (summed over the whole
-                # supercell), but the energies are per magnetic ion (see
-                # HeisenbergScreener._do_cleanup).
-                # Normalising each row by its site count puts every ordering on
-                # the same per-ion normalisation, so orderings living in
-                # different-sized supercells can share a single fit.
-                # This also means that the E0 contribution is per magnetic ion,
-                # which the nonmagnetic energy contribution should be.
-                ex_row[j_columns] /= len(sgraph.structure)
-
-                # Ignore the row if it is a duplicate to avoid singular matrix
-                # Create a temporary DataFrame with the new row
-                ex_mat = ex_mat.dropna(how="all", axis=1)
-                ex_row = ex_row.dropna(how="all", axis=1)
-                temp_df = pd.concat([ex_mat, ex_row], ignore_index=True)
-                if temp_df[j_columns].equals(temp_df[j_columns].drop_duplicates(keep="first")):
-                    e_index = self.ordered_structures.index(sgraph.structure)
-                    ex_row.loc[sgraph_index, "E"] = self.energies[e_index]
-                    sgraph_index += 1
-                    ex_mat = pd.concat([ex_mat, ex_row], ignore_index=True)
-                    # if sgraph_index == num_nn_j:  # check for zero columns
-                    #     zeros = [b for b in (ex_mat[j_columns] == 0).all(axis=0)]
-                    #     if True in zeros:
-                    #         sgraph_index -= 1  # keep looking
-
-            ex_mat[j_columns] = ex_mat[j_columns].div(2)  # 1/2 factor in Heisenberg Hamiltonian
-            ex_mat[["E0"]] = 1  # Nonmagnetic contribution
-
-            # Check for singularities and delete columns with all zeros
-            zeros = list((ex_mat == 0).all(axis=0))
-            if True in zeros:
-                c = ex_mat.columns[zeros.index(True)]
-                ex_mat = ex_mat.drop(columns=[c], axis=1)
-                # ex_mat = ex_mat.drop(ex_mat.tail(len_zeros).index)
-
-            # Force ex_mat to be square
-            ex_mat = ex_mat[: ex_mat.shape[1] - 1]
-
-            self.ex_mat = ex_mat
+        # Square system: one row per parameter (E0 + the J_ij)
+        n_params = ex_mat.shape[1] - 1
+        self.ex_mat = ex_mat.iloc[:n_params].reset_index(drop=True)
 
     def get_exchange(self):
         """
@@ -442,34 +362,26 @@ class HeisenbergMapper:
         solve for the exchange parameters.
 
         Returns:
-            dict[str, float]: Exchange parameters (meV/atom).
+            dict[str, float]: Exchange parameters (meV).
         """
         ex_mat = self.ex_mat
-        # Solve the matrix equation for J_ij values
         E = ex_mat[["E"]]
         j_names = [j for j in ex_mat.columns if j != "E"]
 
-        # Only 1 NN interaction
+        # Only 1 NN interaction -> estimate <J> from E_AFM - E_FM
         if len(j_names) < 3:
-            # Estimate exchange by J ~ E_AFM - E_FM
-            j_avg = self.estimate_exchange()
-            ex_params = {"<J>": j_avg}
+            ex_params = {"<J>": self.estimate_exchange()}
             self.ex_params = ex_params
-
             return ex_params
 
-        # Solve eigenvalue problem for more than 1 NN interaction
+        # Solve the linear system for E0 and the J_ij
         H = np.array(ex_mat.loc[:, ex_mat.columns != "E"].values).astype(float)
-        H_inv = np.linalg.inv(H)
-        j_ij = np.dot(H_inv, E)
+        j_ij = np.dot(np.linalg.inv(H), E)
 
-        # Convert J_ij to meV
-        j_ij[1:] *= 1000  # J_ij in meV
-        j_ij = j_ij.tolist()
-        ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij, strict=True)}
+        j_ij[1:] *= 1000  # J_ij in meV (E0 stays in eV)
+        ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij.tolist(), strict=True)}
 
         self.ex_params = ex_params
-
         return ex_params
 
     def get_low_energy_orderings(self):
@@ -485,8 +397,6 @@ class HeisenbergMapper:
         mag_min = np.inf
         mag_max = 0.001
         fm_e = afm_e = fm_e_min = afm_e_min = 0
-
-        # epas = [e / len(s) for (e, s) in zip(self.energies, self.ordered_structures)]
 
         for s, e in zip(self.ordered_structures, self.energies, strict=True):
             ordering = CollinearMagneticStructureAnalyzer(s, threshold=0, make_primitive=False).ordering
@@ -547,18 +457,13 @@ class HeisenbergMapper:
             afm_e (float): afm energy/atom
 
         Returns:
-            float: Average J exchange parameter (meV/atom)
+            float: Average J exchange parameter (meV)
         """
         # Get low energy orderings if not supplied
         if any(arg is None for arg in [fm_struct, afm_struct, fm_e, afm_e]):
             fm_struct, afm_struct, fm_e, afm_e = self.get_low_energy_orderings()
 
         magmoms = fm_struct.site_properties["magmom"]
-
-        # Normalize energies by number of magnetic ions
-        # fm_e = fm_e / len(magmoms)
-        # afm_e = afm_e / len(afm_magmoms)
-
         m_avg = np.mean([np.sqrt(m**2) for m in magmoms])
 
         # If m_avg for FM config is < 1 we won't get sensible results.
@@ -581,13 +486,12 @@ class HeisenbergMapper:
         material.
 
         Args:
-            j_avg (float): j_avg (float): Average exchange parameter (meV/atom)
+            j_avg (float): Average exchange parameter (meV/atom)
 
         Returns:
             float: Critical temperature mft_t (K)
         """
-        # Number of magnetic sublattices = number of distinct global site ids
-        # (one per parent orbit), not the number of orderings.
+        # Number of magnetic sublattices = number of parent orbits
         n_sub_lattices = len(self.wyckoff_ids)
         k_boltzmann = 0.0861733  # meV/K
 
@@ -597,15 +501,12 @@ class HeisenbergMapper:
 
         else:  # multiple magnetic sublattices
             omega = np.zeros((n_sub_lattices, n_sub_lattices))
-            ex_params = self.ex_params
-            ex_params = {k: v for (k, v) in ex_params.items() if k != "E0"}  # ignore E0
-            for k in ex_params:
-                # split into i, j unique site identifiers
-                sites = k.split("-")
-                sites = [int(num) for num in sites[:2]]  # cut 'nn' identifier
-                i, j = sites[0], sites[1]
-                omega[i, j] += ex_params[k]
-                omega[j, i] += ex_params[k]
+            ex_params = {k: v for (k, v) in self.ex_params.items() if k != "E0"}  # ignore E0
+            for k, j_val in ex_params.items():
+                # split into i, j sublattice ids (cut the shell identifier)
+                i, j = (int(num) for num in k.split("-")[:2])
+                omega[i, j] += j_val
+                omega[j, i] += j_val
 
             omega = omega * 2 / 3 / k_boltzmann
             # omega is symmetric by construction, so use eigvalsh to guarantee
@@ -628,81 +529,56 @@ class HeisenbergMapper:
         Args:
             filename (str): if not None, save interaction graph to filename.
             ordering_index (int): Which ordering (and its supercell) to build the
-                interaction graph for. Site indices and the J_ij lookup use this
-                ordering's map. Defaults to 0 (the lowest-energy ordering).
+                graph for. Site indices and the J_ij lookup use this ordering's
+                sublattice labels. Defaults to 0 (the lowest-energy ordering).
 
         Returns:
             StructureGraph: Exchange interaction graph.
         """
+        if self.ex_params is None:
+            self.get_exchange()
+
         structure = self.ordered_structures[ordering_index]
         sgraph = self.sgraphs[ordering_index]
-        site_ids = self.unique_site_ids[ordering_index]
+        labels = self.site_labels[ordering_index]
 
         igraph = StructureGraph.from_empty_graph(
             structure, edge_weight_name="exchange_constant", edge_weight_units="meV"
         )
 
         if "<J>" in self.ex_params:  # Only <J> is available
-            warning_msg = """
-                Only <J> is available. The interaction graph will not tell
-                you much.
-                """
-            logger.warning(warning_msg)
+            logger.warning("Only <J> is available. The interaction graph will not tell you much.")
 
         # J_ij exchange interaction matrix
-        for idx in range(len(sgraph.graph.nodes)):
-            connections = sgraph.get_connected_sites(idx)
-            for c in connections:
+        for i in range(len(sgraph.graph.nodes)):
+            for c in sgraph.get_connected_sites(i):
                 jimage = c[1]  # relative integer coordinates of atom j
                 j = c[2]  # index of neighbor
-                dist = c[-1]  # i <-> j distance
+                j_exc = self._get_j_exc(labels[i], labels[j], c[-1])
+                igraph.add_edge(i, j, to_jimage=jimage, weight=j_exc, warn_duplicates=False)
 
-                j_exc = self._get_j_exc(idx, j, dist, site_ids)
-
-                igraph.add_edge(idx, j, to_jimage=jimage, weight=j_exc, warn_duplicates=False)
-
-        # Save to a JSON file if desired
         if filename:
             if not filename.endswith(".json"):
                 filename += ".json"
-
             dumpfn(igraph, filename)
 
         return igraph
 
-    def _get_j_exc(self, i, j, dist, site_ids):
-        """
-        Convenience method for looking up exchange parameter between two sites.
+    def _get_j_exc(self, i_id, j_id, dist):
+        """Look up the exchange parameter between two sublattices at a distance.
 
         Args:
-            i (int): index of ith site
-            j (int): index of jth site
-            dist (float): distance (Angstrom) between sites
-                (10E-2 precision)
-            site_ids (dict): The unique_site_ids map (``self.unique_site_ids[k]``)
-                for the ordering that i and j index into, so their site indices
-                resolve to the correct global orbit ids.
+            i_id (int): sublattice id of the ith site
+            j_id (int): sublattice id of the jth site
+            dist (float): distance (Angstrom) between sites (10E-2 precision)
 
         Returns:
-            float: Exchange parameter J_exc in meV
+            float: Exchange parameter J_exc in meV (0 if no matching interaction).
         """
-        # Resolve site indices to global orbit ids using the caller-supplied map
-        # for the ordering i and j belong to. A missing site yields None, which
-        # simply won't match any J_ij key below (rather than aliasing to orbit 0).
-        i_index = self._global_orbit_id(site_ids, i)
-        j_index = self._global_orbit_id(site_ids, j)
-
-        # Determine order of interaction
-        order = ""
-        if abs(dist - self.dists["nn"]) <= self.tol:
-            order = "-nn"
-        elif abs(dist - self.dists["nnn"]) <= self.tol:
-            order = "-nnn"
-        elif abs(dist - self.dists["nnnn"]) <= self.tol:
-            order = "-nnnn"
-
-        j_ij = f"{i_index}-{j_index}{order}"
-        j_ji = f"{j_index}-{i_index}{order}"
+        shell = self._shell_of(round(dist, 2))
+        order = f"-{shell}" if shell else ""
+        j_ij = f"{i_id}-{j_id}{order}"
+        j_ji = f"{j_id}-{i_id}{order}"
 
         if j_ij in self.ex_params:
             j_exc = self.ex_params[j_ij]
@@ -723,40 +599,21 @@ class HeisenbergMapper:
         Returns:
             HeisenbergModel: MSONable object.
         """
-        # Original formula unit with nonmagnetic ions
-        hm_formula = str(self.ordered_structures_[0].reduced_formula)
-
-        hm_structures = self.ordered_structures
-        hm_energies = self.energies
-        hm_cutoff = self.cutoff
-        hm_tol = self.tol
-        hm_sgraphs = self.sgraphs
-        hm_usi = self.unique_site_ids
-        hm_wids = self.wyckoff_ids
-        hm_nni = self.nn_interactions
-        hm_d = self.dists
-
-        # Exchange matrix DataFrame in JSON format
-        hm_em = self.ex_mat.to_json()
-        hm_ep = self.get_exchange()
-        hm_javg = self.estimate_exchange()
-        hm_igraph = self.get_interaction_graph()
-
         return HeisenbergModel(
-            hm_formula,
-            hm_structures,
-            hm_energies,
-            hm_cutoff,
-            hm_tol,
-            hm_sgraphs,
-            hm_usi,
-            hm_wids,
-            hm_nni,
-            hm_d,
-            hm_em,
-            hm_ep,
-            hm_javg,
-            hm_igraph,
+            formula=str(self.ordered_structures_[0].reduced_formula),
+            structures=self.ordered_structures,
+            energies=self.energies,
+            cutoff=self.cutoff,
+            tol=self.tol,
+            sgraphs=self.sgraphs,
+            site_labels=self.site_labels,
+            wyckoff_ids=self.wyckoff_ids,
+            nn_interactions=self.nn_interactions,
+            dists=self.dists,
+            ex_mat=self.ex_mat,
+            ex_params=self.get_exchange(),
+            javg=self.estimate_exchange(),
+            igraph=self.get_interaction_graph(),
         )
 
 
@@ -773,20 +630,23 @@ class HeisenbergScreener:
             screen (bool): Try to screen out high energy and low-spin configurations.
 
         Attributes:
-            screened_structures (list): Sorted structures.
+            screened_structures (list): Sorted magnetic-only structures.
+            screened_full_structures (list): The same orderings with nonmagnetic
+                ions retained, aligned index-for-index with screened_structures.
             screened_energies (list): Sorted energies.
         """
         # Cleanup
-        structures, energies = self._do_cleanup(structures, energies)
+        full_structures, structures, energies = self._do_cleanup(structures, energies)
 
         n_structures = len(structures)
 
         # If there are more than 2 structures, we want to perform a
         # screening to prioritize well-behaved orderings
         if screen and n_structures > 2:
-            structures, energies = self._do_screen(structures, energies)
+            full_structures, structures, energies = self._do_screen(full_structures, structures, energies)
 
         self.screened_structures = structures
+        self.screened_full_structures = full_structures
         self.screened_energies = energies
 
     @staticmethod
@@ -794,7 +654,8 @@ class HeisenbergScreener:
         """Sanitize input structures and energies.
 
         Takes magnetic structures and performs the following operations
-        - Erases nonmagnetic ions and gives all ions ['magmom'] site prop
+        - Standardizes magmoms (every site gets a ['magmom'] site prop)
+        - Builds a magnetic-only copy of each ordering, keeping a full copy too
         - Converts total energies -> energy / magnetic ion
         - Checks for duplicate/degenerate orderings
         - Sorts by energy
@@ -804,17 +665,17 @@ class HeisenbergScreener:
             energies (list): Corresponding energies.
 
         Returns:
-            ordered_structures (list): Sanitized structures.
-            ordered_energies (list): Sorted energies.
+            full_structures (list): Sanitized orderings with all ions retained.
+            ordered_structures (list): The same orderings with only magnetic ions.
+            ordered_energies (list): Sorted energies (per magnetic ion).
         """
-        # Get only magnetic ions & give all structures site_properties['magmom']
-        # zero threshold so that magnetic ions with small moments
-        # are preserved
+        # Standardize moments (zero threshold so small moments are preserved).
+        # Keep both a full copy (all ions, needed for correct site symmetry) and
+        # a magnetic-only copy (used to build the interaction graphs).
+        analyzers = [CollinearMagneticStructureAnalyzer(s, make_primitive=False, threshold=0.0) for s in structures]
+        full_structures = [analyzer.structure for analyzer in analyzers]
         ordered_structures = [
-            CollinearMagneticStructureAnalyzer(
-                s, make_primitive=False, threshold=0.0
-            ).get_structure_with_only_magnetic_atoms(make_primitive=False)
-            for s in structures
+            analyzer.get_structure_with_only_magnetic_atoms(make_primitive=False) for analyzer in analyzers
         ]
 
         # Convert to energies / magnetic ion
@@ -833,36 +694,30 @@ class HeisenbergScreener:
                     if idx != i_check and i_check not in remove_list and energy == e_check:
                         remove_list.append(i_check)
 
-        # Also discard structures with small |magmoms| < 0.1 uB
-        # xx - get rid of these or just bury them in the list?
-        # for idx, struct in enumerate(ordered_structures):
-        #     magmoms = struct.site_properties["magmom"]
-        #     if idx not in remove_list and any(abs(m) < 0.1 for m in magmoms):
-        #         remove_list.append(idx)
+        # Drop duplicates, then sort by energy, keeping the three lists aligned.
+        keep = [idx for idx in range(len(energies)) if idx not in remove_list]
+        keep.sort(key=lambda idx: energies[idx])
 
-        # Remove duplicates
-        if remove_list:
-            ordered_structures = [struct for idx, struct in enumerate(ordered_structures) if idx not in remove_list]
-            energies = [energy for idx, energy in enumerate(energies) if idx not in remove_list]
+        full_structures = [full_structures[idx] for idx in keep]
+        ordered_structures = [ordered_structures[idx] for idx in keep]
+        ordered_energies = [energies[idx] for idx in keep]
 
-        # Sort by energy if not already sorted
-        ordered_structures = [s for _, s in sorted(zip(energies, ordered_structures, strict=True), reverse=False)]
-        ordered_energies = sorted(energies, reverse=False)
-
-        return ordered_structures, ordered_energies
+        return full_structures, ordered_structures, ordered_energies
 
     @staticmethod
-    def _do_screen(structures, energies):
+    def _do_screen(full_structures, structures, energies):
         """Screen and sort magnetic orderings based on some criteria.
 
         Prioritize low energy orderings and large, localized magmoms. do_clean should be run first to sanitize inputs.
 
         Args:
-            structures (list): At least three structure objects.
+            full_structures (list): Orderings with all ions retained.
+            structures (list): The same orderings with only magnetic ions.
             energies (list): Energies.
 
         Returns:
-            screened_structures (list): Sorted structures.
+            screened_full_structures (list): Sorted full structures.
+            screened_structures (list): Sorted magnetic-only structures.
             screened_energies (list): Sorted energies.
         """
         magmoms = [struct.site_properties["magmom"] for struct in structures]
@@ -870,6 +725,7 @@ class HeisenbergScreener:
 
         df_mag = pd.DataFrame(
             {
+                "full": full_structures,
                 "structure": structures,
                 "energy": energies,
                 "magmoms": magmoms,
@@ -879,7 +735,6 @@ class HeisenbergScreener:
 
         # keep the ground and first excited state fixed to capture the
         # low-energy spectrum
-        index = list(df_mag.index)[2:]
         df_high_energy = df_mag.iloc[2:]
 
         # Prioritize structures with fewer magmoms < 1 uB
@@ -889,10 +744,11 @@ class HeisenbergScreener:
 
         # sort
         df_mag = df_mag.reindex(index)
-        screened_structures = list(df_mag["structure"].values)
-        screened_energies = list(df_mag["energy"].values)
-
-        return screened_structures, screened_energies
+        return (
+            list(df_mag["full"].values),
+            list(df_mag["structure"].values),
+            list(df_mag["energy"].values),
+        )
 
 
 class HeisenbergModel(MSONable):
@@ -909,7 +765,7 @@ class HeisenbergModel(MSONable):
         cutoff=None,
         tol=None,
         sgraphs=None,
-        unique_site_ids=None,
+        site_labels=None,
         wyckoff_ids=None,
         nn_interactions=None,
         dists=None,
@@ -926,18 +782,14 @@ class HeisenbergModel(MSONable):
             cutoff (float): Cutoff in Angstrom for nearest neighbor search.
             tol (float): Tolerance (in Angstrom) on nearest neighbor distances being equal.
             sgraphs (list): StructureGraph objects.
-            unique_site_ids (list[dict]): One map per ordering; each maps a tuple
-                of equivalent site indices to a global orbit identifier shared across
-                orderings.
-            wyckoff_ids (dict): Maps unique numerical identifier to wyckoff
-                position.
-            nn_interactions (dict): {i: j} pairs of NN interactions
-                between unique sites.
-            dists (dict): NN, NNN, and NNNN interaction distances
-            ex_mat (DataFrame): Invertible Heisenberg Hamiltonian for each
-                graph.
-            ex_params (dict): Exchange parameter values (meV/atom).
-            javg (float): <J> exchange param (meV/atom).
+            site_labels (list[list[int]]): site_labels[k][i] is the sublattice id of
+                site i in ordering k.
+            wyckoff_ids (dict): Maps each sublattice id to its wyckoff position.
+            nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
+            dists (dict): NN, NNN, and NNNN interaction distances.
+            ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
+            ex_params (dict): Exchange parameter values (meV).
+            javg (float): <J> exchange param (meV).
             igraph (StructureGraph): Exchange interaction graph.
         """
         self.formula = formula
@@ -946,7 +798,7 @@ class HeisenbergModel(MSONable):
         self.cutoff = cutoff
         self.tol = tol
         self.sgraphs = sgraphs
-        self.unique_site_ids = unique_site_ids
+        self.site_labels = site_labels
         self.wyckoff_ids = wyckoff_ids
         self.nn_interactions = nn_interactions
         self.dists = dists
@@ -955,8 +807,13 @@ class HeisenbergModel(MSONable):
         self.javg = javg
         self.igraph = igraph
 
+    @property
+    def unique_site_ids(self):
+        """list[dict]: One {tuple(site indices): sublattice id} map per ordering."""
+        return [HeisenbergMapper._site_ids_dict(labels) for labels in self.site_labels]
+
     def as_dict(self):
-        """Because some dicts have tuple keys, some sanitization is required for JSON compatibility."""
+        """Because some dicts have int keys, some sanitization is required for JSON compatibility."""
         return {
             "@module": type(self).__module__,
             "@class": type(self).__name__,
@@ -967,71 +824,41 @@ class HeisenbergModel(MSONable):
             "cutoff": self.cutoff,
             "tol": self.tol,
             "sgraphs": [sgraph.as_dict() for sgraph in self.sgraphs],
+            "site_labels": self.site_labels,
             "dists": self.dists,
             "ex_params": self.ex_params,
             "javg": self.javg,
             "igraph": self.igraph.as_dict(),
-            # Sanitize tuple & int keys
-            "ex_mat": jsanitize(self.ex_mat),
+            # Sanitize int keys / DataFrame
+            "ex_mat": jsanitize(self.ex_mat.to_dict()),
             "nn_interactions": jsanitize(self.nn_interactions),
-            "unique_site_ids": jsanitize(self.unique_site_ids),
             "wyckoff_ids": jsanitize(self.wyckoff_ids),
         }
 
     @classmethod
     def from_dict(cls, dct: dict) -> Self:
         """Create a HeisenbergModel from a dict."""
-        # Reconstitute the site ids
-        unique_site_ids = []
-        wyckoff_ids = {}
-        nn_interactions = {}
+        # Reconstitute the int-keyed dicts that jsanitize stringified
+        nn_interactions = {
+            shell: {literal_eval(i): j for i, j in pairs.items()} for shell, pairs in dct["nn_interactions"].items()
+        }
+        wyckoff_ids = {literal_eval(k): v for k, v in dct["wyckoff_ids"].items()}
 
-        for k, v in dct["nn_interactions"].items():
-            nn_dict = {}
-            for k1, v1 in v.items():
-                key = literal_eval(k1)
-                nn_dict[key] = v1
-            nn_interactions[k] = nn_dict
-
-        # unique_site_ids is one map per ordering (a list of dicts); rebuild the
-        # tuple keys that jsanitize stringified for each ordering's map.
-        for site_map in dct["unique_site_ids"]:
-            rebuilt = {}
-            for k, v in site_map.items():
-                key = literal_eval(k)
-                rebuilt[(key,) if isinstance(key, int) else tuple(key)] = v
-            unique_site_ids.append(rebuilt)
-
-        for k, v in dct["wyckoff_ids"].items():
-            wyckoff_ids[literal_eval(k)] = v
-
-        # Reconstitute the structure and graph objects
         structures = [Structure.from_dict(v) for v in dct["structures"]]
         sgraphs = [StructureGraph.from_dict(v) for v in dct["sgraphs"]]
-
-        # Interaction graph
         igraph = StructureGraph.from_dict(dct["igraph"])
 
-        # Reconstitute the exchange matrix DataFrame. as_dict() serializes
-        # ex_mat with jsanitize, which turns a DataFrame into a dict, while
-        # older serializations may store a (JSON/repr) string instead. Accept
-        # both forms and fall back to an empty matrix when ex_mat is empty.
-        ex_mat = dct["ex_mat"]
-        if isinstance(ex_mat, str):
-            try:
-                ex_mat = literal_eval(ex_mat)
-            except (SyntaxError, ValueError):  # empty or unparsable string
-                ex_mat = None
-        ex_mat = pd.DataFrame.from_dict(ex_mat) if ex_mat else pd.DataFrame(columns=["E", "E0"])
+        # Reconstitute the exchange matrix DataFrame
+        ex_mat = pd.DataFrame.from_dict(dct["ex_mat"]) if dct["ex_mat"] else pd.DataFrame(columns=["E", "E0"])
 
-        return HeisenbergModel(
+        return cls(
             formula=dct["formula"],
             structures=structures,
             energies=dct["energies"],
             cutoff=dct["cutoff"],
             tol=dct["tol"],
             sgraphs=sgraphs,
-            unique_site_ids=unique_site_ids,
+            site_labels=dct["site_labels"],
             wyckoff_ids=wyckoff_ids,
             nn_interactions=nn_interactions,
             dists=dct["dists"],

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -55,7 +55,8 @@ class HeisenbergMapper:
         nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
         dists (dict): NN, NNN, and NNNN interaction distances.
         ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
-        ex_params (dict): Exchange parameter values (meV).
+        ex_params (dict): Exchange parameter values. The J_ij are in meV; the
+            included 'E0' offset stays in eV.
     """
 
     def __init__(self, ordered_structures, energies, parent=None, cutoff=0, tol: float = 0.02):
@@ -295,8 +296,8 @@ class HeisenbergMapper:
         return columns[: len(self.sgraphs) + 1]
 
     def _get_exchange_df(self):
-        """Build the Heisenberg Hamiltonian, one row per ordering, by counting
-        +-|S_i . S_j| over each graph. Sets self.ex_mat.
+        """Build the Heisenberg Hamiltonian, one row per ordering, by summing the
+        signed products S_i . S_j over each graph. Sets self.ex_mat.
 
         Each row is normalised per magnetic ion so that orderings living in
         different-sized supercells share a single linear system (the energies are
@@ -362,7 +363,8 @@ class HeisenbergMapper:
         solve for the exchange parameters.
 
         Returns:
-            dict[str, float]: Exchange parameters (meV).
+            dict[str, float]: Exchange parameters. The J_ij are in meV; the
+                included 'E0' offset stays in eV.
         """
         ex_mat = self.ex_mat
         E = ex_mat[["E"]]
@@ -376,6 +378,19 @@ class HeisenbergMapper:
 
         # Solve the linear system for E0 and the J_ij
         H = np.array(ex_mat.loc[:, ex_mat.columns != "E"].values).astype(float)
+
+        # Warn when the fit is ill-conditioned: near-degenerate orderings or an
+        # over-parameterized model make H nearly singular, so tiny energy
+        # differences blow up into unphysical exchange parameters.
+        cond = np.linalg.cond(H)
+        if cond > 1e5:
+            logger.warning(
+                f"Exchange matrix is ill-conditioned (cond={cond:.1e}); the fitted exchange "
+                "parameters are unreliable. The input orderings are near-degenerate or the "
+                "model has more parameters than the orderings can constrain. Supply more, "
+                "more-distinct orderings."
+            )
+
         j_ij = np.dot(np.linalg.inv(H), E)
 
         j_ij[1:] *= 1000  # J_ij in meV (E0 stays in eV)
@@ -453,8 +468,8 @@ class HeisenbergMapper:
         Args:
             fm_struct (Structure): fm structure with 'magmom' site property
             afm_struct (Structure): afm structure with 'magmom' site property
-            fm_e (float): fm energy/atom
-            afm_e (float): afm energy/atom
+            fm_e (float): fm energy per magnetic ion
+            afm_e (float): afm energy per magnetic ion
 
         Returns:
             float: Average J exchange parameter (meV)
@@ -486,7 +501,7 @@ class HeisenbergMapper:
         material.
 
         Args:
-            j_avg (float): Average exchange parameter (meV/atom)
+            j_avg (float): Average exchange parameter (meV)
 
         Returns:
             float: Critical temperature mft_t (K)
@@ -555,6 +570,14 @@ class HeisenbergMapper:
                 jimage = c[1]  # relative integer coordinates of atom j
                 j = c[2]  # index of neighbor
                 j_exc = self._get_j_exc(labels[i], labels[j], c[-1])
+                # Only add bonds the fit actually parameterized. Unparameterized
+                # bonds (no matching sublattice-pair/shell in ex_params, exactly
+                # the bonds _get_exchange_df also ignores) get j_exc == 0, which
+                # StructureGraph.add_edge silently drops via its falsy-weight
+                # guard, leaving an edge with weight=None that breaks downstream
+                # per-bond consumers.
+                if not j_exc:
+                    continue
                 igraph.add_edge(i, j, to_jimage=jimage, weight=j_exc, warn_duplicates=False)
 
         if filename:
@@ -626,7 +649,7 @@ class HeisenbergScreener:
 
         Args:
             structures (list): Structure objects with magnetic moments.
-            energies (list): Energies/atom of magnetic orderings.
+            energies (list): Total energies of magnetic orderings.
             screen (bool): Try to screen out high energy and low-spin configurations.
 
         Attributes:
@@ -789,7 +812,8 @@ class HeisenbergModel(MSONable):
             nn_interactions (dict): {i: j} pairs of NN interactions between sublattices.
             dists (dict): NN, NNN, and NNNN interaction distances.
             ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
-            ex_params (dict): Exchange parameter values (meV).
+            ex_params (dict): Exchange parameter values. The J_ij are in meV; the
+                included 'E0' offset stays in eV.
             javg (float): <J> exchange param (meV).
             igraph (StructureGraph): Exchange interaction graph.
         """

--- a/src/pymatgen/analysis/magnetism/heisenberg.py
+++ b/src/pymatgen/analysis/magnetism/heisenberg.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from functools import cached_property
 from typing import TYPE_CHECKING
+from warnings import deprecated
 
 import numpy as np
 import pandas as pd
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TOL = 0.05  # Angstrom tolerance
 DISTANCE_ROUND_DECIMALS = 2  # Round distances to this many decimals when matching interactions
+
 
 def _analyzer(structure: Structure, **kwargs) -> CollinearMagneticStructureAnalyzer:
     """CollinearMagneticStructureAnalyzer factory with the settings used throughout this module.
@@ -284,8 +286,9 @@ class HeisenbergMapper:
             each sublattice pair, ordered from the nearest shell outwards.
         dists (dict): {J label: interaction distance in Angstrom}.
         ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
-        ex_params (dict): Exchange parameter values. The J_ij are in meV; the
-            included 'E0' offset stays in eV.
+        ex_params (dict): Exchange parameter values. The J_ij are in meV/muB^2 (they
+            multiply the raw moments, see get_exchange); the included 'E0' offset is in
+            eV per magnetic ion. get_interaction_graph carries the per-bond J_ij in meV.
     """
 
     def __init__(self, ordered_structures, energies, parent=None, cutoff=0, tol: float = DEFAULT_TOL):
@@ -300,10 +303,10 @@ class HeisenbergMapper:
 
         ***IMPORTANT NOTE***
 
-        If the parent is not supplied, it is inferred as the primitive cell of the lowest-energy ordering. 
-        Not supplying a parent cell is only safe if the lowest-energy ordering still preserves the symmetry of the paramagnetic parent. 
+        If the parent is not supplied, it is inferred as the primitive cell of the lowest-energy ordering.
+        Not supplying a parent cell is only safe if the lowest-energy ordering still preserves the symmetry of the paramagnetic parent.
         In most cases, relaxation will lower the symmetry and the parent cell must be supplied explicitly.
-        
+
         Args:
             ordered_structures (list): Structure objects with magmoms.
             energies (list): Total energies of each relaxed magnetic structure.
@@ -452,7 +455,9 @@ class HeisenbergMapper:
         for label in self.nn_interactions.get(self._order_sublattice_ids(i_id, j_id), ()):
             if abs(dist - self.dists[label]) <= self.tol:
                 return label
-        logger.warning(f"Interaction between sublattices {i_id} and {j_id} at {dist:.2f} Angstrom does not match any interaction in nn_interactions built from the parent:\n{self.nn_interactions}\n")
+        logger.warning(
+            f"Interaction between sublattices {i_id} and {j_id} at {dist:.2f} Angstrom does not match any interaction in nn_interactions built from the parent:\n{self.nn_interactions}\n"
+        )
         return None
 
     def _set_interactions(self):
@@ -524,7 +529,7 @@ class HeisenbergMapper:
             return
 
         rows = []
-        seen = set()  # de-duplicate identical interaction rows to avoid singularity
+        seen = set()  # de-duplicate identical interaction rows so no ordering is weighted twice
         for ordering in self.orderings:
             nn_graph = ordering.nn_graph
             sub_ids = ordering.sublattice_ids
@@ -546,9 +551,7 @@ class HeisenbergMapper:
                     if col in row:
                         row[col] -= s_i * magmoms[cs[2]]
 
-            # Extensive sums -> per magnetic ion, with the 1/2 Heisenberg factor.
-            # Each interaction is visited from both ends, so 2 * n_sites also removes the
-            # double counting.
+            # Extensive sums -> per magnetic ion, with the 1/2 Heisenberg factor for double counting.
             for c in j_columns:
                 row[c] /= 2 * n_sites
 
@@ -562,22 +565,36 @@ class HeisenbergMapper:
 
         ex_mat = pd.DataFrame(rows, columns=columns)
 
-        # Drop interaction columns that never appear (all zero) to keep H invertible
+        # Drop interaction columns that never appear (all zero) to keep H full rank
         j_columns = [c for c in j_columns if not (ex_mat[c] == 0).all()]
-        ex_mat = ex_mat[["E", "E0", *j_columns]]
 
-        # Square system: one row per parameter (E0 + the J_ij)
-        n_params = ex_mat.shape[1] - 1
-        self.ex_mat = ex_mat.iloc[:n_params].reset_index(drop=True)
+        # Every ordering is kept: get_exchange fits the parameters by least squares, so
+        # surplus orderings average out the noise on the energies instead of being
+        # discarded to square the system.
+        self.ex_mat = ex_mat[["E", "E0", *j_columns]].reset_index(drop=True)
 
     def get_exchange(self):
         """
         Take Heisenberg Hamiltonian and corresponding energy for each row and
-        solve for the exchange parameters.
+        solve for the exchange parameters in the least-squares sense.
+
+        With exactly as many orderings as parameters this reproduces the solution of the
+        square linear system of equations; with more it is a fit over all of them compensating
+        for the noise in the DFT-energies.
+
+        The rows of ex_mat multiply the raw magnetic moments in muB rather than normalized
+        spins, so the fitted J_ij come out in meV/muB^2: it takes J_ij * m_i * m_j to get
+        the energy of a bond. This follows Frey et al., Sci. Adv. 6, eabd1076 (2020), where
+        "S is the magnitude of the average magnetic moment". Codes and papers working with
+        normalized spins (VAMPIRE, UppASD, TB2J) instead report J in meV for
+        E = -sum_<ij> J_ij e_i.e_j with |e| = 1; get_interaction_graph does that conversion.
 
         Returns:
-            dict[str, float]: Exchange parameters. The J_ij are in meV; the
-                included 'E0' offset stays in eV.
+            ex_params (dict[str, float]): Exchange parameters. The J_ij are in meV/muB^2;
+                the included 'E0' offset is in eV per magnetic ion (its column in ex_mat
+                is 1.0 and the fitted energies are per magnetic ion, so it comes out
+                intensive, which is what lets orderings of different size share one fit).
+            residual (float): Residual of the least-squares fit.
         """
         ex_mat = self.ex_mat
         E = ex_mat[["E"]]
@@ -589,7 +606,7 @@ class HeisenbergMapper:
             self.ex_params = ex_params
             return ex_params
 
-        # Solve the linear system for E0 and the J_ij
+        # Fit E0 and the J_ij to the energies of every ordering
         H = np.array(ex_mat.loc[:, ex_mat.columns != "E"].values).astype(float)
 
         # Warn when the fit is ill-conditioned: near-degenerate orderings or an
@@ -604,13 +621,24 @@ class HeisenbergMapper:
                 "more-distinct orderings."
             )
 
-        j_ij = np.dot(np.linalg.inv(H), E)
+        j_ij, residuals, rank, _singular = np.linalg.lstsq(H, E, rcond=None)
 
-        j_ij[1:] *= 1000  # J_ij in meV (E0 stays in eV)
+        # A least-squares fit does not fail on a system it cannot determine,
+        # it silently returns the minimum-norm solution. cond above cannot see this case:
+        # with fewer rows than parameters it stays finite.
+        if rank < H.shape[1]:
+            logger.warning(
+                f"Exchange matrix is rank deficient (rank {rank} for {H.shape[1]} parameters); "
+                "the orderings do not constrain every exchange parameter, and the values "
+                "returned are one of infinitely many fits. Supply more distinct orderings."
+            )
+
+        j_ij[1:] *= 1000  # J_ij in meV/muB^2 (E0 stays in eV per magnetic ion)
         ex_params = {j_name: j[0] for j_name, j in zip(j_names, j_ij.tolist(), strict=True)}
 
         self.ex_params = ex_params
-        return ex_params
+        self.residual = residuals[0]
+        return self.ex_params, self.residual
 
     def get_low_energy_orderings(self):
         """Find lowest energy FM and AFM orderings to compute E_AFM - E_FM.
@@ -670,6 +698,7 @@ class HeisenbergMapper:
 
         return fm_struct, afm_struct, fm_e, afm_e
 
+    @deprecated("<J> is in units of meV/magnetic ion.")
     def estimate_exchange(self, fm_struct=None, afm_struct=None, fm_e=None, afm_e=None):
         """Estimate <J> for a structure based on low energy FM and AFM orderings.
 
@@ -680,7 +709,7 @@ class HeisenbergMapper:
             afm_e (float): afm energy per magnetic ion
 
         Returns:
-            float: Average J exchange parameter (meV)
+            float: Average J exchange parameter (meV / magnetic ion)
         """
         # Get low energy orderings if not supplied
         if any(arg is None for arg in [fm_struct, afm_struct, fm_e, afm_e]):
@@ -702,6 +731,9 @@ class HeisenbergMapper:
 
         return j_avg
 
+    @deprecated(
+        "<J> is in units of meV/magnetic ion, double counts diagonal entries, and is only a crude estimate of the true exchange parameters."
+    )
     def get_mft_temperature(self, j_avg):
         """
         Crude mean field estimate of critical temperature based on <J> for
@@ -709,7 +741,7 @@ class HeisenbergMapper:
         material.
 
         Args:
-            j_avg (float): Average exchange parameter (meV)
+            j_avg (float): Average exchange parameter (meV / magnetic ion)
 
         Returns:
             float: Critical temperature mft_t (K)
@@ -749,6 +781,11 @@ class HeisenbergMapper:
         """Get a StructureGraph with edges and weights that correspond to exchange
         interactions and J_ij values, respectively.
 
+        Edge weights are in meV, for the normalized-spin Hamiltonian
+        E = -sum_<ij> J_ij e_i.e_j, i.e. this ordering's moments are folded into the
+        fitted meV/muB^2 parameters (see get_exchange). That is the convention VAMPIRE,
+        UppASD and TB2J use, so the weights can go straight into a ucf file.
+
         Args:
             filename (str): if not None, save interaction graph to filename.
             ordering_index (int): Which ordering (and its supercell) to build the
@@ -764,13 +801,15 @@ class HeisenbergMapper:
         ordering = self.orderings[ordering_index]
         structure = ordering.magnetic_structure
         nn_graph = ordering.nn_graph
+        magmoms = structure.site_properties["magmom"]
         sub_ids = ordering.sublattice_ids
 
         igraph = StructureGraph.from_empty_graph(
             structure, edge_weight_name="exchange_constant", edge_weight_units="meV"
         )
 
-        if "<J>" in self.ex_params:  # Only <J> is available
+        javg_only = "<J>" in self.ex_params
+        if javg_only:
             logger.warning("Only <J> is available. The interaction graph will not tell you much.")
 
         # J_ij exchange interaction matrix
@@ -779,6 +818,13 @@ class HeisenbergMapper:
                 jimage = c[1]  # relative integer coordinates of atom j
                 j = c[2]  # index of neighbor
                 j_exc = self._get_j_exc(sub_ids[i], sub_ids[j], c[-1])
+                # Weights are in meV, so fold this ordering's moments into the fitted
+                # meV/muB^2 parameters. Only the magnitudes enter: the relative orientation
+                # of the two sites belongs to the spin vectors, not to J_ij. The <J>
+                # fallback is already an energy (meV per magnetic ion, see
+                # estimate_exchange), so there is nothing to fold in there.
+                if not javg_only:
+                    j_exc *= abs(magmoms[i] * magmoms[j])
                 # Only add interactions the fit actually parameterized. Unparameterized
                 # interactions (no matching sublattice-pair/shell in ex_params, exactly
                 # the interactions _build_exchange_mat also ignores) get j_exc == 0, which
@@ -805,7 +851,8 @@ class HeisenbergMapper:
             dist (float): distance (Angstrom) between sites (10E-2 precision)
 
         Returns:
-            float: Exchange parameter J_exc in meV (0 if no matching interaction).
+            float: Exchange parameter J_exc in meV/muB^2 (0 if no matching interaction).
+                Multiply by the two moments to get meV, as get_interaction_graph does.
         """
         label = self._interaction_label(i_id, j_id, round(dist, DISTANCE_ROUND_DECIMALS))
 
@@ -843,7 +890,7 @@ class HeisenbergMapper:
 class HeisenbergScreener:
     """Clean and screen magnetic orderings."""
 
-    def __init__(self, orderings:list[RelaxedOrdering], screen=False):
+    def __init__(self, orderings: list[RelaxedOrdering], screen=False):
         """Pre-processes magnetic orderings for HeisenbergMapper.
         It prioritizes low-energy orderings with large and localized magnetic moments.
 
@@ -866,7 +913,7 @@ class HeisenbergScreener:
         self.screened_orderings = orderings
 
     @staticmethod
-    def _do_cleanup(orderings:list[RelaxedOrdering]):
+    def _do_cleanup(orderings: list[RelaxedOrdering]):
         """Drop duplicate/degenerate orderings and sort by energy per magnetic ion.
 
         Sometimes different initial configs relax to the same state; those show up as
@@ -894,7 +941,7 @@ class HeisenbergScreener:
         return [orderings[idx] for idx in keep]
 
     @staticmethod
-    def _do_screen(orderings:list[RelaxedOrdering]):
+    def _do_screen(orderings: list[RelaxedOrdering]):
         """Screen and sort magnetic orderings based on some criteria.
 
         Prioritize low energy orderings and large, localized magmoms. _do_cleanup should be
@@ -958,10 +1005,11 @@ class HeisenbergModel(MSONable):
                 of each sublattice pair, ordered from the nearest shell outwards.
             dists (dict): {J label: interaction distance in Angstrom}.
             ex_mat (DataFrame): Heisenberg Hamiltonian (per magnetic ion) for each ordering.
-            ex_params (dict): Exchange parameter values. The J_ij are in meV; the
-                included 'E0' offset stays in eV.
-            javg (float): <J> exchange param (meV).
-            igraph (StructureGraph): Exchange interaction graph.
+            ex_params (dict): Exchange parameter values. The J_ij are in meV/muB^2 (they
+                multiply the raw moments, see HeisenbergMapper.get_exchange); the included
+                'E0' offset is in eV per magnetic ion.
+            javg (float): <J> exchange param (meV / magnetic ion).
+            igraph (StructureGraph): Exchange interaction graph, edge weights in meV.
         """
         self.formula = formula
         self.structures = structures

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pytest import approx
 
-from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
+from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.core import Lattice
 from pymatgen.core.structure import Structure
 from tests.testing import TEST_FILES_DIR
@@ -80,6 +80,26 @@ class TestHeisenbergMapper:
         for hm in self.hms:
             hmodel = hm.get_heisenberg_model()
             assert hmodel.formula == "Mn3Al"
+
+    def test_as_from_dict_round_trip(self): 
+        # HeisenbergModel must survive MSON round-trips. as_dict() serializes
+        # ex_mat with jsanitize (a DataFrame becomes a dict), so from_dict()
+        # must accept a dict and not only a string.
+        # https://github.com/materialsproject/pymatgen/issues/4664
+        for hm in self.hms:
+            model = hm.get_heisenberg_model()
+
+            # First round-trip: ex_mat starts as a JSON string, becomes a DataFrame.
+            model_rt = HeisenbergModel.from_dict(model.as_dict())
+            assert isinstance(model_rt.ex_mat, pd.DataFrame)
+            assert model_rt.formula == model.formula
+
+            # Second round-trip: ex_mat is now a DataFrame, which jsanitize
+            # serializes to a dict. This raised
+            # "ValueError: malformed node or string" before the fix.
+            model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
+            assert isinstance(model_rt2.ex_mat, pd.DataFrame)
+            pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
 
 
 class TestHeisenbergMapperMixedSupercells:

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -32,11 +32,13 @@ class TestHeisenbergMapperKnownHamiltonian:
         |  |  |  |      chains run along y, spaced D_AA
         A  B  A  B
 
-    so a site's nearest-neighbor shell holds both its own-species chain neighbors
-    and its cross-species column neighbors. That gives three distinct interactions
-    (A-A, B-B, A-B) without ever passing a cutoff, and the orderings below live in
-    1x1, 1x2 and 2x2 supercells of the parent, so the fit must recover the same
-    constants from cells of 2, 4 and 8 sites.
+    giving three distinct interactions (A-A, B-B, A-B) without ever passing a cutoff.
+    The chains are deliberately spaced much wider than the columns, so the two
+    intra-sublattice interactions are nowhere near a site's overall shortest bond:
+    they only survive because the neighbor search takes the nearest shell of each
+    sublattice pair separately. The orderings below live in 1x1, 1x2 and 2x2
+    supercells of the parent, so the fit must recover the same constants from cells
+    of 2, 4 and 8 sites.
 
     Total energies are assigned from E = N * e0 - sum_<ij> J_ab s_i s_j, evaluated
     over explicit lattice vectors rather than over the mapper's own neighbor graph,
@@ -48,11 +50,11 @@ class TestHeisenbergMapperKnownHamiltonian:
     J_AB, J_AA, J_BB = 0.011, 0.004, -0.006  # eV, all distinct
     A, B = "Mn", "Fe"
 
-    # D_AA must stay inside the default nearest-neighbor search's 10% window around
-    # D_AB, or the chain bonds drop out of the graph; and the two must differ by more
-    # than the mapper's tol, or they collapse into one shell.
+    # The chain spacing is 60% wider than the column spacing, far outside the 10% window
+    # a single global nearest-neighbor distance would allow. It must stay below 2 * D_AB,
+    # though, or the chain bond stops being the shortest A-A one.
     D_AB = 1.0  # A-B spacing along x
-    D_AA = 1.05  # A-A and B-B spacing along y
+    D_AA = 1.6  # A-A and B-B spacing along y
 
     # (A spins, B spins) per ordering, indexed [y][x] in units of the parent cell.
     ORDERINGS = (

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -204,6 +204,13 @@ class TestHeisenbergMapperKnownHamiltonian:
         assert set(hmodel.ex_params) == {"E0", *self._labels(hm)}
         assert hmodel.residual == approx(0, abs=1e-12)
 
+    def test_residual_is_none_before_fit(self):
+        # residual is set alongside ex_params by get_exchange(); before that runs it
+        # must read back as None rather than raise AttributeError.
+        hm = self._mapper()
+        assert hm.residual is None
+        assert hm.ex_params is None
+
     def test_as_from_dict_round_trip(self):
         # HeisenbergModel must survive repeated MSON round-trips. as_dict()
         # serializes ex_mat with jsanitize (a DataFrame becomes a nested dict),
@@ -222,6 +229,17 @@ class TestHeisenbergMapperKnownHamiltonian:
         model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
         assert isinstance(model_rt2.ex_mat, pd.DataFrame)
         pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
+
+    def test_from_dict_rejects_legacy_serialization(self):
+        # A dict serialized with HeisenbergModel <0.2 (pre parent-cell-sublattice
+        # refactor) has `unique_site_ids`/`wyckoff_ids`/`sgraphs` instead of
+        # `sublattice_ids`/`magnetic_structures`, which don't map onto the new
+        # parent-cell sublattices. Loading it must fail with a clear explanation,
+        # not a bare KeyError.
+        dct = self._mapper().get_heisenberg_model().as_dict()
+        del dct["sublattice_ids"]
+        with pytest.raises(ValueError, match="HeisenbergModel"):
+            HeisenbergModel.from_dict(dct)
 
     def test_shells_are_counted_within_a_sublattice_pair(self):
         hm = self._mapper()
@@ -263,6 +281,16 @@ class TestHeisenbergMapperKnownHamiltonian:
         structures = [self._structure(*self.ORDERINGS[0])]
         with pytest.raises(ValueError, match="at least 2 unique orderings"):
             HeisenbergMapper(structures, [self._energy(*self.ORDERINGS[0])], tol=0.02)
+
+    def test_non_structure_parent_raises_clear_error(self):
+        # parent moved to third position when this class was refactored (was
+        # HeisenbergMapper(ordered_structures, energies, cutoff, tol)); a caller still
+        # passing cutoff positionally now hands a number to `parent`. That must fail
+        # with a pointed error, not deep inside unrelated Structure/symmetry code.
+        structures = [self._structure(*spins) for spins in self.ORDERINGS]
+        energies = [self._energy(*spins) for spins in self.ORDERINGS]
+        with pytest.raises(TypeError, match="parent must be a Structure"):
+            HeisenbergMapper(structures, energies, 5.0)
 
     def test_inferred_parent_warns(self):
         structures = [self._structure(*spins) for spins in self.ORDERINGS]

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
+import pytest
 from pytest import approx
 
-from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
+from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper
+from pymatgen.core import Lattice
 from pymatgen.core.structure import Structure
 from tests.testing import TEST_FILES_DIR
 
@@ -38,7 +41,13 @@ class TestHeisenbergMapper:
     def test_sites(self):
         for hm in self.hms:
             unique_site_ids = hm.unique_site_ids
-            assert unique_site_ids[0, 1] == 0
+            # One site map per ordering
+            assert len(unique_site_ids) == len(hm.sgraphs)
+            # Site 0 of the first ordering belongs to global sublattice 0
+            assert hm._global_orbit_id(unique_site_ids[0], 0) == 0
+            # Global ids are shared across orderings and match the wyckoff labels
+            used_ids = {gid for site_map in unique_site_ids for gid in site_map.values()}
+            assert used_ids == set(hm.wyckoff_ids)
 
     def test_nn_interactions(self):
         for hm in self.hms:
@@ -51,8 +60,7 @@ class TestHeisenbergMapper:
     def test_exchange_params(self):
         for hm in self.hms:
             ex_params = hm.get_exchange()
-            J_nn = round(18.052116895702852, 3)
-            assert round(ex_params["0-1-nn"], 3) == J_nn
+            assert ex_params["0-1-nn"] == approx(30.813729, abs=1e-2)
 
     def test_mean_field(self):
         for hm in self.hms:
@@ -61,8 +69,7 @@ class TestHeisenbergMapper:
             assert round(j_avg, 3) == value
 
             mft_t = hm.get_mft_temperature(j_avg)
-            value = round(292.90252668100584)
-            assert round(mft_t) == value
+            assert mft_t == approx(21596.7, abs=1)
 
     def test_get_igraph(self):
         for hm in self.hms:
@@ -74,22 +81,79 @@ class TestHeisenbergMapper:
             hmodel = hm.get_heisenberg_model()
             assert hmodel.formula == "Mn3Al"
 
-    def test_as_from_dict_round_trip(self):
-        # HeisenbergModel must survive MSON round-trips. as_dict() serializes
-        # ex_mat with jsanitize (a DataFrame becomes a dict), so from_dict()
-        # must accept a dict and not only a string.
-        # https://github.com/materialsproject/pymatgen/issues/4664
-        for hm in self.hms:
-            model = hm.get_heisenberg_model()
 
-            # First round-trip: ex_mat starts as a JSON string, becomes a DataFrame.
-            model_rt = HeisenbergModel.from_dict(model.as_dict())
-            assert isinstance(model_rt.ex_mat, pd.DataFrame)
-            assert model_rt.formula == model.formula
+class TestHeisenbergMapperMixedSupercells:
+    """Round-trip on a J1-J2 square lattice with orderings living in different
+    supercells of one parent cell.
 
-            # Second round-trip: ex_mat is now a DataFrame, which jsanitize
-            # serializes to a dict. This raised
-            # "ValueError: malformed node or string" before the fix.
-            model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
-            assert isinstance(model_rt2.ex_mat, pd.DataFrame)
-            pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
+    Total energies are assigned from a known Hamiltonian
+    E = N * e0 - sum_<ij> J_ab s_i s_j, so the fit must recover e0 and the
+    physical exchange constants independent of the supercell sizes.
+    """
+
+    E0 = -5.0  # eV per magnetic ion
+    J_NN = 0.012  # eV
+    J_NNN = -0.004  # eV
+    NN_VECS = ((1, 0), (-1, 0), (0, 1), (0, -1))
+    NNN_VECS = ((1, 1), (1, -1), (-1, 1), (-1, -1))
+
+    @staticmethod
+    def _structure(spins):
+        spins = np.atleast_2d(np.asarray(spins, dtype=float))
+        n_y, n_x = spins.shape
+        lattice = Lattice.from_parameters(n_x, n_y, 10, 90, 90, 90)
+        coords = [[x / n_x, y / n_y, 0.5] for y in range(n_y) for x in range(n_x)]
+        magmoms = [spins[y, x] for y in range(n_y) for x in range(n_x)]
+        return Structure(lattice, ["Fe"] * (n_x * n_y), coords, site_properties={"magmom": magmoms})
+
+    def _energy(self, spins):
+        spins = np.atleast_2d(np.asarray(spins, dtype=float))
+        n_y, n_x = spins.shape
+        e_ex = 0.0
+        for y in range(n_y):
+            for x in range(n_x):
+                s_i = spins[y, x]
+                nn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NN_VECS)
+                nnn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NNN_VECS)
+                e_ex -= 0.5 * (self.J_NN * nn + self.J_NNN * nnn)  # 1/2: bonds counted from both ends
+        return n_x * n_y * self.E0 + e_ex
+
+    def test_physical_exchange_recovery(self):
+        # FM in the 1x1 primitive cell, stripe AFM in 1x2, Neel AFM in 2x2
+        all_spins = [[[1]], [[1], [-1]], [[1, -1], [-1, 1]]]
+        structures = [self._structure(spins) for spins in all_spins]
+        energies = [self._energy(spins) for spins in all_spins]
+        hm = HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+
+        ex_params = hm.get_exchange()
+        assert ex_params["E0"] == approx(self.E0, abs=1e-8)
+        assert ex_params["0-0-nn"] == approx(self.J_NN * 1000, abs=1e-6)
+        assert ex_params["0-0-nnn"] == approx(self.J_NNN * 1000, abs=1e-6)
+
+    def test_interaction_graph_consistent_across_orderings(self):
+        # The fitted J_ij must be recoverable from the interaction graph of any
+        # ordering, not just the first, even though the orderings live in
+        # different-sized supercells.
+        all_spins = [[[1]], [[1], [-1]], [[1, -1], [-1, 1]]]
+        structures = [self._structure(spins) for spins in all_spins]
+        energies = [self._energy(spins) for spins in all_spins]
+        hm = HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+        hm.get_exchange()
+
+        for ordering_index in range(len(structures)):
+            igraph = hm.get_interaction_graph(ordering_index=ordering_index)
+            weights = {round(d["weight"], 6) for *_, d in igraph.graph.edges(data=True)}
+            assert weights == {self.J_NN * 1000, self.J_NNN * 1000}
+
+    def test_incompatible_ordering_raises(self):
+        fm, stripe = [[1]], [[1], [-1]]
+        triangular = Structure(
+            Lattice.from_parameters(1, 1, 10, 90, 90, 120),  # not a supercell of the square parent
+            ["Fe"],
+            [[0, 0, 0.5]],
+            site_properties={"magmom": [1.0]},
+        )
+        structures = [self._structure(fm), self._structure(stripe), triangular]
+        energies = [self._energy(fm), self._energy(stripe), -5.0]
+        with pytest.raises(ValueError, match="parent cell"):
+            HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections import Counter
 
 import numpy as np
@@ -255,6 +256,26 @@ class TestHeisenbergMapperKnownHamiltonian:
         energies = [self._energy(*self.ORDERINGS[0]), self._energy(*self.ORDERINGS[1]), -5.0]
         with pytest.raises(ValueError, match="parent cell"):
             HeisenbergMapper(structures, energies, tol=0.02)
+
+    def test_too_few_orderings_raises_value_error(self):
+        # ValueError, not SystemExit: an unusable input must not tear down the
+        # interpreter session the mapper is being called from.
+        structures = [self._structure(*self.ORDERINGS[0])]
+        with pytest.raises(ValueError, match="at least 2 unique orderings"):
+            HeisenbergMapper(structures, [self._energy(*self.ORDERINGS[0])], tol=0.02)
+
+    def test_inferred_parent_warns(self):
+        structures = [self._structure(*spins) for spins in self.ORDERINGS]
+        energies = [self._energy(*spins) for spins in self.ORDERINGS]
+
+        with pytest.warns(UserWarning, match="No `parent` cell supplied"):
+            HeisenbergMapper(structures, energies, tol=0.02)
+
+        # An explicit parent is the documented way out, and must stay silent.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            HeisenbergMapper(structures, energies, parent=self._structure(*self.ORDERINGS[0]), tol=0.02)
+        assert not [warning for warning in caught if "No `parent` cell supplied" in str(warning.message)]
 
     def test_ill_conditioned_fit_warns(self, caplog):
         # Near-degenerate orderings make H nearly singular, so tiny energy differences

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 
 import numpy as np
 import pandas as pd
 import pytest
 from pytest import approx
+from scipy.constants import physical_constants
 
-from pymatgen.analysis.graphs import StructureGraph
-from pymatgen.analysis.local_env import MinimumDistanceNN
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.core import Lattice
 from pymatgen.core.structure import Structure
@@ -16,190 +16,318 @@ from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 
-# Same Boltzmann constant HeisenbergMapper.get_mft_temperature uses (meV/K).
-K_BOLTZMANN = 0.0861733
+# Taken from scipy rather than copied out of HeisenbergMapper.get_mft_temperature, so a
+# wrong constant in the implementation shows up here instead of cancelling out.
+K_BOLTZMANN = physical_constants["Boltzmann constant in eV/K"][0] * 1000  # meV/K
+
+
+def _wyckoff_multiplicity(symbol: str) -> int:
+    """Leading integer of a wyckoff symbol, e.g. '2c' -> 2."""
+    return int("".join(char for char in symbol if char.isdigit()))
 
 
 class TestHeisenbergMapper:
     """End-to-end run on real Mn3Al DFT orderings.
 
     Mn3Al has no independently-known exchange constants -- the mapper is the only
-    estimator -- so asserting specific J or Tc values here would be circular.
-    These tests assert physical *invariants* instead (geometry, sublattice
-    structure, finiteness, MSON round-trips), and that the mapper flags the fit
-    as ill-conditioned rather than silently returning unphysical numbers. Exact
-    numeric recovery is validated on synthetic known-Hamiltonian models below.
+    estimator -- so asserting specific J or Tc values here would be circular. These
+    tests assert physical invariants instead (sublattice structure, geometry, the
+    <J> fallback, MSON round-trips). Exact numeric recovery is validated against a
+    known Hamiltonian in TestHeisenbergMapperKnownHamiltonian below.
+
+    No cutoff is passed, so each site keeps only its nearest-neighbor shell. In
+    Mn3Al that shell holds a single sublattice pair, which leaves the mapper with
+    too few interactions to invert and sends it down the <J> path.
     """
 
     @classmethod
     def setup_class(cls):
         cls.Mn3Al = pd.read_json(f"{TEST_DIR}/Mn3Al.json")
-        cls.compounds = [cls.Mn3Al]
+        cls.structures = [Structure.from_dict(dct) for dct in cls.Mn3Al["structure"]]
+        cls.energies = [
+            epa * len(struct) for epa, struct in zip(cls.Mn3Al["energy_per_atom"], cls.structures, strict=True)
+        ]
+        cls.hm = HeisenbergMapper(cls.structures, cls.energies, tol=0.02)
 
-        cls.hms = []
-        for c in cls.compounds:
-            ordered_structures = [Structure.from_dict(d) for d in c["structure"]]
-            epa = list(c["energy_per_atom"])
-            energies = [e * len(s) for (e, s) in zip(epa, ordered_structures, strict=True)]
+    def test_degenerate_orderings_are_dropped(self):
+        # Different initial configs relax to the same state and show up as orderings
+        # sharing an energy per magnetic ion; only one of each survives screening.
+        n_magnetic = [sum(site.specie.symbol == "Mn" for site in struct) for struct in self.structures]
+        energies_per_ion = [energy / n for energy, n in zip(self.energies, n_magnetic, strict=True)]
 
-            hm = HeisenbergMapper(ordered_structures, energies, cutoff=5.0, tol=0.02)
-            cls.hms.append(hm)
+        assert len(self.hm.orderings) < len(self.structures)  # something was dropped
+        assert len(self.hm.orderings) == len({round(energy, 6) for energy in energies_per_ion})
+        assert self.hm.energies == sorted(self.hm.energies)  # sorted, ground state first
 
-    def test_graphs(self):
-        for hm in self.hms:
-            assert len(hm.sgraphs) == 7
+    def test_sublattices_follow_parent_wyckoff_orbits(self):
+        hm = self.hm
+        # Mn occupies two inequivalent orbits of the parent cell.
+        assert sorted(hm.sublattice_wyckoff_symbols.values()) == ["1a", "2c"]
 
-    def test_sites(self):
-        for hm in self.hms:
-            # One sublattice label per site, one label list per ordering
-            assert len(hm.site_labels) == len(hm.sgraphs)
-            # Site 0 of the first ordering belongs to sublattice 0
-            assert hm.site_labels[0][0] == 0
+        # Every ordering draws its labels from those orbits, and every orbit is used.
+        assert {sub_id for sub_ids in hm.sublattice_ids for sub_id in sub_ids} == set(hm.sublattice_wyckoff_symbols)
 
-            # unique_site_ids groups each ordering's sites by sublattice id
-            unique_site_ids = hm.unique_site_ids
-            assert len(unique_site_ids) == len(hm.sgraphs)
-            assert unique_site_ids[0][0, 1] == 0
-            # Sublattice ids are shared across orderings and match the wyckoff labels
-            used_ids = {sub for site_map in unique_site_ids for sub in site_map.values()}
-            assert used_ids == set(hm.wyckoff_ids)
+        for ordering in hm.orderings:
+            # Labels are indexed against the magnetic-only cell the graph is built from,
+            # so no None placeholders survive from the parent's full-cell labelling.
+            assert len(ordering.sublattice_ids) == len(ordering.magnetic_structure)
+            assert all(isinstance(sub_id, int) for sub_id in ordering.sublattice_ids)
 
-    def test_nn_interactions(self):
-        for hm in self.hms:
-            assert len(hm.nn_interactions) == 3
-            assert hm.dists["nn"] == approx(2.51)
+            # Each sublattice is filled in proportion to its wyckoff multiplicity, i.e.
+            # every ordering is a whole number of parent cells. Independent of which
+            # orbit happens to be labelled 0.
+            counts = Counter(ordering.sublattice_ids)
+            n_cells = {
+                counts[sub_id] / _wyckoff_multiplicity(symbol)
+                for sub_id, symbol in hm.sublattice_wyckoff_symbols.items()
+            }
+            assert len(n_cells) == 1
 
-    def test_exchange_params_are_physical_invariants(self):
-        # No ground-truth J for real DFT data: assert structure and finiteness.
-        for hm in self.hms:
-            ex_params = hm.get_exchange()
-            assert set(hm.wyckoff_ids) == {0, 1}  # two Mn sublattices (1a, 2c)
-            assert "E0" in ex_params
-            assert all(np.isfinite(v) for v in ex_params.values())
+    def test_single_interaction_falls_back_to_javg(self):
+        hm = self.hm
+        # The nearest-neighbor shell of Mn3Al holds exactly one sublattice pair.
+        [(pair, labels)] = hm.nn_interactions.items()
+        assert set(pair) == set(hm.sublattice_wyckoff_symbols)  # the two orbits are coupled
+        assert labels == [f"{pair[0]}-{pair[1]}-nn"]
+        assert hm.dists[labels[0]] == approx(2.51, abs=0.01)
 
-    def test_ill_conditioned_fit_warns(self, caplog):
-        # The Mn3Al system is over-parameterized: several orderings are
-        # near-degenerate, so H is nearly singular (cond ~ 1e6) and the fitted
-        # exchange constants are unphysical. The mapper must warn, not hand back
-        # garbage silently.
-        for hm in self.hms:
-            with caplog.at_level(logging.WARNING):
-                hm.get_exchange()
-            assert "ill-conditioned" in caplog.text
-            caplog.clear()
+        # One interaction cannot constrain E0 and a J at once, so the mapper reports the
+        # average exchange from E_AFM - E_FM rather than inverting a degenerate system.
+        ex_params = hm.get_exchange()
+        assert set(ex_params) == {"<J>"}
+        assert np.isfinite(ex_params["<J>"])
 
-    def test_get_igraph(self):
-        for hm in self.hms:
-            igraph = hm.get_interaction_graph()
-            assert len(igraph) == 6
+    def test_interaction_graph_carries_javg_on_every_bond(self):
+        hm = self.hm
+        igraph = hm.get_interaction_graph()
+
+        # In the <J> fallback every nearest-neighbor bond carries the same constant, and
+        # none are dropped: the interaction graph covers the whole neighbor graph.
+        assert igraph.graph.number_of_edges() == hm.nn_graphs[0].graph.number_of_edges()
+        weights = {round(data["weight"], 6) for *_, data in igraph.graph.edges(data=True)}
+        assert weights == {round(hm.get_exchange()["<J>"], 6)}
 
     def test_heisenberg_model(self):
-        for hm in self.hms:
-            hmodel = hm.get_heisenberg_model()
-            assert hmodel.formula == "Mn3Al"
+        hmodel = self.hm.get_heisenberg_model()
+        assert hmodel.formula == "Mn3Al"
+
+        # structures keep every ion; magnetic_structures keep only the magnetic species,
+        # and those are what the graphs and sublattice labels are indexed against.
+        assert {sp.symbol for struct in hmodel.magnetic_structures for sp in struct.composition} == {"Mn"}
+        assert all(
+            len(mag_struct) < len(struct)
+            for struct, mag_struct in zip(hmodel.structures, hmodel.magnetic_structures, strict=True)
+        )
 
     def test_as_from_dict_round_trip(self):
         # HeisenbergModel must survive repeated MSON round-trips. as_dict()
         # serializes ex_mat with jsanitize (a DataFrame becomes a nested dict),
         # so from_dict() must reconstruct the DataFrame from that dict.
         # https://github.com/materialsproject/pymatgen/issues/4664
-        for hm in self.hms:
-            model = hm.get_heisenberg_model()
+        model = self.hm.get_heisenberg_model()
 
-            model_rt = HeisenbergModel.from_dict(model.as_dict())
-            assert isinstance(model_rt.ex_mat, pd.DataFrame)
-            assert model_rt.formula == model.formula
+        model_rt = HeisenbergModel.from_dict(model.as_dict())
+        assert isinstance(model_rt.ex_mat, pd.DataFrame)
+        assert model_rt.formula == model.formula
+        assert model_rt.structures == model.structures
+        assert model_rt.magnetic_structures == model.magnetic_structures
 
-            # A second round-trip must be a no-op on the exchange matrix.
-            model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
-            assert isinstance(model_rt2.ex_mat, pd.DataFrame)
-            pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
+        # A second round-trip must be a no-op on the exchange matrix.
+        model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
+        assert isinstance(model_rt2.ex_mat, pd.DataFrame)
+        pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
 
 
-class TestHeisenbergMapperMixedSupercells:
-    """Round-trip on a J1-J2 square lattice with orderings living in different
-    supercells of one parent cell.
+class TestHeisenbergMapperKnownHamiltonian:
+    """Round-trip against a Hamiltonian whose exchange constants are known.
 
-    Total energies are assigned from a known Hamiltonian
-    E = N * e0 - sum_<ij> J_ab s_i s_j, so the fit must recover e0 and the
-    physical exchange constants independent of the supercell sizes.
+    Two magnetic species sit on alternating columns of a rectangular lattice::
+
+        A  B  A  B      columns alternate along x, spaced D_AB
+        |  |  |  |      chains run along y, spaced D_AA
+        A  B  A  B
+
+    so a site's nearest-neighbor shell holds both its own-species chain neighbors
+    and its cross-species column neighbors. That gives three distinct interactions
+    (A-A, B-B, A-B) without ever passing a cutoff, and the orderings below live in
+    1x1, 1x2 and 2x2 supercells of the parent, so the fit must recover the same
+    constants from cells of 2, 4 and 8 sites.
+
+    Total energies are assigned from E = N * e0 - sum_<ij> J_ab s_i s_j, evaluated
+    over explicit lattice vectors rather than over the mapper's own neighbor graph,
+    so the topology is ground truth here and not something the test borrows back
+    from the code under test.
     """
 
     E0 = -5.0  # eV per magnetic ion
-    J_NN = 0.012  # eV
-    J_NNN = -0.004  # eV
-    NN_VECS = ((1, 0), (-1, 0), (0, 1), (0, -1))
-    NNN_VECS = ((1, 1), (1, -1), (-1, 1), (-1, -1))
+    J_AB, J_AA, J_BB = 0.011, 0.004, -0.006  # eV, all distinct
+    A, B = "Mn", "Fe"
 
-    @staticmethod
-    def _structure(spins):
-        spins = np.atleast_2d(np.asarray(spins, dtype=float))
-        n_y, n_x = spins.shape
-        lattice = Lattice.from_parameters(n_x, n_y, 10, 90, 90, 90)
-        coords = [[x / n_x, y / n_y, 0.5] for y in range(n_y) for x in range(n_x)]
-        magmoms = [spins[y, x] for y in range(n_y) for x in range(n_x)]
-        return Structure(lattice, ["Fe"] * (n_x * n_y), coords, site_properties={"magmom": magmoms})
+    # D_AA must stay inside the default nearest-neighbor search's 10% window around
+    # D_AB, or the chain bonds drop out of the graph; and the two must differ by more
+    # than the mapper's tol, or they collapse into one shell.
+    D_AB = 1.0  # A-B spacing along x
+    D_AA = 1.05  # A-A and B-B spacing along y
 
-    def _energy(self, spins):
-        spins = np.atleast_2d(np.asarray(spins, dtype=float))
-        n_y, n_x = spins.shape
+    # (A spins, B spins) per ordering, indexed [y][x] in units of the parent cell.
+    ORDERINGS = (
+        ([[1]], [[1]]),  # FM, 1x1
+        ([[1]], [[-1]]),  # A up / B down, 1x1
+        ([[1], [-1]], [[1], [1]]),  # A chains antialigned, B FM, 1x2
+        ([[1, 1], [1, 1]], [[1, -1], [-1, 1]]),  # A FM, B checkerboard, 2x2
+    )
+
+    @classmethod
+    def _structure(cls, spins_a, spins_b):
+        spins_a = np.atleast_2d(np.asarray(spins_a, dtype=float))
+        spins_b = np.atleast_2d(np.asarray(spins_b, dtype=float))
+        n_y, n_x = spins_a.shape
+        lattice = Lattice.from_parameters(2 * cls.D_AB * n_x, cls.D_AA * n_y, 10, 90, 90, 90)
+        species, coords, magmoms = [], [], []
+        for y in range(n_y):
+            for x in range(n_x):
+                species += [cls.A, cls.B]
+                coords += [[x / n_x, y / n_y, 0.5], [(x + 0.5) / n_x, y / n_y, 0.5]]
+                magmoms += [spins_a[y, x], spins_b[y, x]]
+        return Structure(lattice, species, coords, site_properties={"magmom": magmoms})
+
+    def _energy(self, spins_a, spins_b):
+        spins_a = np.atleast_2d(np.asarray(spins_a, dtype=float))
+        spins_b = np.atleast_2d(np.asarray(spins_b, dtype=float))
+        n_y, n_x = spins_a.shape
         e_ex = 0.0
         for y in range(n_y):
             for x in range(n_x):
-                s_i = spins[y, x]
-                nn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NN_VECS)
-                nnn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NNN_VECS)
-                e_ex -= 0.5 * (self.J_NN * nn + self.J_NNN * nnn)  # 1/2: bonds counted from both ends
-        return n_x * n_y * self.E0 + e_ex
+                up, down = (y + 1) % n_y, (y - 1) % n_y
+                # Chains along y couple a site to its own species.
+                e_ex -= 0.5 * self.J_AA * spins_a[y, x] * (spins_a[up, x] + spins_a[down, x])
+                e_ex -= 0.5 * self.J_BB * spins_b[y, x] * (spins_b[up, x] + spins_b[down, x])
+                # Along x each A sits between the B of its own cell and the B of the cell
+                # to its left; each B likewise between two A. 1/2: bonds counted twice.
+                e_ex -= 0.5 * self.J_AB * spins_a[y, x] * (spins_b[y, x] + spins_b[y, (x - 1) % n_x])
+                e_ex -= 0.5 * self.J_AB * spins_b[y, x] * (spins_a[y, x] + spins_a[y, (x + 1) % n_x])
+        return 2 * n_x * n_y * self.E0 + e_ex
+
+    def _mapper(self):
+        structures = [self._structure(*spins) for spins in self.ORDERINGS]
+        energies = [self._energy(*spins) for spins in self.ORDERINGS]
+        return HeisenbergMapper(structures, energies, tol=0.02)
+
+    @staticmethod
+    def _labels(hm):
+        """J labels of the A-A, B-B and A-B interactions, keyed off species.
+
+        Which orbit is labelled 0 and which 1 is an artifact of the symmetry analysis,
+        so the assertions below never assume an order.
+        """
+        sub_ids = {
+            site.specie.symbol: sub_id
+            for site, sub_id in zip(hm.parent.magnetic_structure, hm.parent.sublattice_ids, strict=True)
+        }
+        a, b = sub_ids[TestHeisenbergMapperKnownHamiltonian.A], sub_ids[TestHeisenbergMapperKnownHamiltonian.B]
+        return f"{a}-{a}-nn", f"{b}-{b}-nn", f"{min(a, b)}-{max(a, b)}-nn"
 
     def test_physical_exchange_recovery(self):
-        # FM in the 1x1 primitive cell, stripe AFM in 1x2, Neel AFM in 2x2
-        all_spins = [[[1]], [[1], [-1]], [[1, -1], [-1, 1]]]
-        structures = [self._structure(spins) for spins in all_spins]
-        energies = [self._energy(spins) for spins in all_spins]
-        hm = HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+        hm = self._mapper()
+        assert len(hm.sublattice_wyckoff_symbols) == 2  # Mn and Fe are distinct sublattices
+        # The orderings really do live in different-sized supercells of the parent.
+        assert sorted(len(struct) for struct in hm.magnetic_structures) == [2, 2, 4, 8]
 
+        aa, bb, ab = self._labels(hm)
         ex_params = hm.get_exchange()
+
+        # One constant per sublattice pair, each recovered independently rather than
+        # averaged together, and independent of the supercell each ordering lives in.
+        assert set(ex_params) == {"E0", aa, bb, ab}
+        assert ex_params[ab] == approx(self.J_AB * 1000, abs=1e-6)
+        assert ex_params[aa] == approx(self.J_AA * 1000, abs=1e-6)
+        assert ex_params[bb] == approx(self.J_BB * 1000, abs=1e-6)
         assert ex_params["E0"] == approx(self.E0, abs=1e-8)
-        assert ex_params["0-0-nn"] == approx(self.J_NN * 1000, abs=1e-6)
-        assert ex_params["0-0-nnn"] == approx(self.J_NNN * 1000, abs=1e-6)
+
+    def test_shells_are_counted_within_a_sublattice_pair(self):
+        hm = self._mapper()
+        aa, bb, ab = self._labels(hm)
+
+        # The A-A and B-B chain bonds are the 'nn' of their own pair even though they
+        # are longer than the A-B bond, which is the 'nn' of its pair.
+        assert hm.dists[ab] == approx(self.D_AB, abs=0.01)
+        assert hm.dists[aa] == hm.dists[bb] == approx(self.D_AA, abs=0.01)
 
     def test_interaction_graph_consistent_across_orderings(self):
         # The fitted J_ij must be recoverable from the interaction graph of any
         # ordering, not just the first, even though the orderings live in
         # different-sized supercells.
-        all_spins = [[[1]], [[1], [-1]], [[1, -1], [-1, 1]]]
-        structures = [self._structure(spins) for spins in all_spins]
-        energies = [self._energy(spins) for spins in all_spins]
-        hm = HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+        hm = self._mapper()
         hm.get_exchange()
+        expected = {self.J_AA * 1000, self.J_BB * 1000, self.J_AB * 1000}
 
-        for ordering_index in range(len(structures)):
+        for ordering_index in range(len(self.ORDERINGS)):
             igraph = hm.get_interaction_graph(ordering_index=ordering_index)
-            weights = {round(d["weight"], 6) for *_, d in igraph.graph.edges(data=True)}
-            assert weights == {self.J_NN * 1000, self.J_NNN * 1000}
+            weights = {round(data["weight"], 6) for *_, data in igraph.graph.edges(data=True)}
+            assert weights == expected
 
     def test_incompatible_ordering_raises(self):
-        fm, stripe = [[1]], [[1], [-1]]
         triangular = Structure(
-            Lattice.from_parameters(1, 1, 10, 90, 90, 120),  # not a supercell of the square parent
-            ["Fe"],
-            [[0, 0, 0.5]],
-            site_properties={"magmom": [1.0]},
+            Lattice.from_parameters(1, 1, 10, 90, 90, 120),  # not a supercell of the parent
+            [self.A, self.B],
+            [[0, 0, 0.5], [0.5, 0.5, 0.5]],
+            site_properties={"magmom": [1.0, 1.0]},
         )
-        structures = [self._structure(fm), self._structure(stripe), triangular]
-        energies = [self._energy(fm), self._energy(stripe), -5.0]
+        structures = [self._structure(*self.ORDERINGS[0]), self._structure(*self.ORDERINGS[1]), triangular]
+        energies = [self._energy(*self.ORDERINGS[0]), self._energy(*self.ORDERINGS[1]), -5.0]
         with pytest.raises(ValueError, match="parent cell"):
-            HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+            HeisenbergMapper(structures, energies, tol=0.02)
+
+    def test_ill_conditioned_fit_warns(self, caplog):
+        # Near-degenerate orderings make H nearly singular, so tiny energy differences
+        # blow up into unphysical exchange constants. The mapper must warn rather than
+        # hand the numbers back silently. Perturbing one row of the exchange matrix is
+        # the only way to reach that state here: the rows are sums of spin products, so
+        # no choice of collinear ordering puts two of them ~1e-7 apart.
+        hm = self._mapper()
+
+        with caplog.at_level(logging.WARNING):
+            hm.get_exchange()
+        assert "ill-conditioned" not in caplog.text  # the honest fit does not warn
+        caplog.clear()
+
+        ex_mat = hm.ex_mat.copy()
+        ex_mat.iloc[1] = ex_mat.iloc[0] + 1e-7
+        hm.ex_mat = ex_mat
+
+        with caplog.at_level(logging.WARNING):
+            hm.get_exchange()
+        assert "ill-conditioned" in caplog.text
+
+    def test_multi_sublattice_mft_pins_current_formula(self):
+        # NOT an independent physical check. get_mft_temperature's multi-sublattice
+        # branch uses bare J_ij with no coordination numbers, and adds each diagonal
+        # term twice, so it does not reduce to the single-sublattice formula
+        # Tc = 2<J>/(3 k_B) that TestHeisenbergMeanFieldTemperature validates. This
+        # test pins the matrix the branch currently builds,
+        #     omega = (2 / 3 k_B) * [[2 Jaa, Jab], [Jab, 2 Jbb]],
+        # so any change to it is deliberate rather than accidental. Its largest
+        # eigenvalue is symmetric in (Jaa, Jbb), hence independent of the labelling.
+        hm = self._mapper()
+        hm.get_exchange()  # populates ex_params used by the multi-sublattice branch
+
+        mft_t = hm.get_mft_temperature(hm.estimate_exchange())
+
+        jab, jaa, jbb = self.J_AB * 1000, self.J_AA * 1000, self.J_BB * 1000
+        max_eig = (jaa + jbb) + np.sqrt((jaa - jbb) ** 2 + jab**2)
+        assert mft_t == approx(2 / 3 / K_BOLTZMANN * max_eig, rel=1e-5)
 
 
 class TestHeisenbergMeanFieldTemperature:
-    """Single magnetic sublattice (square lattice, nearest-neighbor coupling
-    only) so both the average exchange and the mean-field critical temperature
-    have closed forms to check against:
+    """Single magnetic sublattice (square lattice, nearest-neighbor coupling only)
+    so both the average exchange and the mean-field critical temperature have
+    closed forms to check against:
 
         <J> = z * J           (z = 4 nearest neighbors)
         Tc  = 2 |<J>| / (3 k_B)
+
+    The next-nearest neighbors sit at sqrt(2) a, outside the default
+    nearest-neighbor search, so a single interaction survives without a cutoff.
     """
 
     E0 = -5.0  # eV per magnetic ion
@@ -223,20 +351,19 @@ class TestHeisenbergMeanFieldTemperature:
             for x in range(n_x):
                 s_i = spins[y, x]
                 nn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NN_VECS)
-                e_ex -= 0.5 * j_nn * nn
+                e_ex -= 0.5 * j_nn * nn  # 1/2: bonds counted from both ends
         return n_x * n_y * self.E0 + e_ex
 
     def _mapper(self, j_nn):
         fm, afm = [[1, 1], [1, 1]], [[1, -1], [-1, 1]]
         structures = [self._structure(fm), self._structure(afm)]
         energies = [self._energy(fm, j_nn), self._energy(afm, j_nn)]
-        # cutoff between NN (1.0) and NNN (sqrt(2)) keeps a single interaction
-        return HeisenbergMapper(structures, energies, cutoff=1.2, tol=0.02)
+        return HeisenbergMapper(structures, energies, tol=0.02)
 
     def test_single_sublattice_mft_matches_analytic(self):
         j_nn = 0.010  # eV
         hm = self._mapper(j_nn)
-        assert len(hm.wyckoff_ids) == 1  # one magnetic sublattice
+        assert len(hm.sublattice_wyckoff_symbols) == 1  # one magnetic sublattice
 
         j_avg = hm.estimate_exchange()
         assert j_avg == approx(self.Z * j_nn * 1000, abs=1e-6)  # <J> = z * J (meV)
@@ -254,102 +381,6 @@ class TestHeisenbergMeanFieldTemperature:
         assert j_avg == approx(self.Z * j_nn * 1000, abs=1e-6)
 
 
-class TestHeisenbergTwoSublatticeCoupling:
-    """Two inequivalent magnetic sublattices (Mn, Fe) arranged on a checkerboard
-    so the parent cell has two Wyckoff orbits. The mapper must resolve a separate
-    exchange constant for *each* sublattice pair (A-B nearest neighbor, A-A and
-    B-B next-nearest neighbor) rather than averaging them, and the coupled
-    mean-field temperature must follow from those constants.
-    """
-
-    E0 = -5.0  # eV per magnetic ion
-    J_AB, J_AA, J_BB = 0.011, 0.004, -0.006  # eV, all distinct
-    A, B = "Mn", "Fe"
-    NN, NNN = 1.0, np.sqrt(2)  # a = sqrt(2): A-B nn = 1, A-A / B-B nnn = sqrt(2)
-
-    # Orderings as (A-sublattice spins, B-sublattice spins) grids, in 1x1 and 2x2
-    # supercells of the parent, chosen to constrain all three couplings + E0.
-    ORDERINGS = (
-        ([[1]], [[1]]),  # FM
-        ([[1]], [[-1]]),  # A up, B down
-        ([[1, -1], [-1, 1]], [[1, 1], [1, 1]]),  # A Neel, B FM
-        ([[1, 1], [1, 1]], [[1, -1], [-1, 1]]),  # A FM, B Neel
-        ([[1, -1], [-1, 1]], [[1, -1], [-1, 1]]),  # both Neel
-    )
-
-    @classmethod
-    def _structure(cls, spins_a, spins_b):
-        spins_a = np.atleast_2d(np.asarray(spins_a, dtype=float))
-        spins_b = np.atleast_2d(np.asarray(spins_b, dtype=float))
-        n_y, n_x = spins_a.shape
-        a = np.sqrt(2)
-        lattice = Lattice.from_parameters(n_x * a, n_y * a, 10, 90, 90, 90)
-        species, coords, magmoms = [], [], []
-        for y in range(n_y):
-            for x in range(n_x):
-                species += [cls.A, cls.B]
-                coords += [[x / n_x, y / n_y, 0.5], [(x + 0.5) / n_x, (y + 0.5) / n_y, 0.5]]
-                magmoms += [spins_a[y, x], spins_b[y, x]]
-        return Structure(lattice, species, coords, site_properties={"magmom": magmoms})
-
-    def _energy(self, struct):
-        # Forward Heisenberg energy on the mapper's own neighbor graph: the
-        # neighbor topology is a geometric fact, while the coupling assigned to
-        # each (sublattice pair, shell) is the physics the mapper must invert.
-        graph = StructureGraph.from_local_env_strategy(struct, MinimumDistanceNN(cutoff=1.5, get_all_sites=True))
-        j_by_pair = {
-            (frozenset((self.A, self.B)), "nn"): self.J_AB,
-            (frozenset((self.A,)), "nnn"): self.J_AA,
-            (frozenset((self.B,)), "nnn"): self.J_BB,
-        }
-        mags = struct.site_properties["magmom"]
-        e_ex = 0.0
-        for i in range(len(struct)):
-            for cs in graph.get_connected_sites(i):
-                j, dist = cs[2], cs[-1]
-                if abs(dist - self.NN) < 0.05:
-                    shell = "nn"
-                elif abs(dist - self.NNN) < 0.05:
-                    shell = "nnn"
-                else:
-                    continue
-                pair = frozenset((struct[i].specie.symbol, struct[j].specie.symbol))
-                e_ex -= 0.5 * j_by_pair[pair, shell] * mags[i] * mags[j]
-        return len(struct) * self.E0 + e_ex
-
-    def _mapper(self):
-        structures = [self._structure(sa, sb) for sa, sb in self.ORDERINGS]
-        energies = [self._energy(s) for s in structures]
-        return HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
-
-    def test_distinct_sublattice_couplings_resolved(self):
-        hm = self._mapper()
-        assert len(hm.wyckoff_ids) == 2  # Mn and Fe are distinct sublattices
-
-        ex_params = hm.get_exchange()
-        # One constant per sublattice pair, each recovered independently. Compare
-        # the (order-independent) multiset of J values against the inputs.
-        j_values = sorted(v for k, v in ex_params.items() if k != "E0")
-        expected = sorted([self.J_AB * 1000, self.J_AA * 1000, self.J_BB * 1000])
-        assert len(j_values) == 3
-        assert j_values == approx(expected, abs=1e-6)
-        assert ex_params["E0"] == approx(self.E0, abs=1e-8)
-
-    def test_multi_sublattice_mft_matches_analytic(self):
-        hm = self._mapper()
-        hm.get_exchange()  # populates ex_params used by the multi-sublattice branch
-
-        mft_t = hm.get_mft_temperature(hm.estimate_exchange())
-
-        # get_mft_temperature builds omega = (2/3 k_B) * [[2 Jaa, Jab], [Jab, 2 Jbb]]
-        # and takes its largest eigenvalue. That eigenvalue is symmetric in
-        # (Jaa, Jbb), so it does not depend on which sublattice is labelled 0/1.
-        jab, jaa, jbb = self.J_AB * 1000, self.J_AA * 1000, self.J_BB * 1000
-        max_eig = (jaa + jbb) + np.sqrt((jaa - jbb) ** 2 + jab**2)
-        tc_expected = 2 / 3 / K_BOLTZMANN * max_eig
-        assert mft_t == approx(tc_expected, rel=1e-9)
-
-
 class TestHeisenbergMapperFullCellSymmetry:
     """Site equivalence must be read from the full structure. Removing the
     nonmagnetic ions first can raise the apparent site symmetry and wrongly
@@ -358,27 +389,64 @@ class TestHeisenbergMapperFullCellSymmetry:
 
     lattice = Lattice.from_parameters(6, 4, 4, 90, 90, 90)
 
-    def _ordering(self, spins, with_x=True):
+    def _ordering(self, spins, with_zn=True):
         # Two Fe that look equivalent on their own; an off-center nonmagnetic Zn
         # breaks the symmetry between them.
         species, coords, magmoms = ["Fe", "Fe"], [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], list(spins)
-        if with_x:
+        if with_zn:
             species, coords, magmoms = [*species, "Zn"], [*coords, [0.18, 0.0, 0.0]], [*magmoms, 0.0]
         return Structure(self.lattice, species, coords, site_properties={"magmom": magmoms})
 
     def test_nonmagnetic_ions_split_sublattices(self):
         structures = [self._ordering([3, 3]), self._ordering([3, -3])]
-        hm = HeisenbergMapper(structures, [-10.0, -9.0], cutoff=3.5, tol=0.02)
+        hm = HeisenbergMapper(structures, [-10.0, -9.0], tol=0.02)
 
-        # The two Fe are distinct sublattices because of the off-center Zn.
-        assert len(hm.wyckoff_ids) == 2
-        assert hm.site_labels == [[0, 1], [0, 1]]
+        # The two Fe are distinct sublattices because of the off-center Zn. They share a
+        # wyckoff symbol, so the sublattice ids -- not the symbols -- are what separate
+        # them. Which Fe is labelled 0 is arbitrary, only the split is asserted.
+        assert len(hm.sublattice_wyckoff_symbols) == 2
+        assert all(len(set(sub_ids)) == 2 for sub_ids in hm.sublattice_ids)
 
-    def test_stripping_nonmagnetic_ions_would_merge_sublattices(self):
-        # Without the nonmagnetic Zn the two Fe look equivalent (one sublattice).
-        # This is the skewed result the full-cell symmetry analysis avoids.
-        structures = [self._ordering([3, 3], with_x=False), self._ordering([3, -3], with_x=False)]
-        hm = HeisenbergMapper(structures, [-10.0, -9.0], cutoff=3.5, tol=0.02)
+    def test_equivalent_sites_share_a_sublattice(self):
+        # Control for the test above: with the Zn gone the two Fe genuinely are
+        # equivalent and belong to one sublattice. Stripping the nonmagnetic ions
+        # before the symmetry analysis would make the case above look like this one.
+        structures = [self._ordering([3, 3], with_zn=False), self._ordering([3, -3], with_zn=False)]
+        hm = HeisenbergMapper(structures, [-10.0, -9.0], tol=0.02)
 
-        assert len(hm.wyckoff_ids) == 1
-        assert hm.site_labels == [[0, 0], [0, 0]]
+        assert len(hm.sublattice_wyckoff_symbols) == 1
+        assert all(set(sub_ids) == {0} for sub_ids in hm.sublattice_ids)
+
+
+class TestHeisenbergMapperZeroMomentIon:
+    """A magnetic species that relaxes to zero moment throughout one ordering must
+    stay on the magnetic lattice there. Magnetic sites are selected by species
+    pooled over *all* orderings, so those ions contribute zero terms instead of
+    vanishing and leaving that ordering with a different site count, graph
+    topology and energy per magnetic ion than its siblings.
+    """
+
+    lattice = Lattice.from_parameters(2, 2, 10, 90, 90, 90)
+    species = ("Fe", "Mn", "Fe", "Mn")
+    coords = ((0, 0, 0.5), (0.5, 0, 0.5), (0, 0.5, 0.5), (0.5, 0.5, 0.5))
+
+    def _ordering(self, magmoms):
+        return Structure(
+            self.lattice,
+            list(self.species),
+            [list(coord) for coord in self.coords],
+            site_properties={"magmom": list(magmoms)},
+        )
+
+    def test_quenched_species_stays_on_the_magnetic_lattice(self):
+        # Both Mn relaxed to zero moment in the second ordering, so on its own that
+        # ordering looks like an Fe-only compound.
+        structures = [self._ordering([3, 2, 3, 2]), self._ordering([3, 0, -3, 0])]
+        hm = HeisenbergMapper(structures, [-20.0, -19.0], tol=0.02)
+
+        assert hm.parent.magn_species == {"Fe", "Mn"}
+        # Without pooling, the second cell would carry two magnetic sites instead of
+        # four and its energy per magnetic ion would be off by a factor of two.
+        assert [len(struct) for struct in hm.magnetic_structures] == [4, 4]
+        assert [len(sub_ids) for sub_ids in hm.sublattice_ids] == [4, 4]
+        assert hm.energies == [-5.0, -4.75]

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
 from pytest import approx
 
+from pymatgen.analysis.graphs import StructureGraph
+from pymatgen.analysis.local_env import MinimumDistanceNN
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.core import Lattice
 from pymatgen.core.structure import Structure
@@ -12,21 +16,29 @@ from tests.testing import TEST_FILES_DIR
 
 TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 
+# Same Boltzmann constant HeisenbergMapper.get_mft_temperature uses (meV/K).
+K_BOLTZMANN = 0.0861733
+
 
 class TestHeisenbergMapper:
+    """End-to-end run on real Mn3Al DFT orderings.
+
+    Mn3Al has no independently-known exchange constants -- the mapper is the only
+    estimator -- so asserting specific J or Tc values here would be circular.
+    These tests assert physical *invariants* instead (geometry, sublattice
+    structure, finiteness, MSON round-trips), and that the mapper flags the fit
+    as ill-conditioned rather than silently returning unphysical numbers. Exact
+    numeric recovery is validated on synthetic known-Hamiltonian models below.
+    """
+
     @classmethod
     def setup_class(cls):
-        cls.df = pd.read_json(f"{TEST_DIR}/mag_orderings_test_cases.json")
-
-        # Good tests
         cls.Mn3Al = pd.read_json(f"{TEST_DIR}/Mn3Al.json")
-
         cls.compounds = [cls.Mn3Al]
 
         cls.hms = []
         for c in cls.compounds:
-            ordered_structures = list(c["structure"])
-            ordered_structures = [Structure.from_dict(d) for d in ordered_structures]
+            ordered_structures = [Structure.from_dict(d) for d in c["structure"]]
             epa = list(c["energy_per_atom"])
             energies = [e * len(s) for (e, s) in zip(epa, ordered_structures, strict=True)]
 
@@ -35,8 +47,7 @@ class TestHeisenbergMapper:
 
     def test_graphs(self):
         for hm in self.hms:
-            struct_graphs = hm.sgraphs
-            assert len(struct_graphs) == 7
+            assert len(hm.sgraphs) == 7
 
     def test_sites(self):
         for hm in self.hms:
@@ -55,25 +66,27 @@ class TestHeisenbergMapper:
 
     def test_nn_interactions(self):
         for hm in self.hms:
-            n_interacts = len(hm.nn_interactions)
-            assert n_interacts == 3
+            assert len(hm.nn_interactions) == 3
+            assert hm.dists["nn"] == approx(2.51)
 
-            dists = hm.dists
-            assert dists["nn"] == approx(2.51)
-
-    def test_exchange_params(self):
+    def test_exchange_params_are_physical_invariants(self):
+        # No ground-truth J for real DFT data: assert structure and finiteness.
         for hm in self.hms:
             ex_params = hm.get_exchange()
-            assert ex_params["0-1-nn"] == approx(30.813729, abs=1e-2)
+            assert set(hm.wyckoff_ids) == {0, 1}  # two Mn sublattices (1a, 2c)
+            assert "E0" in ex_params
+            assert all(np.isfinite(v) for v in ex_params.values())
 
-    def test_mean_field(self):
+    def test_ill_conditioned_fit_warns(self, caplog):
+        # The Mn3Al system is over-parameterized: several orderings are
+        # near-degenerate, so H is nearly singular (cond ~ 1e6) and the fitted
+        # exchange constants are unphysical. The mapper must warn, not hand back
+        # garbage silently.
         for hm in self.hms:
-            j_avg = hm.estimate_exchange()
-            value = round(52.54997149705518, 3)
-            assert round(j_avg, 3) == value
-
-            mft_t = hm.get_mft_temperature(j_avg)
-            assert mft_t == approx(21596.7, abs=1)
+            with caplog.at_level(logging.WARNING):
+                hm.get_exchange()
+            assert "ill-conditioned" in caplog.text
+            caplog.clear()
 
     def test_get_igraph(self):
         for hm in self.hms:
@@ -178,6 +191,163 @@ class TestHeisenbergMapperMixedSupercells:
         energies = [self._energy(fm), self._energy(stripe), -5.0]
         with pytest.raises(ValueError, match="parent cell"):
             HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+
+
+class TestHeisenbergMeanFieldTemperature:
+    """Single magnetic sublattice (square lattice, nearest-neighbor coupling
+    only) so both the average exchange and the mean-field critical temperature
+    have closed forms to check against:
+
+        <J> = z * J           (z = 4 nearest neighbors)
+        Tc  = 2 |<J>| / (3 k_B)
+    """
+
+    E0 = -5.0  # eV per magnetic ion
+    Z = 4  # nearest neighbors on the square lattice
+    NN_VECS = ((1, 0), (-1, 0), (0, 1), (0, -1))
+
+    @staticmethod
+    def _structure(spins):
+        spins = np.atleast_2d(np.asarray(spins, dtype=float))
+        n_y, n_x = spins.shape
+        lattice = Lattice.from_parameters(n_x, n_y, 10, 90, 90, 90)
+        coords = [[x / n_x, y / n_y, 0.5] for y in range(n_y) for x in range(n_x)]
+        magmoms = [spins[y, x] for y in range(n_y) for x in range(n_x)]
+        return Structure(lattice, ["Fe"] * (n_x * n_y), coords, site_properties={"magmom": magmoms})
+
+    def _energy(self, spins, j_nn):
+        spins = np.atleast_2d(np.asarray(spins, dtype=float))
+        n_y, n_x = spins.shape
+        e_ex = 0.0
+        for y in range(n_y):
+            for x in range(n_x):
+                s_i = spins[y, x]
+                nn = sum(s_i * spins[(y + dy) % n_y, (x + dx) % n_x] for dx, dy in self.NN_VECS)
+                e_ex -= 0.5 * j_nn * nn
+        return n_x * n_y * self.E0 + e_ex
+
+    def _mapper(self, j_nn):
+        fm, afm = [[1, 1], [1, 1]], [[1, -1], [-1, 1]]
+        structures = [self._structure(fm), self._structure(afm)]
+        energies = [self._energy(fm, j_nn), self._energy(afm, j_nn)]
+        # cutoff between NN (1.0) and NNN (sqrt(2)) keeps a single interaction
+        return HeisenbergMapper(structures, energies, cutoff=1.2, tol=0.02)
+
+    def test_single_sublattice_mft_matches_analytic(self):
+        j_nn = 0.010  # eV
+        hm = self._mapper(j_nn)
+        assert len(hm.wyckoff_ids) == 1  # one magnetic sublattice
+
+        j_avg = hm.estimate_exchange()
+        assert j_avg == approx(self.Z * j_nn * 1000, abs=1e-6)  # <J> = z * J (meV)
+
+        mft_t = hm.get_mft_temperature(j_avg)
+        tc_expected = 2 * abs(self.Z * j_nn * 1000) / 3 / K_BOLTZMANN
+        assert mft_t == approx(tc_expected, abs=1e-3)  # ~309.5 K
+
+    @pytest.mark.parametrize(("j_nn", "fm_ground_state"), [(0.010, True), (-0.010, False)])
+    def test_exchange_sign_follows_ground_state(self, j_nn, fm_ground_state):
+        # J > 0 stabilizes FM (<J> > 0); J < 0 stabilizes AFM (<J> < 0).
+        hm = self._mapper(j_nn)
+        j_avg = hm.estimate_exchange()
+        assert bool(j_avg > 0) == fm_ground_state
+        assert j_avg == approx(self.Z * j_nn * 1000, abs=1e-6)
+
+
+class TestHeisenbergTwoSublatticeCoupling:
+    """Two inequivalent magnetic sublattices (Mn, Fe) arranged on a checkerboard
+    so the parent cell has two Wyckoff orbits. The mapper must resolve a separate
+    exchange constant for *each* sublattice pair (A-B nearest neighbor, A-A and
+    B-B next-nearest neighbor) rather than averaging them, and the coupled
+    mean-field temperature must follow from those constants.
+    """
+
+    E0 = -5.0  # eV per magnetic ion
+    J_AB, J_AA, J_BB = 0.011, 0.004, -0.006  # eV, all distinct
+    A, B = "Mn", "Fe"
+    NN, NNN = 1.0, np.sqrt(2)  # a = sqrt(2): A-B nn = 1, A-A / B-B nnn = sqrt(2)
+
+    # Orderings as (A-sublattice spins, B-sublattice spins) grids, in 1x1 and 2x2
+    # supercells of the parent, chosen to constrain all three couplings + E0.
+    ORDERINGS = (
+        ([[1]], [[1]]),  # FM
+        ([[1]], [[-1]]),  # A up, B down
+        ([[1, -1], [-1, 1]], [[1, 1], [1, 1]]),  # A Neel, B FM
+        ([[1, 1], [1, 1]], [[1, -1], [-1, 1]]),  # A FM, B Neel
+        ([[1, -1], [-1, 1]], [[1, -1], [-1, 1]]),  # both Neel
+    )
+
+    @classmethod
+    def _structure(cls, spins_a, spins_b):
+        spins_a = np.atleast_2d(np.asarray(spins_a, dtype=float))
+        spins_b = np.atleast_2d(np.asarray(spins_b, dtype=float))
+        n_y, n_x = spins_a.shape
+        a = np.sqrt(2)
+        lattice = Lattice.from_parameters(n_x * a, n_y * a, 10, 90, 90, 90)
+        species, coords, magmoms = [], [], []
+        for y in range(n_y):
+            for x in range(n_x):
+                species += [cls.A, cls.B]
+                coords += [[x / n_x, y / n_y, 0.5], [(x + 0.5) / n_x, (y + 0.5) / n_y, 0.5]]
+                magmoms += [spins_a[y, x], spins_b[y, x]]
+        return Structure(lattice, species, coords, site_properties={"magmom": magmoms})
+
+    def _energy(self, struct):
+        # Forward Heisenberg energy on the mapper's own neighbor graph: the
+        # neighbor topology is a geometric fact, while the coupling assigned to
+        # each (sublattice pair, shell) is the physics the mapper must invert.
+        graph = StructureGraph.from_local_env_strategy(struct, MinimumDistanceNN(cutoff=1.5, get_all_sites=True))
+        j_by_pair = {
+            (frozenset((self.A, self.B)), "nn"): self.J_AB,
+            (frozenset((self.A,)), "nnn"): self.J_AA,
+            (frozenset((self.B,)), "nnn"): self.J_BB,
+        }
+        mags = struct.site_properties["magmom"]
+        e_ex = 0.0
+        for i in range(len(struct)):
+            for cs in graph.get_connected_sites(i):
+                j, dist = cs[2], cs[-1]
+                if abs(dist - self.NN) < 0.05:
+                    shell = "nn"
+                elif abs(dist - self.NNN) < 0.05:
+                    shell = "nnn"
+                else:
+                    continue
+                pair = frozenset((struct[i].specie.symbol, struct[j].specie.symbol))
+                e_ex -= 0.5 * j_by_pair[pair, shell] * mags[i] * mags[j]
+        return len(struct) * self.E0 + e_ex
+
+    def _mapper(self):
+        structures = [self._structure(sa, sb) for sa, sb in self.ORDERINGS]
+        energies = [self._energy(s) for s in structures]
+        return HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+
+    def test_distinct_sublattice_couplings_resolved(self):
+        hm = self._mapper()
+        assert len(hm.wyckoff_ids) == 2  # Mn and Fe are distinct sublattices
+
+        ex_params = hm.get_exchange()
+        # One constant per sublattice pair, each recovered independently. Compare
+        # the (order-independent) multiset of J values against the inputs.
+        j_values = sorted(v for k, v in ex_params.items() if k != "E0")
+        expected = sorted([self.J_AB * 1000, self.J_AA * 1000, self.J_BB * 1000])
+        assert len(j_values) == 3
+        assert j_values == approx(expected, abs=1e-6)
+        assert ex_params["E0"] == approx(self.E0, abs=1e-8)
+
+    def test_multi_sublattice_mft_matches_analytic(self):
+        hm = self._mapper()
+        hm.get_exchange()  # populates ex_params used by the multi-sublattice branch
+
+        mft_t = hm.get_mft_temperature(hm.estimate_exchange())
+
+        # get_mft_temperature builds omega = (2/3 k_B) * [[2 Jaa, Jab], [Jab, 2 Jbb]]
+        # and takes its largest eigenvalue. That eigenvalue is symmetric in
+        # (Jaa, Jbb), so it does not depend on which sublattice is labelled 0/1.
+        jab, jaa, jbb = self.J_AB * 1000, self.J_AA * 1000, self.J_BB * 1000
+        max_eig = (jaa + jbb) + np.sqrt((jaa - jbb) ** 2 + jab**2)
+        tc_expected = 2 / 3 / K_BOLTZMANN * max_eig
+        assert mft_t == approx(tc_expected, rel=1e-9)
 
 
 class TestHeisenbergMapperFullCellSymmetry:

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -40,13 +40,17 @@ class TestHeisenbergMapper:
 
     def test_sites(self):
         for hm in self.hms:
+            # One sublattice label per site, one label list per ordering
+            assert len(hm.site_labels) == len(hm.sgraphs)
+            # Site 0 of the first ordering belongs to sublattice 0
+            assert hm.site_labels[0][0] == 0
+
+            # unique_site_ids groups each ordering's sites by sublattice id
             unique_site_ids = hm.unique_site_ids
-            # One site map per ordering
             assert len(unique_site_ids) == len(hm.sgraphs)
-            # Site 0 of the first ordering belongs to global sublattice 0
-            assert hm._global_orbit_id(unique_site_ids[0], 0) == 0
-            # Global ids are shared across orderings and match the wyckoff labels
-            used_ids = {gid for site_map in unique_site_ids for gid in site_map.values()}
+            assert unique_site_ids[0][0, 1] == 0
+            # Sublattice ids are shared across orderings and match the wyckoff labels
+            used_ids = {sub for site_map in unique_site_ids for sub in site_map.values()}
             assert used_ids == set(hm.wyckoff_ids)
 
     def test_nn_interactions(self):
@@ -81,22 +85,19 @@ class TestHeisenbergMapper:
             hmodel = hm.get_heisenberg_model()
             assert hmodel.formula == "Mn3Al"
 
-    def test_as_from_dict_round_trip(self): 
-        # HeisenbergModel must survive MSON round-trips. as_dict() serializes
-        # ex_mat with jsanitize (a DataFrame becomes a dict), so from_dict()
-        # must accept a dict and not only a string.
+    def test_as_from_dict_round_trip(self):
+        # HeisenbergModel must survive repeated MSON round-trips. as_dict()
+        # serializes ex_mat with jsanitize (a DataFrame becomes a nested dict),
+        # so from_dict() must reconstruct the DataFrame from that dict.
         # https://github.com/materialsproject/pymatgen/issues/4664
         for hm in self.hms:
             model = hm.get_heisenberg_model()
 
-            # First round-trip: ex_mat starts as a JSON string, becomes a DataFrame.
             model_rt = HeisenbergModel.from_dict(model.as_dict())
             assert isinstance(model_rt.ex_mat, pd.DataFrame)
             assert model_rt.formula == model.formula
 
-            # Second round-trip: ex_mat is now a DataFrame, which jsanitize
-            # serializes to a dict. This raised
-            # "ValueError: malformed node or string" before the fix.
+            # A second round-trip must be a no-op on the exchange matrix.
             model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
             assert isinstance(model_rt2.ex_mat, pd.DataFrame)
             pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
@@ -177,3 +178,37 @@ class TestHeisenbergMapperMixedSupercells:
         energies = [self._energy(fm), self._energy(stripe), -5.0]
         with pytest.raises(ValueError, match="parent cell"):
             HeisenbergMapper(structures, energies, cutoff=1.5, tol=0.02)
+
+
+class TestHeisenbergMapperFullCellSymmetry:
+    """Site equivalence must be read from the full structure. Removing the
+    nonmagnetic ions first can raise the apparent site symmetry and wrongly
+    merge magnetic sublattices that are actually distinct.
+    """
+
+    lattice = Lattice.from_parameters(6, 4, 4, 90, 90, 90)
+
+    def _ordering(self, spins, with_x=True):
+        # Two Fe that look equivalent on their own; an off-center nonmagnetic Zn
+        # breaks the symmetry between them.
+        species, coords, magmoms = ["Fe", "Fe"], [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], list(spins)
+        if with_x:
+            species, coords, magmoms = [*species, "Zn"], [*coords, [0.18, 0.0, 0.0]], [*magmoms, 0.0]
+        return Structure(self.lattice, species, coords, site_properties={"magmom": magmoms})
+
+    def test_nonmagnetic_ions_split_sublattices(self):
+        structures = [self._ordering([3, 3]), self._ordering([3, -3])]
+        hm = HeisenbergMapper(structures, [-10.0, -9.0], cutoff=3.5, tol=0.02)
+
+        # The two Fe are distinct sublattices because of the off-center Zn.
+        assert len(hm.wyckoff_ids) == 2
+        assert hm.site_labels == [[0, 1], [0, 1]]
+
+    def test_stripping_nonmagnetic_ions_would_merge_sublattices(self):
+        # Without the nonmagnetic Zn the two Fe look equivalent (one sublattice).
+        # This is the skewed result the full-cell symmetry analysis avoids.
+        structures = [self._ordering([3, 3], with_x=False), self._ordering([3, -3], with_x=False)]
+        hm = HeisenbergMapper(structures, [-10.0, -9.0], cutoff=3.5, tol=0.02)
+
+        assert len(hm.wyckoff_ids) == 1
+        assert hm.site_labels == [[0, 0], [0, 0]]

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -12,9 +12,6 @@ from scipy.constants import physical_constants
 from pymatgen.analysis.magnetism.heisenberg import HeisenbergMapper, HeisenbergModel
 from pymatgen.core import Lattice
 from pymatgen.core.structure import Structure
-from tests.testing import TEST_FILES_DIR
-
-TEST_DIR = f"{TEST_FILES_DIR}/analysis/magnetic_orderings"
 
 # Taken from scipy rather than copied out of HeisenbergMapper.get_mft_temperature, so a
 # wrong constant in the implementation shows up here instead of cancelling out.
@@ -24,118 +21,6 @@ K_BOLTZMANN = physical_constants["Boltzmann constant in eV/K"][0] * 1000  # meV/
 def _wyckoff_multiplicity(symbol: str) -> int:
     """Leading integer of a wyckoff symbol, e.g. '2c' -> 2."""
     return int("".join(char for char in symbol if char.isdigit()))
-
-
-class TestHeisenbergMapper:
-    """End-to-end run on real Mn3Al DFT orderings.
-
-    Mn3Al has no independently-known exchange constants -- the mapper is the only
-    estimator -- so asserting specific J or Tc values here would be circular. These
-    tests assert physical invariants instead (sublattice structure, geometry, the
-    <J> fallback, MSON round-trips). Exact numeric recovery is validated against a
-    known Hamiltonian in TestHeisenbergMapperKnownHamiltonian below.
-
-    No cutoff is passed, so each site keeps only its nearest-neighbor shell. In
-    Mn3Al that shell holds a single sublattice pair, which leaves the mapper with
-    too few interactions to invert and sends it down the <J> path.
-    """
-
-    @classmethod
-    def setup_class(cls):
-        cls.Mn3Al = pd.read_json(f"{TEST_DIR}/Mn3Al.json")
-        cls.structures = [Structure.from_dict(dct) for dct in cls.Mn3Al["structure"]]
-        cls.energies = [
-            epa * len(struct) for epa, struct in zip(cls.Mn3Al["energy_per_atom"], cls.structures, strict=True)
-        ]
-        cls.hm = HeisenbergMapper(cls.structures, cls.energies, tol=0.02)
-
-    def test_degenerate_orderings_are_dropped(self):
-        # Different initial configs relax to the same state and show up as orderings
-        # sharing an energy per magnetic ion; only one of each survives screening.
-        n_magnetic = [sum(site.specie.symbol == "Mn" for site in struct) for struct in self.structures]
-        energies_per_ion = [energy / n for energy, n in zip(self.energies, n_magnetic, strict=True)]
-
-        assert len(self.hm.orderings) < len(self.structures)  # something was dropped
-        assert len(self.hm.orderings) == len({round(energy, 6) for energy in energies_per_ion})
-        assert self.hm.energies == sorted(self.hm.energies)  # sorted, ground state first
-
-    def test_sublattices_follow_parent_wyckoff_orbits(self):
-        hm = self.hm
-        # Mn occupies two inequivalent orbits of the parent cell.
-        assert sorted(hm.sublattice_wyckoff_symbols.values()) == ["1a", "2c"]
-
-        # Every ordering draws its labels from those orbits, and every orbit is used.
-        assert {sub_id for sub_ids in hm.sublattice_ids for sub_id in sub_ids} == set(hm.sublattice_wyckoff_symbols)
-
-        for ordering in hm.orderings:
-            # Labels are indexed against the magnetic-only cell the graph is built from,
-            # so no None placeholders survive from the parent's full-cell labelling.
-            assert len(ordering.sublattice_ids) == len(ordering.magnetic_structure)
-            assert all(isinstance(sub_id, int) for sub_id in ordering.sublattice_ids)
-
-            # Each sublattice is filled in proportion to its wyckoff multiplicity, i.e.
-            # every ordering is a whole number of parent cells. Independent of which
-            # orbit happens to be labelled 0.
-            counts = Counter(ordering.sublattice_ids)
-            n_cells = {
-                counts[sub_id] / _wyckoff_multiplicity(symbol)
-                for sub_id, symbol in hm.sublattice_wyckoff_symbols.items()
-            }
-            assert len(n_cells) == 1
-
-    def test_single_interaction_falls_back_to_javg(self):
-        hm = self.hm
-        # The nearest-neighbor shell of Mn3Al holds exactly one sublattice pair.
-        [(pair, labels)] = hm.nn_interactions.items()
-        assert set(pair) == set(hm.sublattice_wyckoff_symbols)  # the two orbits are coupled
-        assert labels == [f"{pair[0]}-{pair[1]}-nn"]
-        assert hm.dists[labels[0]] == approx(2.51, abs=0.01)
-
-        # One interaction cannot constrain E0 and a J at once, so the mapper reports the
-        # average exchange from E_AFM - E_FM rather than inverting a degenerate system.
-        ex_params = hm.get_exchange()
-        assert set(ex_params) == {"<J>"}
-        assert np.isfinite(ex_params["<J>"])
-
-    def test_interaction_graph_carries_javg_on_every_bond(self):
-        hm = self.hm
-        igraph = hm.get_interaction_graph()
-
-        # In the <J> fallback every nearest-neighbor bond carries the same constant, and
-        # none are dropped: the interaction graph covers the whole neighbor graph.
-        assert igraph.graph.number_of_edges() == hm.nn_graphs[0].graph.number_of_edges()
-        weights = {round(data["weight"], 6) for *_, data in igraph.graph.edges(data=True)}
-        assert weights == {round(hm.get_exchange()["<J>"], 6)}
-
-    def test_heisenberg_model(self):
-        hmodel = self.hm.get_heisenberg_model()
-        assert hmodel.formula == "Mn3Al"
-
-        # structures keep every ion; magnetic_structures keep only the magnetic species,
-        # and those are what the graphs and sublattice labels are indexed against.
-        assert {sp.symbol for struct in hmodel.magnetic_structures for sp in struct.composition} == {"Mn"}
-        assert all(
-            len(mag_struct) < len(struct)
-            for struct, mag_struct in zip(hmodel.structures, hmodel.magnetic_structures, strict=True)
-        )
-
-    def test_as_from_dict_round_trip(self):
-        # HeisenbergModel must survive repeated MSON round-trips. as_dict()
-        # serializes ex_mat with jsanitize (a DataFrame becomes a nested dict),
-        # so from_dict() must reconstruct the DataFrame from that dict.
-        # https://github.com/materialsproject/pymatgen/issues/4664
-        model = self.hm.get_heisenberg_model()
-
-        model_rt = HeisenbergModel.from_dict(model.as_dict())
-        assert isinstance(model_rt.ex_mat, pd.DataFrame)
-        assert model_rt.formula == model.formula
-        assert model_rt.structures == model.structures
-        assert model_rt.magnetic_structures == model.magnetic_structures
-
-        # A second round-trip must be a no-op on the exchange matrix.
-        model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
-        assert isinstance(model_rt2.ex_mat, pd.DataFrame)
-        pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
 
 
 class TestHeisenbergMapperKnownHamiltonian:
@@ -234,7 +119,7 @@ class TestHeisenbergMapperKnownHamiltonian:
         assert sorted(len(struct) for struct in hm.magnetic_structures) == [2, 2, 4, 8]
 
         aa, bb, ab = self._labels(hm)
-        ex_params = hm.get_exchange()
+        ex_params, residual = hm.get_exchange()
 
         # One constant per sublattice pair, each recovered independently rather than
         # averaged together, and independent of the supercell each ordering lives in.
@@ -243,6 +128,74 @@ class TestHeisenbergMapperKnownHamiltonian:
         assert ex_params[aa] == approx(self.J_AA * 1000, abs=1e-6)
         assert ex_params[bb] == approx(self.J_BB * 1000, abs=1e-6)
         assert ex_params["E0"] == approx(self.E0, abs=1e-8)
+
+        # The energies are exactly Heisenberg here, so the fit reproduces them.
+        assert residual == approx(0, abs=1e-12)
+
+    def test_degenerate_orderings_are_dropped(self):
+        # The same state in a 1x1 and in a 2x2 cell has the same energy per magnetic ion,
+        # so screening keeps only one of the two. Per-ion normalization is what makes
+        # cells of different size comparable, and hence what makes them degenerate here.
+        orderings = [*self.ORDERINGS, ([[1, 1], [1, 1]], [[1, 1], [1, 1]])]  # the FM ordering again, 2x2
+        structures = [self._structure(*spins) for spins in orderings]
+        energies = [self._energy(*spins) for spins in orderings]
+        hm = HeisenbergMapper(structures, energies, tol=0.02)
+
+        assert len(hm.orderings) == len(self.ORDERINGS)  # the duplicate was dropped
+        assert hm.energies == sorted(hm.energies)  # sorted, ground state first
+
+    def test_sublattices_follow_parent_wyckoff_orbits(self):
+        hm = self._mapper()
+        # A and B occupy two inequivalent orbits of the parent cell, and every ordering
+        # draws its labels from those orbits.
+        assert len(hm.sublattice_wyckoff_symbols) == 2
+        assert {sub_id for sub_ids in hm.sublattice_ids for sub_id in sub_ids} == set(hm.sublattice_wyckoff_symbols)
+
+        for ordering in hm.orderings:
+            # Labels are indexed against the magnetic-only cell the graph is built from,
+            # so no None placeholders survive from the parent's full-cell labelling.
+            assert len(ordering.sublattice_ids) == len(ordering.magnetic_structure)
+            assert all(isinstance(sub_id, int) for sub_id in ordering.sublattice_ids)
+
+            # Each sublattice is filled in proportion to its wyckoff multiplicity, i.e.
+            # every ordering is a whole number of parent cells. Independent of which
+            # orbit happens to be labelled 0.
+            counts = Counter(ordering.sublattice_ids)
+            n_cells = {
+                counts[sub_id] / _wyckoff_multiplicity(symbol)
+                for sub_id, symbol in hm.sublattice_wyckoff_symbols.items()
+            }
+            assert len(n_cells) == 1
+
+    def test_heisenberg_model(self):
+        hm = self._mapper()
+        hmodel = hm.get_heisenberg_model()
+
+        assert hmodel.formula == "MnFe"
+        assert {sp.symbol for struct in hmodel.magnetic_structures for sp in struct.composition} == {self.A, self.B}
+
+        # The fit travels with the model, residual included.
+        assert set(hmodel.ex_params) == {"E0", *self._labels(hm)}
+        assert hmodel.residual == approx(0, abs=1e-12)
+
+    def test_as_from_dict_round_trip(self):
+        # HeisenbergModel must survive repeated MSON round-trips. as_dict()
+        # serializes ex_mat with jsanitize (a DataFrame becomes a nested dict),
+        # so from_dict() must reconstruct the DataFrame from that dict.
+        # https://github.com/materialsproject/pymatgen/issues/4664
+        model = self._mapper().get_heisenberg_model()
+
+        model_rt = HeisenbergModel.from_dict(model.as_dict())
+        assert isinstance(model_rt.ex_mat, pd.DataFrame)
+        assert model_rt.formula == model.formula
+        assert model_rt.structures == model.structures
+        assert model_rt.magnetic_structures == model.magnetic_structures
+        assert model_rt.residual == model.residual
+
+        # A second round-trip must be a no-op on the exchange matrix.
+        model_rt2 = HeisenbergModel.from_dict(model_rt.as_dict())
+        assert isinstance(model_rt2.ex_mat, pd.DataFrame)
+        pd.testing.assert_frame_equal(model_rt.ex_mat, model_rt2.ex_mat)
 
     def test_shells_are_counted_within_a_sublattice_pair(self):
         hm = self._mapper()
@@ -371,6 +324,15 @@ class TestHeisenbergMeanFieldTemperature:
         mft_t = hm.get_mft_temperature(j_avg)
         tc_expected = 2 * abs(self.Z * j_nn * 1000) / 3 / K_BOLTZMANN
         assert mft_t == approx(tc_expected, abs=1e-3)  # ~309.5 K
+
+    def test_single_interaction_cannot_be_fitted(self):
+        # One interaction cannot constrain E0 and a J at once, so there is nothing for
+        # the least-squares fit to solve and the mapper must say so rather than guess.
+        hm = self._mapper(0.010)
+        assert len(hm.nn_interactions) == 1
+
+        with pytest.raises(ValueError, match="needs at least 2"):
+            hm.get_exchange()
 
     @pytest.mark.parametrize(("j_nn", "fm_ground_state"), [(0.010, True), (-0.010, False)])
     def test_exchange_sign_follows_ground_state(self, j_nn, fm_ground_state):

--- a/tests/analysis/magnetism/test_heisenberg.py
+++ b/tests/analysis/magnetism/test_heisenberg.py
@@ -132,6 +132,29 @@ class TestHeisenbergMapperKnownHamiltonian:
         # The energies are exactly Heisenberg here, so the fit reproduces them.
         assert residual == approx(0, abs=1e-12)
 
+    def test_residual_is_rms_energy_error_per_ion(self):
+        # Four parameters, so the four orderings above make a square system the fit solves
+        # exactly whatever the energies are. A fifth ordering plus an energy pushed off the
+        # Heisenberg surface is what leaves a residual to look at.
+        orderings = [*self.ORDERINGS, ([[1, 1], [1, -1]], [[1, 1], [1, 1]])]  # A stripe/B FM, 2x2
+        structures = [self._structure(*spins) for spins in orderings]
+        energies = [self._energy(*spins) for spins in orderings]
+        energies[0] += 0.05  # eV, on the 2-ion FM cell
+        hm = HeisenbergMapper(structures, energies, tol=0.02)
+
+        ex_params, residual = hm.get_exchange()
+        assert residual > 0
+
+        # The residual is a root mean square over the orderings, in meV per magnetic ion:
+        # averaging rather than summing is what keeps it from growing with the number of
+        # orderings, and makes it comparable between materials.
+        j_columns = [col for col in hm.ex_mat.columns if col != "E"]
+        H = hm.ex_mat[j_columns].to_numpy(dtype=float)
+        E = hm.ex_mat["E"].to_numpy(dtype=float)
+        # ex_params reports E0 in eV and the J_ij in meV; ex_mat is all eV per ion.
+        params = np.array([ex_params["E0"], *(ex_params[col] / 1000 for col in j_columns[1:])])
+        assert residual == approx(np.sqrt(np.mean((H @ params - E) ** 2)) * 1000, rel=1e-9)
+
     def test_degenerate_orderings_are_dropped(self):
         # The same state in a 1x1 and in a 2x2 cell has the same energy per magnetic ion,
         # so screening keeps only one of the two. Per-ion normalization is what makes


### PR DESCRIPTION
### Summary
Refactors `HeisenbergMapper` so magnetic sublattices are defined once on a common parent cell, and every DFT-relaxed ordering is mapped onto it by structure matching rather than by direct index comparison. This decouples exchange-parameter fitting from any single ordering's cell size/shape, so orderings that were relaxed in different-sized supercells of the same parent can now be combined in one fit.

Closes #4667.

### Motivation
The old implementation identified "unique sites" from the geometry of `ordered_structures[0]` and assumed every other ordering shared that exact indexing/cell. Orderings enumerated by a `MagneticOrderingsWF`-style workflow frequently don't: different orderings can relax into different (but commensurate) supercells of the same parent, and the mapper had no way to reconcile them. This branch introduces an explicit parent cell as the single source of truth for sublattice identity, with each ordering's sites matched onto it via `StructureMatcher(attempt_supercell=True)`.

### Key changes

1. New MagneticOrdering / ParentOrdering / RelaxedOrdering classes (heisenberg.py) - each ordering now owns its magnetic-only structure, its NN graph, and its parent-sublattice labels. ParentOrdering derives sublattices from the parent's Wyckoff orbits (nonmagnetic ions kept in for correct site symmetry); RelaxedOrdering maps onto the parent via get_s2_like_s1 and raises a clear ValueError if it isn't a supercell of the parent.
2. HeisenbergMapper(..., parent=None, ...) - new optional parent argument. If omitted, the parent is inferred as the primitive cell of the lowest-energy ordering (documented caveat: only safe if that ordering hasn't broken the paramagnetic symmetry).
3. SublatticeMinimumDistanceNN - new NN strategy that takes the nearest shell per sublattice pair instead of one global nearest-neighbor window, so intra-sublattice bonds longer than the shortest inter-sublattice bond no longer silently drop out of the graph.
4. Interaction labeling by nearest-shell-of-a-pair, not fixed ±tol windows.
5. Least-squares fit over all supplied orderings (get_exchange) replacing the old square-system solve - surplus orderings now average out DFT-energy noise instead of being discarded; added an ill-conditioned/rank-deficient warning and an RMS residual (meV/magnetic ion) as a fit-quality metric.
6. threshold_nonmag handling so induced moments on nominally nonmagnetic ions don't get miscounted as magnetic sites and change site counts/graph topology between orderings.
7. Removed <J> dependency from the core fit path; estimate_exchange and get_mft_temperature are now @deprecated (deadline 2027-08-01) in favor of get_exchange's shell-resolved J_ij and an external Monte Carlo solver, respectively.
8. HeisenbergModel.from_dict fixed to handle unique_site_ids serialized as lists, and ex_mat serialization corrected (per PR #4664).
9. Units/docstring corrections throughout (J_ij in meV/μ_B² on raw moments vs. the meV-normalized-spin convention used by get_interaction_graph/VAMPIRE/TB2J).


### Testing
All tests pass locally, including new coverage added on this branch:

`TestHeisenbergMapperKnownHamiltonian `- exchange recovery, RMS residual, degenerate-ordering dropping, Wyckoff-orbit sublattices, ill-conditioned-fit warning, shell counting per sublattice pair, interaction-graph consistency, incompatible (non-supercell) ordering rejection
`TestHeisenbergMeanFieldTemperature `- single/multi-sublattice MFT, exchange sign vs. ground state
`TestHeisenbergMapperFullCellSymmetry `- nonmagnetic ions splitting sublattices, symmetry-equivalent sites sharing one
`TestHeisenbergMapperZeroMomentIon `- quenched-moment species staying on the magnetic lattice