### PR TITLE
Fix MagneticStructureEnumerator duplicate-ordering pruning never running

### DIFF
--- a/src/pymatgen/analysis/magnetism/analyzer.py
+++ b/src/pymatgen/analysis/magnetism/analyzer.py
@@ -1010,7 +1010,7 @@ class MagneticStructureEnumerator:
                     ):
                         structures_to_remove.append(check_idx)
 
-        if len(structures_to_remove) == 0:
+        if structures_to_remove:
             self.logger.info(f"Removing {len(structures_to_remove)} duplicate ordered structures")
             ordered_structures = [s for idx, s in enumerate(ordered_structures) if idx not in structures_to_remove]
             ordered_structures_origins = [

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -431,9 +431,7 @@ class TestMagneticStructureEnumeratorTruncation:
         enumerator.transformations = {}
         enumerator.sanitized_structure = structures[0]
         enumerator.num_orderings = 64
-        enumerator.input_analyzer = CollinearMagneticStructureAnalyzer(
-            structures[0], overwrite_magmom_mode="none"
-        )
+        enumerator.input_analyzer = CollinearMagneticStructureAnalyzer(structures[0], overwrite_magmom_mode="none")
         enumerator.ordered_structures = list(structures)
         enumerator.ordered_structure_origins = list(origins)
 

--- a/tests/analysis/magnetism/test_analyzer.py
+++ b/tests/analysis/magnetism/test_analyzer.py
@@ -313,13 +313,21 @@ class TestMagneticStructureEnumeratorTruncation:
     # Not gated on ENUMLIB_PRESENT: these tests call _generate_ordered_structures
     # directly on a manually-built MagneticStructureEnumerator, so they don't need
     # enumlib to generate orderings.
-    def test_truncate_by_symmetry_respects_configured_count(self):
+    def test_truncate_by_symmetry_respects_configured_count(self, monkeypatch):
         # Regression test: truncate_by_symmetry used to be ignored by the actual
         # truncation step, which had a hardcoded cap of 5 regardless of what the
         # user configured. Build a set of structures with 5 distinct symmetries
         # and confirm that requesting truncate_by_symmetry=2 actually keeps 2,
         # not 5. Bypasses __init__ (and enumlib) since only the truncation logic
         # in _generate_ordered_structures is under test.
+        #
+        # These structures carry no magmoms and differ only in lattice, so
+        # StructureMatcher (scale=True, primitive_cell=True) considers some of
+        # them equivalent orderings. Stub out matches_ordering so the duplicate
+        # pruning earlier in _generate_ordered_structures cannot interfere with
+        # the truncation behavior actually under test here.
+        monkeypatch.setattr(CollinearMagneticStructureAnalyzer, "matches_ordering", lambda self, other: False)
+
         base = Structure.from_spacegroup(225, Lattice.cubic(4.2), ["Ni", "O"], [[0, 0, 0], [0.5, 0.5, 0.5]])
         lattices = [
             Lattice.from_parameters(4.2, 4.2, 4.6, 90, 90, 90),  # tetragonal
@@ -374,6 +382,8 @@ class TestMagneticStructureEnumeratorTruncation:
         # structures directly so the real truncation logic in
         # _generate_ordered_structures runs on our controlled set.
         monkeypatch.setattr(MagneticStructureEnumerator, "_generate_transformations", lambda self, struct: {})
+        # As above, isolate truncation from the duplicate-ordering pruning.
+        monkeypatch.setattr(CollinearMagneticStructureAnalyzer, "matches_ordering", lambda self, other: False)
 
         real_generate = MagneticStructureEnumerator._generate_ordered_structures
 
@@ -392,6 +402,54 @@ class TestMagneticStructureEnumeratorTruncation:
         assert not isinstance(enumerator.truncate_by_symmetry, bool)
         # all 5 distinct symmetry levels kept, not just 1
         assert len(enumerator.ordered_structures) == len(structures)
+
+    def test_duplicate_orderings_are_pruned(self):
+        # Regression test: the duplicate-pruning block was gated on
+        # `len(structures_to_remove) == 0`, so it only ran when there was
+        # nothing to remove. Detected duplicates were logged but kept. Feed in
+        # a set containing an exact duplicate ordering and confirm it is gone.
+        lattice = Lattice.cubic(4.2)
+        up_down = Structure(
+            lattice,
+            ["Ni", "Ni"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+            site_properties={"magmom": [4, -4]},
+        )
+        down_up = Structure(
+            lattice,
+            ["Ni", "Ni"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+            site_properties={"magmom": [-4, 4]},
+        )
+        # up_down repeated: an exact duplicate that must be pruned
+        structures = [up_down, up_down.copy(), down_up]
+        origins = ["afm1", "afm1_dup", "afm2"]
+
+        enumerator = object.__new__(MagneticStructureEnumerator)
+        enumerator.logger = logging.getLogger("test")
+        enumerator.truncate_by_symmetry = False
+        enumerator.transformations = {}
+        enumerator.sanitized_structure = structures[0]
+        enumerator.num_orderings = 64
+        enumerator.input_analyzer = CollinearMagneticStructureAnalyzer(
+            structures[0], overwrite_magmom_mode="none"
+        )
+        enumerator.ordered_structures = list(structures)
+        enumerator.ordered_structure_origins = list(origins)
+
+        out_structures, out_origins = MagneticStructureEnumerator._generate_ordered_structures(
+            enumerator, structures[0], {}
+        )
+
+        assert len(out_structures) < len(structures)
+        assert len(out_structures) == len(out_origins)
+        assert "afm1_dup" not in out_origins
+        # no two surviving structures share an ordering
+        for idx, struct in enumerate(out_structures):
+            analyzer = CollinearMagneticStructureAnalyzer(struct, overwrite_magmom_mode="none")
+            for other_idx, other in enumerate(out_structures):
+                if idx != other_idx:
+                    assert not analyzer.matches_ordering(other)
 
 
 class TestMagneticDeformation:


### PR DESCRIPTION
Fixes #4697.

### The bug

`MagneticStructureEnumerator._generate_ordered_structures` identifies duplicate magnetic orderings via `matches_ordering`, then guards the removal block with an inverted condition:

```python
if len(structures_to_remove) == 0:
    self.logger.info(f"Removing {len(structures_to_remove)} duplicate ordered structures")
    ordered_structures = [...]
```

The block therefore only runs when there is nothing to remove. Duplicates are detected, logged as `Removing 0 duplicate ordered structures`, and then kept. The surrounding comment (`# in case we've introduced duplicates, let's remove them`) and the log message both make the intent clear, so this looks like a typo rather than a deliberate disable.

### The fix

```diff
-        if len(structures_to_remove) == 0:
+        if structures_to_remove:
```

### This is a user-visible behaviour change

Worth flagging explicitly: the pruning has been dead since it was written, so enabling it means `MagneticStructureEnumerator` now returns **fewer** orderings than before for any input that produces symmetry-equivalent orderings. That is the documented intent, but downstream workflows that depend on the current ordering count will see a difference.

Two consequences I found:

1. **Two existing truncation tests asserted the unpruned counts.** `test_truncate_by_symmetry_respects_configured_count` and `test_truncate_by_symmetry_default_true_keeps_five` build six Ni/O structures that carry no magmoms and differ only in lattice. Because `StructureMatcher` defaults to `scale=True` and `primitive_cell=True`, `matches_ordering` judges two of those pairs equivalent, so pruning removes two and the tests' `== 6` assertions fail. Since those tests were written to exercise *truncation*, I've stubbed `matches_ordering` in both so they isolate that logic, rather than rewriting their assertions around a new premise.

2. **Cost.** The pruning is O(N²) in `CollinearMagneticStructureAnalyzer` construction and `matches_ordering` calls. It was free while dead; real enumerations now pay it. At the default `num_orderings=64` this is not significant, but it is no longer zero.

Happy to gate this behind a keyword argument instead if you'd prefer a strictly non-breaking change.

### Test

`test_duplicate_orderings_are_pruned` feeds three orderings, two of which are identical, and asserts the duplicate is removed and no two survivors match. It follows the existing enumlib-free pattern in `TestMagneticStructureEnumeratorTruncation` (`object.__new__` to bypass `__init__`), so it runs in CI without the enumlib binaries.

Verified in both directions: the test fails on master (`assert 3 < 3`) and passes with the fix.
