### PR TITLE
Reuse first termination slabs in `CoherentInterfaceBuilder._find_matches` 

### DIFF
--- a/src/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/src/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -11,7 +11,7 @@ from scipy.linalg import polar
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.interfaces.zsl import ZSLGenerator, fast_norm
 from pymatgen.core.interface import Interface, label_termination
-from pymatgen.core.surface import SlabGenerator
+from pymatgen.core.surface import Slab, SlabGenerator
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -68,37 +68,16 @@ class CoherentInterfaceBuilder:
         self.termination_ftol = termination_ftol
         self.label_index = label_index
         self.filter_out_sym_slabs = filter_out_sym_slabs
-        self._find_matches()
-        self._find_terminations()
+        self._find_matches(self._find_terminations())
 
-    def _find_matches(self) -> None:
-        """Find and stores the ZSL matches."""
+    def _find_matches(self, film_slab: Slab, sub_slab: Slab) -> None:
+        """Find and stores the ZSL matches.
+
+        Args:
+            film_slab (Slab): A slab of the film structure, transformed as used in the other functions.
+            sub_slab (Slab): Associated slab of the substrate structure.
+        """
         self.zsl_matches = []
-
-        film_sg = SlabGenerator(
-            self.film_structure,
-            self.film_miller,
-            min_slab_size=1,
-            min_vacuum_size=3,
-            in_unit_planes=True,
-            center_slab=True,
-            primitive=True,
-            reorient_lattice=False,  # This is necessary to not screw up the lattice
-        )
-
-        sub_sg = SlabGenerator(
-            self.substrate_structure,
-            self.substrate_miller,
-            min_slab_size=1,
-            min_vacuum_size=3,
-            in_unit_planes=True,
-            center_slab=True,
-            primitive=True,
-            reorient_lattice=False,  # This is necessary to not screw up the lattice
-        )
-
-        film_slab = film_sg.get_slab(shift=0)
-        sub_slab = sub_sg.get_slab(shift=0)
 
         film_vectors = film_slab.lattice.matrix
         substrate_vectors = sub_slab.lattice.matrix
@@ -119,8 +98,11 @@ class CoherentInterfaceBuilder:
                     "Substrate lattice vectors changed during ZSL match, check your ZSL Generator parameters"
                 )
 
-    def _find_terminations(self):
-        """Find all terminations."""
+    def _find_terminations(self) -> tuple[Slab, Slab]:
+        """Find all terminations.
+        Returns:
+            first_pair (tuple[Slab, Slab]): The slab pair of the first termination, useful to check the primitivization.
+        """
         film_sg = SlabGenerator(
             self.film_structure,
             self.film_miller,
@@ -179,6 +161,8 @@ class CoherentInterfaceBuilder:
             )
         }
         self.terminations = list(self._terminations)
+
+        return film_slabs[0], sub_slabs[0]
 
     def get_interfaces(
         self,

--- a/src/pymatgen/analysis/interfaces/coherent_interfaces.py
+++ b/src/pymatgen/analysis/interfaces/coherent_interfaces.py
@@ -68,7 +68,7 @@ class CoherentInterfaceBuilder:
         self.termination_ftol = termination_ftol
         self.label_index = label_index
         self.filter_out_sym_slabs = filter_out_sym_slabs
-        self._find_matches(self._find_terminations())
+        self._find_matches(*self._find_terminations())
 
     def _find_matches(self, film_slab: Slab, sub_slab: Slab) -> None:
         """Find and stores the ZSL matches.


### PR DESCRIPTION
Currently, CoherentInterfaceBuilder._find_matches always uses shift 0. As discussed in https://github.com/materialsproject/pymatgen/issues/4651 and https://github.com/materialsproject/pymatgen-core/issues/105 this will lead to some primitivizations differing from the nonzero shifts in other functions.
I believe that to be the source of issues such as https://github.com/materialsproject/pymatgen/issues/4651 (and thus it closes #4651), but I do not have a test case, given the one in the issue works fine already (I do believe that this will cause errors in other cases where primitivization is shift-dependent though).
Additionally, passing the slabs to find_matches saves creating the SlabGenerator and generating the two slabs.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
